### PR TITLE
docs: refresh bilingual project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,106 @@
 # pi-extensions
 
-A set of extensions for [pi](https://github.com/badlogic/pi-mono), the coding agent.
+[![CI](https://github.com/maplezzk/pi-extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/maplezzk/pi-extensions/actions/workflows/ci.yml)
+[![pi-distill](https://img.shields.io/npm/v/pi-distill?label=pi-distill)](https://www.npmjs.com/package/pi-distill)
+[![pi-tool-supervisor](https://img.shields.io/npm/v/pi-tool-supervisor?label=pi-tool-supervisor)](https://www.npmjs.com/package/pi-tool-supervisor)
+[![pi-extensions-i18n](https://img.shields.io/npm/v/pi-extensions-i18n?label=pi-extensions-i18n)](https://www.npmjs.com/package/pi-extensions-i18n)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-> 中文说明见下方。[中文](#中文)
+Small, composable extensions for the [Pi coding agent](https://github.com/earendil-works/pi).
+
+These packages focus on three practical gaps around tool-heavy coding sessions:
+
+- keeping large tool results from consuming the agent's context unnecessarily;
+- reviewing file changes against project rules immediately after `edit` and `write`;
+- giving independently developed extensions a consistent bilingual runtime.
+
+> 中文文档：[README.zh-CN.md](./README.zh-CN.md)
+
+## Why this project exists
+
+Pi is intentionally small and extensible. That makes it a good foundation for personal workflows, but it also leaves application-level concerns to extensions:
+
+1. **Long output creates context pressure.** Logs, search results, and generated files can be much larger than the useful information the agent needs for its next decision.
+2. **A successful edit is not the same as a reviewed edit.** An agent can write syntactically valid code that still violates local rules, file conventions, or review expectations.
+3. **Extension UX drifts without shared infrastructure.** Each extension should not have to reimplement locale selection, catalog validation, fallback behavior, and configuration paths.
+
+`pi-extensions` addresses these problems with independent npm packages. Each package can be installed on its own, uses Pi's native extension events, and avoids replacing or registering duplicate built-in tools.
 
 ## Packages
 
-| Package | Description |
-|---|---|
-| [`pi-extensions-i18n`](./packages/pi-extensions-i18n) | Shared i18n catalog loader & translator for pi extensions |
-| [`pi-distill`](./packages/pi-distill) | Tool-output distillation with file-first configuration |
-| [`pi-tool-supervisor`](./packages/pi-tool-supervisor) | Tool supervisor: edit/write review with interactive configuration |
+| Package | What it does | Problem it addresses | Documentation |
+| --- | --- | --- | --- |
+| [`pi-distill`](./packages/pi-distill) | Distills `bash`, `read`, `grep`, and `find` results according to the tool's `outputPrompt`; preserves raw output when explicitly requested and spills oversized content to a temporary file. | Large tool results crowd the context window and make the next model turn slower or less reliable. | [English](./packages/pi-distill/README.md) · [中文](./packages/pi-distill/README.zh-CN.md) |
+| [`pi-tool-supervisor`](./packages/pi-tool-supervisor) | Captures the before/after file state for `edit` and `write`, loads matching rule files, and asks one or more configured models for a structured review. | File changes can pass the tool call but still miss project-specific safety, architecture, or style rules. | [English](./packages/pi-tool-supervisor/README.md) · [中文](./packages/pi-tool-supervisor/README.zh-CN.md) |
+| [`pi-extensions-i18n`](./packages/pi-extensions-i18n) | Shared `zh-CN` / `en-US` / `auto` locale selection, catalog loading, validation, interpolation, and the `/pi-language` command. | Independently shipped extensions otherwise duplicate localization and configuration logic or expose inconsistent user-facing messages. | [English](./packages/pi-extensions-i18n/README.md) · [中文](./packages/pi-extensions-i18n/README.zh-CN.md) |
+
+The packages are deliberately separate. Install only the behavior you need; `pi-extensions-i18n` is pulled in as a shared dependency when required.
 
 ## Install
 
-Extensions are installed via pi itself:
+Requirements: Pi with the compatible extension API and Node.js 22 or newer.
 
 ```bash
 pi install npm:pi-distill
 pi install npm:pi-tool-supervisor
 ```
 
-`pi-extensions-i18n` is a shared dependency and is pulled in automatically.
+Install the shared localization package explicitly when you want the `/pi-language` command without the other extensions:
+
+```bash
+pi install npm:pi-extensions-i18n
+```
+
+Reload Pi after installation:
+
+```text
+/reload
+```
+
+Useful first-run commands:
+
+```text
+/pi-language        # choose zh-CN, en-US, or auto
+/pi-distill         # inspect or edit distillation settings
+/pi-tool-supervisor # inspect or edit file-review settings
+```
+
+## How the extensions work together
+
+```text
+Pi tool call
+    │
+    ├── bash/read/grep/find ──► pi-distill ──► compact result + audit details
+    │                                              └─► temporary file for oversized content
+    │
+    └── edit/write ───────────► pi-tool-supervisor ─► diff + rule-based model review
+                                                       └─► review audit appended to result
+
+Shared runtime: pi-extensions-i18n ──► locale selection + catalog-backed messages
+```
+
+Both behavior extensions use Pi's `tool_call` and `tool_result` events. They do not register same-named replacements for Pi's tools, so they can be composed with other display or workflow extensions.
 
 ## Configuration
 
-Each extension reads its config from `~/.pi/agent/extensions/<name>/config.json`
-(file-first; environment variables as fallback). See each package's
-`config.example.json` and README for details.
+Configuration is file-first and portable:
+
+```text
+~/.pi/agent/extensions/<package-name>/config.json
+```
+
+See the checked-in examples:
+
+- [`pi-distill/config.example.json`](./packages/pi-distill/config.example.json)
+- [`pi-tool-supervisor/config.example.json`](./packages/pi-tool-supervisor/config.example.json)
+
+Each package documents its environment variables, defaults, compatibility behavior, and failure modes in its package README. In general, a missing or invalid optional configuration degrades to a diagnostic or no-op instead of preventing Pi from starting.
+
+## Important boundaries
+
+- `pi-distill` is a context-management extension, not a replacement for Pi's permission model or a guarantee that a summary retains every detail. Use the strict `RAW` output prompt when exact output is required.
+- `pi-tool-supervisor` is a post-edit review layer. It records findings and returns them to the agent; it does not roll back a successful edit or provide OS-level sandboxing.
+- The extensions do not assume a particular home directory, daemon, terminal multiplexer, notification service, or private network. Paths and environment differences are resolved at runtime.
 
 ## Development
 
@@ -38,35 +111,27 @@ npm test
 npm run check   # typecheck + tests + local-binding gate
 ```
 
-### Contributing
+The repository is a small npm workspace under `packages/`. Each publishable package contains its own entrypoint, tests, configuration example, and README. Tests do not require a live reviewer or summarizer model.
 
-- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
-  (`feat:` / `fix:` / `chore:` / `docs:` ...); release-please derives version
-  bumps and the changelog from them.
-- All user-facing copy must be bilingual (zh-CN + en-US) via the
-  `pi-extensions-i18n` catalog.
-- No machine-local paths, daemons, or private services in source, tests, or docs
-  — CI enforces this (`npm run check`).
+## Releases
 
-Releases are automated with release-please: merging the Release PR publishes to
-npm with `--provenance` via OIDC trusted publishing.
+Releases are automated with [release-please](https://github.com/googleapis/release-please):
+
+1. Use [Conventional Commits](https://www.conventionalcommits.org/) for changes.
+2. CI checks the pull request.
+3. Release Please opens or updates a release PR with package versions and changelogs.
+4. Merging the release PR publishes changed packages to npm with OIDC trusted publishing and provenance.
+
+## Contributing
+
+Issues and pull requests are welcome. Before opening a change:
+
+- explain the user problem and the observable behavior you want to improve;
+- add or update focused tests for deterministic logic;
+- keep user-facing messages in the bilingual i18n catalogs;
+- avoid machine-local paths, private services, and undeclared runtime dependencies;
+- run `npm run check` locally.
 
 ## License
 
 [MIT](./LICENSE)
-
----
-
-## 中文
-
-一组 pi 编码助手的扩展包：
-
-| 包 | 说明 |
-|---|---|
-| `pi-extensions-i18n` | 扩展公共 i18n 底座（catalog 加载 + 翻译器） |
-| `pi-distill` | 工具输出提炼（配置优先，环境变量兜底） |
-| `pi-tool-supervisor` | 工具监督：文件编辑/写入评审 + 交互式配置 |
-
-安装：`pi install npm:<包名>`；配置文件位于 `~/.pi/agent/extensions/<name>/config.json`。
-
-开发与贡献要求与上文一致：常规式提交、用户文案中英文双语、禁止任何本机绑定（CI 强制）。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,137 @@
+# pi-extensions
+
+[![CI](https://github.com/maplezzk/pi-extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/maplezzk/pi-extensions/actions/workflows/ci.yml)
+[![pi-distill](https://img.shields.io/npm/v/pi-distill?label=pi-distill)](https://www.npmjs.com/package/pi-distill)
+[![pi-tool-supervisor](https://img.shields.io/npm/v/pi-tool-supervisor?label=pi-tool-supervisor)](https://www.npmjs.com/package/pi-tool-supervisor)
+[![pi-extensions-i18n](https://img.shields.io/npm/v/pi-extensions-i18n?label=pi-extensions-i18n)](https://www.npmjs.com/package/pi-extensions-i18n)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+面向 [Pi 编码助手](https://github.com/earendil-works/pi) 的一组小型、可组合扩展。
+
+项目聚焦于工具调用型编码会话中的三个实际问题：
+
+- 避免超长工具结果无谓占满 Agent 上下文；
+- 在 `edit` 和 `write` 完成后，立即对文件变更执行项目规则审查；
+- 为独立开发、独立发布的扩展提供一致的中英文运行时底座。
+
+> English documentation: [README.md](./README.md)
+
+## 为什么需要这个项目
+
+Pi 有意保持小巧并通过扩展增强。这种设计适合构建个人工作流，但也意味着一些应用层能力需要由扩展提供：
+
+1. **超长输出会制造上下文压力。** 日志、搜索结果和生成文件的内容，往往远大于 Agent 下一步真正需要的信息。
+2. **编辑成功不等于编辑经过审查。** Agent 可以写出语法正确的代码，但仍可能违反项目规则、文件约定或评审要求。
+3. **没有公共底座时，各扩展的体验容易分叉。** 每个扩展都不应该重复实现语言选择、catalog 校验、fallback 和配置路径。
+
+`pi-extensions` 用相互独立的 npm 包解决这些问题。每个包都可以单独安装，使用 Pi 原生扩展事件，并避免替换或注册同名内置工具。
+
+## 包清单
+
+| 包 | 做什么 | 解决的问题 | 文档 |
+| --- | --- | --- | --- |
+| [`pi-distill`](./packages/pi-distill) | 按工具的 `outputPrompt` 提炼 `bash`、`read`、`grep`、`find` 结果；显式要求时保留原文，超大内容写入临时文件。 | 超长工具结果挤占上下文窗口，导致后续推理更慢或不稳定。 | [English](./packages/pi-distill/README.md) · [中文](./packages/pi-distill/README.zh-CN.md) |
+| [`pi-tool-supervisor`](./packages/pi-tool-supervisor) | 捕获 `edit` / `write` 前后的文件状态，加载匹配的规则文件，并交给一个或多个配置好的模型执行结构化审查。 | 文件变更虽然成功执行，却可能遗漏项目级安全、架构或风格规则。 | [English](./packages/pi-tool-supervisor/README.md) · [中文](./packages/pi-tool-supervisor/README.zh-CN.md) |
+| [`pi-extensions-i18n`](./packages/pi-extensions-i18n) | 提供 `zh-CN` / `en-US` / `auto` 语言选择、catalog 加载与校验、插值，以及 `/pi-language` 命令。 | 独立发布的扩展如果各自实现国际化，容易产生重复代码和不一致的用户文案。 | [English](./packages/pi-extensions-i18n/README.md) · [中文](./packages/pi-extensions-i18n/README.zh-CN.md) |
+
+这些包有意保持独立：只安装需要的能力；依赖它的扩展会自动使用共享的 `pi-extensions-i18n`。
+
+## 安装
+
+要求：具备兼容扩展 API 的 Pi，以及 Node.js 22 或更高版本。
+
+```bash
+pi install npm:pi-distill
+pi install npm:pi-tool-supervisor
+```
+
+如果只需要 `/pi-language`，可以单独安装公共语言包：
+
+```bash
+pi install npm:pi-extensions-i18n
+```
+
+安装后重新加载 Pi：
+
+```text
+/reload
+```
+
+第一次使用时可以执行：
+
+```text
+/pi-language        # 选择 zh-CN、en-US 或 auto
+/pi-distill         # 查看或修改输出提炼配置
+/pi-tool-supervisor # 查看或修改文件审查配置
+```
+
+## 扩展如何协作
+
+```text
+Pi 工具调用
+    │
+    ├── bash/read/grep/find ──► pi-distill ──► 精简结果 + 审计详情
+    │                                             └─► 超大内容写入临时文件
+    │
+    └── edit/write ───────────► pi-tool-supervisor ─► diff + 规则模型审查
+                                                      └─► 将审查结果追加到工具结果
+
+公共运行时：pi-extensions-i18n ──► 语言选择 + 基于 catalog 的用户文案
+```
+
+两个行为扩展都使用 Pi 的 `tool_call` 和 `tool_result` 事件。它们不会注册与 Pi 内置工具同名的替代工具，因此可以和其他展示或工作流扩展组合使用。
+
+## 配置
+
+配置采用文件优先，并且不绑定具体机器：
+
+```text
+~/.pi/agent/extensions/<package-name>/config.json
+```
+
+示例配置：
+
+- [`pi-distill/config.example.json`](./packages/pi-distill/config.example.json)
+- [`pi-tool-supervisor/config.example.json`](./packages/pi-tool-supervisor/config.example.json)
+
+每个包的 README 进一步说明环境变量、默认值、兼容行为和失败模式。通常，缺少或无效的可选配置会降级为诊断信息或 noop，不会阻止 Pi 启动。
+
+## 重要边界
+
+- `pi-distill` 是上下文管理扩展，不是 Pi 权限模型的替代品，也不保证摘要包含所有细节。需要完整原文时，请使用严格的 `RAW` 输出提示。
+- `pi-tool-supervisor` 是编辑后的审查层：它记录发现并返回给 Agent，不会回滚已经成功的编辑，也不提供操作系统级沙箱。
+- 扩展不假定特定用户目录、daemon、终端复用器、通知服务或内网。路径与环境差异会在运行时解析。
+
+## 开发
+
+```bash
+npm install
+npm run typecheck
+npm test
+npm run check   # 类型检查 + 测试 + 本机绑定门禁
+```
+
+仓库是一个位于 `packages/` 下的小型 npm workspace。每个可发布包都包含自己的入口、测试、配置示例和 README；测试不依赖真实的审查模型或提炼模型。
+
+## 发布
+
+项目使用 [release-please](https://github.com/googleapis/release-please) 自动发布：
+
+1. 使用 [Conventional Commits](https://www.conventionalcommits.org/) 提交变更。
+2. CI 检查 Pull Request。
+3. Release Please 创建或更新包含版本号和 changelog 的 release PR。
+4. 合并 release PR 后，GitHub Actions 使用 OIDC trusted publishing 和 provenance 将发生变化的包发布到 npm。
+
+## 参与贡献
+
+欢迎提交 Issue 和 Pull Request。提交前请：
+
+- 说明用户问题，以及希望改善的可观察行为；
+- 为确定性逻辑补充或更新聚焦测试；
+- 用户可见文案统一放在中英文 i18n catalog 中；
+- 不引入本机路径、私有服务或未声明的运行时依赖；
+- 在本地执行 `npm run check`。
+
+## 许可证
+
+[MIT](./LICENSE)

--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -1,35 +1,55 @@
 # pi-distill
 
-Pi 工具输出提炼扩展。它统一处理 `bash`、`read`、`grep`、`find` 的 `outputPrompt`，不再局限于 Bash。
+`pi-distill` is a Pi extension for controlling the amount of tool output that reaches the agent context.
 
-## 安装
+## What it solves
 
-该包独立扩展最终生效工具的参数 schema，并通过 Pi 原生 `tool_call` / `tool_result` 事件处理结果，不依赖 `pi-tool-display`，也不会注册同名工具。未安装、未启用或未接管对应工具时，会显示 UI-only 提炼审计；可用时则通过通用 result render middleware 把同一张卡片放进对应工具结果。`pi-tool-display` 不读取或解释 distill 字段。
+Coding agents often need only the important lines from a command, search, or file read. Passing every byte of a large result into the next turn increases context usage and can hide the signal in logs or generated files. `pi-distill` adds a result-level distillation layer without replacing Pi's built-in tools.
 
-通过 npm 安装：
+## How it works
+
+- Observes `bash`, `read`, `grep`, and `find` through Pi's native `tool_call` / `tool_result` events.
+- Uses the tool's `outputPrompt` as the source of truth for whether and how to distill a result.
+- Treats a prompt containing only `RAW` as an explicit request for the original output.
+- Uses the current session model by default, or a configured `provider/model` override.
+- Keeps diagnostic metadata such as status, character counts, compression ratio, duration, and anomalies in the tool result details.
+- Writes oversized distilled output or final output to a temporary file and returns its path instead of overflowing the tool result.
+- Adds a compact audit card when the active Pi display middleware is available, with a fallback renderer otherwise.
+
+It does not register a second `bash`, `read`, `grep`, or `find` tool, and it does not depend on `pi-tool-display`.
+
+## Install
 
 ```bash
 pi install npm:pi-distill
 ```
 
-安装后用 `/reload` 重新加载扩展。
+Reload Pi after installation:
 
-## 配置
+```text
+/reload
+```
 
-交互式配置命令：
+Use the interactive configuration command at any time:
 
 ```text
 /pi-distill
 ```
 
-配置文件保存在 Pi 全局扩展目录下，文件名为 `config.json`（设置 `PI_CODING_AGENT_DIR` 时使用该环境变量下的对应路径）。可通过 `/pi-distill` 交互命令查看或修改。
+## Configuration
 
-示例：
+The default configuration path is:
+
+```text
+~/.pi/agent/extensions/pi-distill/config.json
+```
+
+Start from [`config.example.json`](./config.example.json):
 
 ```json
 {
   "enabled": true,
-  "model": "provider/model",
+  "model": "",
   "minChars": 200,
   "maxChars": 100000,
   "maxOutputChars": 10000,
@@ -44,25 +64,30 @@ pi install npm:pi-distill
 }
 ```
 
-`render.enabled` 控制提炼审计渲染；`render.showPrompt` 和 `render.showResult` 分别控制是否显示 AI 传入的 `outputPrompt` 和提炼模型返回的文本。配置会随工具结果写入 `details.outputSummaryRender`，由 pi-distill 自己的 fallback 或 result middleware 读取，因此两条渲染路径使用同一组开关。较长文本折叠时显示预览，展开工具输出后显示完整内容。
+Configuration-file fields take precedence over environment variables. Unspecified fields fall back to `PI_DISTILL_*`, then the legacy `PI_BASH_SUMMARY_*` variables, then defaults.
 
-配置文件字段优先于环境变量。没有对应文件字段时，优先读取新变量：
+| Setting | Meaning |
+| --- | --- |
+| `model` | Optional `provider/model`; empty uses the current Pi session model. |
+| `minChars` | Minimum output size before a summary is requested. |
+| `maxChars` | Maximum size of the model's distilled result before it is written to a file. |
+| `maxOutputChars` | Maximum size returned to the agent; larger results are written to a file. |
+| `timeoutSeconds` | Maximum time allowed for the distillation model call. |
+| `missedCompressionRatio` | Long-output threshold used for a diagnostic when no summary prompt was supplied. |
+| `summarizeErrors` | Whether error results should still be sent to the distillation model. |
+| `render.*` | Controls the audit card, prompt preview, and result preview. |
 
-- `PI_DISTILL_MODEL`
-- `PI_DISTILL_MIN_CHARS`
-- `PI_DISTILL_MAX_CHARS`：提炼结果字符上限，默认 `100000`；超过后写入临时文件
-- `PI_DISTILL_MAX_OUTPUT_CHARS`：最终返回字符上限，默认 `10000`；超过后写入临时文件
-- `PI_DISTILL_TIMEOUT_SECONDS`：提炼模型最长等待秒数，默认 `10`
-- `PI_DISTILL_MISSED_COMPRESSION_RATIO`
-- `PI_DISTILL_SUMMARIZE_ERRORS`：工具返回 `isError: true` 时是否仍调用提炼模型，默认 `true`；设置为 `false` 或 `0` 可关闭
+The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_MAX_OUTPUT_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`.
 
-旧版 Bash 变量继续兼容，作为回退：
+## Important behavior
 
-- `PI_BASH_SUMMARY_MODEL`
-- `PI_BASH_SUMMARY_MIN_CHARS`
-- `PI_BASH_SUMMARY_MAX_CHARS`
-- `PI_BASH_SUMMARY_MAX_OUTPUT_CHARS`
-- `PI_BASH_SUMMARY_TIMEOUT_SECONDS`
-- `PI_BASH_SUMMARY_MISSED_COMPRESSION_RATIO`
+Distillation is not lossless. When exact output is required, make the tool request `RAW`; the extension preserves the original result and does not ask the model to summarize it. When a summary is requested but no usable model is available, the original result is retained and the failure is exposed through diagnostics rather than preventing Pi from starting.
 
-配置修改后下一次工具调用立即生效，不需要重启 Pi。总结模型会优先按原始用户消息使用相同的自然语言输出（不可用时使用 `outputPrompt` 的语言）；如果请求语义是返回原文、完整输出、逐字返回或不要总结，模型只返回 `RAW`，扩展再按 RAW 处理，不让模型重复输出原文。无论是否调用模型，最终返回内容都不会超过 `maxOutputChars`；超过时会写入 `/tmp/pi-distill/` 临时文件。
+## Requirements
+
+- Node.js 22 or newer.
+- A current Pi session model, unless `model` points to an available configured model.
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -1,0 +1,93 @@
+# pi-distill
+
+`pi-distill` 是一个控制工具结果进入 Agent 上下文规模的 Pi 扩展。
+
+## 解决什么问题
+
+编码 Agent 通常只需要命令、搜索或文件读取结果中的关键信息。把大段日志、生成文件或搜索结果完整塞入下一轮，会增加上下文消耗，也容易让有效信号被噪声淹没。`pi-distill` 在不替换 Pi 内置工具的前提下，增加一层结果级提炼。
+
+## 工作方式
+
+- 通过 Pi 原生的 `tool_call` / `tool_result` 事件监听 `bash`、`read`、`grep` 和 `find`。
+- 以工具的 `outputPrompt` 作为是否提炼、如何提炼的依据。
+- 当提示词严格只有 `RAW` 时，视为明确要求返回原始输出。
+- 默认使用当前会话模型，也可以配置独立的 `provider/model`。
+- 在工具结果 details 中保留状态、字符数、压缩比、耗时和异常等诊断信息。
+- 提炼结果或最终返回结果过大时写入临时文件，只把文件路径返回给 Agent，避免工具结果失控膨胀。
+- 当前 Pi 展示中间件可用时显示紧凑审计卡片，否则使用自己的 fallback renderer。
+
+它不会注册第二个 `bash`、`read`、`grep` 或 `find` 工具，也不依赖 `pi-tool-display`。
+
+## 安装
+
+```bash
+pi install npm:pi-distill
+```
+
+安装后重新加载 Pi：
+
+```text
+/reload
+```
+
+随时可以使用交互式配置命令：
+
+```text
+/pi-distill
+```
+
+## 配置
+
+默认配置路径：
+
+```text
+~/.pi/agent/extensions/pi-distill/config.json
+```
+
+可以从 [`config.example.json`](./config.example.json) 开始：
+
+```json
+{
+  "enabled": true,
+  "model": "",
+  "minChars": 200,
+  "maxChars": 100000,
+  "maxOutputChars": 10000,
+  "timeoutSeconds": 10,
+  "missedCompressionRatio": 10,
+  "summarizeErrors": true,
+  "render": {
+    "enabled": true,
+    "showPrompt": true,
+    "showResult": true
+  }
+}
+```
+
+配置文件字段优先于环境变量。未在文件中声明的字段依次回退到 `PI_DISTILL_*`、旧版 `PI_BASH_SUMMARY_*` 变量和默认值。
+
+| 配置项 | 含义 |
+| --- | --- |
+| `model` | 可选的 `provider/model`；为空时使用当前 Pi 会话模型。 |
+| `minChars` | 达到此输出长度后才请求提炼。 |
+| `maxChars` | 模型提炼结果超过此长度时写入文件。 |
+| `maxOutputChars` | 返回给 Agent 的最大长度，超出后写入文件。 |
+| `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
+| `missedCompressionRatio` | 没有提供摘要提示时，用于长输出诊断的倍数阈值。 |
+| `summarizeErrors` | 工具返回错误时是否仍发送给提炼模型。 |
+| `render.*` | 控制审计卡片、提示词预览和结果预览。 |
+
+主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_MAX_OUTPUT_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。
+
+## 重要行为
+
+提炼不是无损操作。需要完整输出时，应让工具请求 `RAW`；扩展会保留原始结果，不再请求模型总结。如果请求了摘要但没有可用模型，扩展会保留原始结果，并通过诊断信息暴露失败，不会阻止 Pi 启动。
+
+## 要求
+
+- Node.js 22 或更高版本。
+- 当前 Pi 会话需要有可用模型，除非 `model` 指向一个已配置且可用的模型。
+
+## 许可证
+
+[MIT](../../LICENSE)

--- a/packages/pi-distill/package.json
+++ b/packages/pi-distill/package.json
@@ -8,7 +8,8 @@
     "src",
     "locales",
     "config.example.json",
-    "README.md"
+    "README.md",
+    "README.zh-CN.md"
   ],
   "scripts": {
     "test": "tsx --test tests/bash-output-summary.test.ts",

--- a/packages/pi-extensions-i18n/README.md
+++ b/packages/pi-extensions-i18n/README.md
@@ -1,42 +1,89 @@
 # pi-extensions-i18n
 
-Shared i18n runtime for pi extensions, with bilingual (zh-CN / en-US) support.
+Shared localization runtime for Pi extensions. It provides a small, catalog-backed API for `zh-CN`, `en-US`, and automatic locale selection.
 
-pi 扩展的公共中英文运行时。提供：
+## Why a shared package
 
-- `zh-CN`、`en-US` 和 `auto` 三种语言偏好；
-- 统一读取 `~/.pi/agent/extensions/pi-extensions-i18n/config.json`；
-- `/pi-language` 终端交互式语言配置命令；
-- `PI_EXTENSIONS_LOCALE` 环境变量覆盖配置；
-- 面向 UI、命令描述和 agent prompt 的翻译器，以及外部 JSON catalog 加载和校验。
+Independent Pi extensions still need the same operational pieces: a portable configuration path, locale precedence, fallback behavior, catalog validation, and parameter interpolation. Keeping those pieces here lets feature packages concentrate on their own behavior while keeping user-facing messages consistent.
 
-## Install / 安装
+## Features
+
+- `zh-CN`, `en-US`, and `auto` locale preferences.
+- Persistent setting at `~/.pi/agent/extensions/pi-extensions-i18n/config.json`.
+- `PI_EXTENSIONS_LOCALE` environment-variable override.
+- `/pi-language` interactive command, plus `/pi-language en-US` direct selection.
+- Catalog loading and validation requiring both language entries for every message key.
+- Translator interpolation for user-facing UI, command descriptions, and agent prompts.
+
+## Install
 
 ```bash
 pi install npm:pi-extensions-i18n
 ```
 
-本包是共享 peer dependency，依赖它的扩展（如 `pi-distill`、`pi-tool-supervisor`）会自动引用，不会把配置复制到每个插件目录。
+Feature packages such as `pi-distill` and `pi-tool-supervisor` use it as a shared dependency. Install it explicitly when you want the locale command by itself.
 
-## Locale priority / 语言优先级
+Reload Pi after installation:
 
 ```text
-PI_EXTENSIONS_LOCALE 环境变量 > 持久化配置 > 默认 zh-CN
+/reload
 ```
 
-`PI_EXTENSIONS_LOCALE` 和配置文件支持 `zh-CN`、`en-US`、`auto`，也接受 `zh`、`en` 简写。`auto` 根据 `LC_ALL`、`LC_MESSAGES` 或 `LANG` 判断系统语言。
+## Locale precedence
+
+```text
+PI_EXTENSIONS_LOCALE environment variable
+    > persisted config
+    > default zh-CN
+```
+
+The `auto` preference checks `LC_ALL`, `LC_MESSAGES`, and `LANG`; Chinese system locales resolve to `zh-CN`, and other locales resolve to `en-US`. `zh` and `en` are accepted as short aliases.
+
+Examples:
 
 ```bash
 PI_EXTENSIONS_LOCALE=en-US pi
 ```
 
-在 pi 中执行 `/pi-language` 可通过 select 菜单保存语言；也可以直接执行 `/pi-language en-US`。
+```text
+/pi-language en-US
+```
 
-## Catalog layout / 翻译资源约定
+## Extension author API
 
-扩展自己的翻译资源保留在对应包的 `locales/` 目录中，按源码模块拆分为 JSON 文件，例如 `pi-distill/locales/summary-utils.json`；本包自身的 `/pi-language` 文案位于 `locales/command.json`。
+The package exports the locale and catalog primitives used by the feature packages:
 
-每个 catalog 条目必须同时包含 `zh-CN` 与 `en-US` 两个语言键（CI 强制检查）。运行时只共享语言解析、配置存储、catalog 校验和插值规则，避免各插件重复实现配置路径和 fallback。
+```ts
+import {
+  createTranslator,
+  getLocale,
+  loadCatalog,
+} from "pi-extensions-i18n";
+
+const messages = loadCatalog(new URL("../locales/messages.json", import.meta.url));
+const i18n = createTranslator(messages);
+
+i18n.t("description");
+getLocale();
+```
+
+Catalog entries must contain both locale keys:
+
+```json
+{
+  "description": {
+    "zh-CN": "扩展描述",
+    "en-US": "Extension description"
+  }
+}
+```
+
+Invalid catalogs fail during loading, which makes missing translations visible in tests and CI instead of silently leaking a single-language message to users.
+
+## Requirements
+
+- Node.js 22 or newer.
+- Pi's extension runtime when using the `/pi-language` command.
 
 ## License
 

--- a/packages/pi-extensions-i18n/README.zh-CN.md
+++ b/packages/pi-extensions-i18n/README.zh-CN.md
@@ -1,0 +1,90 @@
+# pi-extensions-i18n
+
+Pi 扩展公共国际化运行时。它提供基于 catalog 的小型 API，支持 `zh-CN`、`en-US` 和自动语言选择。
+
+## 为什么需要公共包
+
+独立的 Pi 扩展仍然需要相同的基础能力：可移植的配置路径、语言优先级、fallback、catalog 校验和参数插值。把这些能力集中在这里，功能包就可以专注于自身逻辑，同时保持用户可见文案的一致性。
+
+## 能力
+
+- 支持 `zh-CN`、`en-US` 和 `auto` 语言偏好。
+- 将设置持久化到 `~/.pi/agent/extensions/pi-extensions-i18n/config.json`。
+- 支持 `PI_EXTENSIONS_LOCALE` 环境变量覆盖。
+- 提供 `/pi-language` 交互式命令，也支持 `/pi-language en-US` 直接设置。
+- 加载并校验 catalog，要求每个消息 key 同时提供两种语言。
+- 为 UI、命令描述和 Agent prompt 提供用户文案插值。
+
+## 安装
+
+```bash
+pi install npm:pi-extensions-i18n
+```
+
+`pi-distill`、`pi-tool-supervisor` 等功能包会把它作为公共依赖使用。如果只需要语言命令，也可以单独安装本包。
+
+安装后重新加载 Pi：
+
+```text
+/reload
+```
+
+## 语言优先级
+
+```text
+PI_EXTENSIONS_LOCALE 环境变量
+    > 持久化配置
+    > 默认 zh-CN
+```
+
+选择 `auto` 时会检查 `LC_ALL`、`LC_MESSAGES` 和 `LANG`：中文系统语言解析为 `zh-CN`，其他语言解析为 `en-US`。同时接受 `zh` 和 `en` 简写。
+
+示例：
+
+```bash
+PI_EXTENSIONS_LOCALE=en-US pi
+```
+
+```text
+/pi-language en-US
+```
+
+## 扩展作者 API
+
+本包导出功能扩展使用的语言和 catalog 原语：
+
+```ts
+import {
+  createTranslator,
+  getLocale,
+  loadCatalog,
+} from "pi-extensions-i18n";
+
+const messages = loadCatalog(new URL("../locales/messages.json", import.meta.url));
+const i18n = createTranslator(messages);
+
+i18n.t("description");
+getLocale();
+```
+
+catalog 条目必须同时包含两种语言：
+
+```json
+{
+  "description": {
+    "zh-CN": "扩展描述",
+    "en-US": "Extension description"
+  }
+}
+```
+
+无效 catalog 会在加载阶段失败，让缺失翻译在测试和 CI 中暴露，而不是静默向用户泄露单一语言文案。
+
+## 要求
+
+- Node.js 22 或更高版本。
+- 使用 `/pi-language` 命令时需要 Pi 扩展运行时。
+
+## 许可证
+
+[MIT](../../LICENSE)

--- a/packages/pi-extensions-i18n/package.json
+++ b/packages/pi-extensions-i18n/package.json
@@ -12,6 +12,7 @@
     "src",
     "locales",
     "README.md",
+    "README.zh-CN.md",
     "tsconfig.json"
   ],
   "scripts": {

--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -1,32 +1,108 @@
 # pi-tool-supervisor
 
-Pi 工具监督扩展。当前在 `edit` / `write` 执行完成后读取实际文件变化，并将 diff 发送给配置的侧边评审模型；后续可在同一包中增加其他工具监督能力。
+`pi-tool-supervisor` is a post-edit review extension for Pi. It checks the actual file change produced by `edit` or `write` against project rules and returns a structured review audit to the agent.
 
-## 安装
+## What it solves
 
-该包通过 Pi 原生 `tool_call` / `tool_result` 事件接入 `edit` / `write`，不依赖 `pi-tool-display`，也不会注册同名工具。未安装、未启用或未接管对应工具时，会显示 UI-only 审查状态；可用时则通过通用 result render middleware 把审查卡片追加到对应工具结果。`pi-tool-display` 不读取或解释 supervisor 字段。
+An edit tool can complete successfully while the resulting file still violates local conventions, architecture constraints, security rules, or task-specific instructions. Reviewing the actual before/after diff gives a model-based reviewer the information needed to catch those issues immediately, while keeping the review policy configurable per project.
 
-通过 npm 安装：
+## How it works
+
+- Captures the file state before `edit` / `write` and the actual file state after the tool result.
+- Builds a diff and selects only reviewers whose rule files match the changed file.
+- Supports multiple reviewers running in parallel, each with its own model and one or more rule files.
+- Reads optional front matter from rule files for `enabled`, `filePatterns`, `complexity`, and `consumers`.
+- Returns `passed`, `rejected`, `failed`, or `skipped` status with summaries, findings, rule groups, and durations.
+- Re-reads the configuration for every edit/write, so configuration changes apply to the next operation.
+- Shows an audit card through Pi's display middleware or a fallback renderer.
+
+It observes Pi's native events and does not register a replacement `edit` or `write` tool.
+
+## Install
 
 ```bash
 pi install npm:pi-tool-supervisor
 ```
 
-安装后用 `/reload` 重新加载扩展。
+Reload Pi after installation:
 
-## 配置
+```text
+/reload
+```
 
-交互式配置命令：
+Use the interactive configuration command:
 
 ```text
 /pi-tool-supervisor
 ```
 
-配置文件保存在 Pi 全局扩展目录下，文件名为 `config.json`（设置 `PI_CODING_AGENT_DIR` 时使用该环境变量下的对应路径）。可通过 `/pi-tool-supervisor` 交互命令查看或修改。
+## Configuration
 
-命令会打开交互式配置菜单，支持配置总开关、超时（秒）、最终返回字符上限、规则行数、Reviewer 增删改、模型和规则文件。默认最长等待 `10` 秒、最终返回上限 `10000` 字符。规则文件仍可以通过 front matter 声明
-`enabled`、`filePatterns`、`complexity` 和 `consumers`。
+The default configuration path is:
 
-配置文件会在每次 `edit` / `write` 前重新读取，保存后立即生效。无论审查是否启用，最终返回内容超过 `maxOutputChars` 时都会写入 `/tmp/pi-tool-supervisor/` 临时文件。旧配置中的 `timeoutMs` 和 `maxChars` 仍兼容，会自动转换为新字段。
+```text
+~/.pi/agent/extensions/pi-tool-supervisor/config.json
+```
 
-从 `pi-file-edit-review` 升级时，如果新目录尚无配置，扩展会继续读取旧的 `extensions/pi-file-edit-review/config.json`；通过 `/pi-tool-supervisor` 保存后，配置会写入新的 `extensions/pi-tool-supervisor/config.json`。
+Start from [`config.example.json`](./config.example.json):
+
+```json
+{
+  "enabled": true,
+  "timeoutSeconds": 10,
+  "maxOutputChars": 10000,
+  "maxRuleLines": 100,
+  "reviewers": [
+    {
+      "name": "project-rules",
+      "model": "provider/model",
+      "rulesFiles": [
+        "/absolute/path/to/rules.md"
+      ]
+    }
+  ]
+}
+```
+
+Each reviewer must have a `provider/model` reference and either `rulesFile` or `rulesFiles`. Relative rule-file paths are resolved from the current project working directory.
+
+| Setting | Meaning |
+| --- | --- |
+| `enabled` | Enables or disables the review layer. |
+| `timeoutSeconds` | Maximum time allowed for each reviewer model call. |
+| `maxOutputChars` | Maximum size of the returned tool result; larger output is written to a temporary file. |
+| `maxRuleLines` | Maximum rule-file size accepted for a single review rule. |
+| `reviewers` | Reviewer name, model, rule files, and optional matching behavior. |
+
+Rule-file front matter can scope a rule to particular files or consumers:
+
+```yaml
+---
+name: TypeScript safety
+enabled: true
+filePatterns:
+  - "**/*.ts"
+complexity: local
+consumers:
+  - editor-review
+---
+```
+
+## Review semantics
+
+- A rejected review is appended to the tool result with findings; the agent is expected to address it before continuing.
+- A reviewer failure is reported as an incomplete review and the original edit result is allowed through.
+- A failed tool call or an unchanged file is skipped.
+- The extension does not roll back edits, block the operating system, or replace Pi's permission and sandbox controls.
+
+When upgrading from `pi-file-edit-review`, the extension reads the legacy configuration if the new configuration does not exist. Saving through `/pi-tool-supervisor` writes the new configuration path.
+
+## Requirements
+
+- Node.js 22 or newer.
+- A configured Pi model for each enabled reviewer.
+- Rule files that describe the project-specific checks the reviewer should apply.
+
+## License
+
+[MIT](../../LICENSE)

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -1,0 +1,108 @@
+# pi-tool-supervisor
+
+`pi-tool-supervisor` 是 Pi 的编辑后审查扩展。它会根据 `edit` 或 `write` 实际产生的文件变化，对照项目规则执行审查，并把结构化审计结果返回给 Agent。
+
+## 解决什么问题
+
+编辑工具成功执行，并不代表结果符合项目约定、架构边界、安全规则或任务要求。对真实的前后文件 diff 执行模型审查，可以及时发现这些问题，同时把审查策略保留在项目可配置的规则文件中。
+
+## 工作方式
+
+- 在 `edit` / `write` 前捕获文件状态，在工具返回后读取实际文件状态。
+- 构建 diff，并只选择规则文件匹配当前变更文件的 reviewer。
+- 支持多个 reviewer 并行执行，每个 reviewer 可以使用自己的模型和一个或多个规则文件。
+- 读取规则文件可选的 front matter：`enabled`、`filePatterns`、`complexity` 和 `consumers`。
+- 返回 `passed`、`rejected`、`failed` 或 `skipped` 状态，以及结论、发现、规则组和耗时。
+- 每次 edit/write 都重新读取配置，因此配置修改会在下一次操作立即生效。
+- 当前 Pi 展示中间件可用时显示审计卡片，否则使用 fallback renderer。
+
+它监听 Pi 原生事件，不会注册替代版 `edit` 或 `write` 工具。
+
+## 安装
+
+```bash
+pi install npm:pi-tool-supervisor
+```
+
+安装后重新加载 Pi：
+
+```text
+/reload
+```
+
+使用交互式配置命令：
+
+```text
+/pi-tool-supervisor
+```
+
+## 配置
+
+默认配置路径：
+
+```text
+~/.pi/agent/extensions/pi-tool-supervisor/config.json
+```
+
+可以从 [`config.example.json`](./config.example.json) 开始：
+
+```json
+{
+  "enabled": true,
+  "timeoutSeconds": 10,
+  "maxOutputChars": 10000,
+  "maxRuleLines": 100,
+  "reviewers": [
+    {
+      "name": "project-rules",
+      "model": "provider/model",
+      "rulesFiles": [
+        "/absolute/path/to/rules.md"
+      ]
+    }
+  ]
+}
+```
+
+每个 reviewer 必须提供 `provider/model` 格式的模型，并提供 `rulesFile` 或 `rulesFiles`。相对规则文件路径按当前项目工作目录解析。
+
+| 配置项 | 含义 |
+| --- | --- |
+| `enabled` | 启用或关闭审查层。 |
+| `timeoutSeconds` | 每个 reviewer 模型调用的最长等待时间。 |
+| `maxOutputChars` | 工具结果最大返回长度，超出后写入临时文件。 |
+| `maxRuleLines` | 单条审查规则允许读取的最大行数。 |
+| `reviewers` | reviewer 名称、模型、规则文件和可选匹配条件。 |
+
+规则文件可以通过 front matter 限定适用文件或消费者：
+
+```yaml
+---
+name: TypeScript safety
+enabled: true
+filePatterns:
+  - "**/*.ts"
+complexity: local
+consumers:
+  - editor-review
+---
+```
+
+## 审查语义
+
+- 审查拒绝会追加到工具结果并列出发现；Agent 应先处理这些问题再继续。
+- reviewer 调用失败会标记为审查未完成，但会放行原始编辑结果。
+- 工具调用失败或文件内容没有变化时跳过审查。
+- 扩展不会回滚编辑、阻断操作系统，也不替代 Pi 的权限与沙箱控制。
+
+从 `pi-file-edit-review` 升级时，如果新配置不存在，扩展会读取旧配置；通过 `/pi-tool-supervisor` 保存后会写入新的配置路径。
+
+## 要求
+
+- Node.js 22 或更高版本。
+- 每个启用 reviewer 都需要一个已配置的 Pi 模型。
+- 需要提供描述项目级检查项的规则文件。
+
+## 许可证
+
+[MIT](../../LICENSE)

--- a/packages/pi-tool-supervisor/package.json
+++ b/packages/pi-tool-supervisor/package.json
@@ -8,7 +8,8 @@
     "src",
     "locales",
     "config.example.json",
-    "README.md"
+    "README.md",
+    "README.zh-CN.md"
   ],
   "scripts": {
     "test": "tsx --test tests/pi-tool-supervisor.test.ts",


### PR DESCRIPTION
## What changed

- Reworked the root README around the project's purpose, user problems, package map, installation, configuration, boundaries, development, releases, and contribution flow.
- Added a separate Chinese entrypoint at `README.zh-CN.md`.
- Rewrote each package README in English and added a matching Chinese README:
  - `pi-distill`
  - `pi-tool-supervisor`
  - `pi-extensions-i18n`
- Included the localized README files in each npm package's `files` list.

## Why

The previous documentation mixed languages and described implementation details without clearly explaining the user problems these extensions solve. The new structure gives English readers a conventional project entrypoint while keeping Chinese documentation complete and easy to discover.

## Validation

- `npm run check`
- Relative links checked across all README files
- `npm pack --dry-run` verified that all three packages include `README.zh-CN.md`
