### PR TITLE
chore: let release please bootstrap display package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,5 @@
 {
   "packages/pi-extensions-i18n": "0.3.0",
   "packages/pi-distill": "0.3.0",
-  "packages/pi-tool-supervisor": "0.2.1",
-  "packages/pi-tool-display": "0.1.0"
+  "packages/pi-tool-supervisor": "0.2.1"
 }


### PR DESCRIPTION
## 变更

移除 `.release-please-manifest.json` 中对尚未发布的 `pi-tool-display` 的手动版本初始化。保留 `release-please-config.json` 中的 package 声明，让 release-please 按 manifest 模式完成首次 bootstrap 和后续版本维护。

## 验证

- release-please JSON 校验通过
- `npm run check` 通过