### PR TITLE
chore: bootstrap tool display release

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/pi-extensions-i18n": "0.3.0",
   "packages/pi-distill": "0.3.0",
-  "packages/pi-tool-supervisor": "0.2.1"
+  "packages/pi-tool-supervisor": "0.2.1",
+  "packages/pi-tool-display": "0.1.0"
 }


### PR DESCRIPTION
## 根因

release-please 的 release workflow 已成功运行，但 `pi-tool-display` 从未发布过且没有 release tag。日志显示 `No version for path packages/pi-tool-display`，因此只找到其他三个 package 的 release，最终没有生成 release PR。

## 修复

在 `.release-please-manifest.json` 中为新包补充首次发布版本 `0.1.0`。这是新 package 首次 release 所需的一次性 bootstrap；后续版本仍由 release-please 自动维护。

## 验证

- manifest JSON 校验通过
- `npm run check` 通过