### PR TITLE
fix: deduplicate shared tool display command

### DIFF
--- a/packages/pi-extensions-tool-display/src/index.ts
+++ b/packages/pi-extensions-tool-display/src/index.ts
@@ -44,6 +44,14 @@ export function toolDisplayReloadRequired(
 
 const initializedHosts = new WeakSet<ExtensionAPI>();
 
+function hasRegisteredToolDisplayCommand(pi: ExtensionAPI): boolean {
+  try {
+    return pi.getCommands().some((command) => command.name === "tool-display");
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Load the display host when a feature extension uses this package as a
  * dependency. Pi only auto-loads top-level packages, so relying on the
@@ -109,13 +117,18 @@ export function ensureToolDisplayHost(
     registerThinkingLabeling(pi);
   }
 
-  pi.registerCommand("tool-display", {
-    description: "Configure tool output rendering (OpenCode-style)",
-    handler: async (args, ctx) => {
-      const { runToolDisplayCommandHandler } = await import("./config-modal.js");
-      await runToolDisplayCommandHandler(args, ctx, { getConfig, setConfig, getCapabilities });
-    },
-  });
+  // Each Pi extension has its own registration map, while getCommands() sees
+  // the shared runtime. Check the latter so feature extensions do not expose
+  // duplicate /tool-display entries when they initialize this host separately.
+  if (!hasRegisteredToolDisplayCommand(pi)) {
+    pi.registerCommand("tool-display", {
+      description: "Configure tool output rendering (OpenCode-style)",
+      handler: async (args, ctx) => {
+        const { runToolDisplayCommandHandler } = await import("./config-modal.js");
+        await runToolDisplayCommandHandler(args, ctx, { getConfig, setConfig, getCapabilities });
+      },
+    });
+  }
 
   pi.on("session_start", async (_event, ctx) => {
     refreshCapabilities();

--- a/packages/pi-extensions-tool-display/tests/index-integration.test.ts
+++ b/packages/pi-extensions-tool-display/tests/index-integration.test.ts
@@ -117,6 +117,25 @@ test("feature extensions can initialize one shared host idempotently", () => {
   assert.ok(sessionStartCountAfterFirstInit >= 1);
 });
 
+test("separate feature APIs do not duplicate the shared tool-display command", () => {
+  const sharedCommands: Array<{ name: string }> = [];
+  const first = createApiStub({
+    getCommands: () => sharedCommands,
+    registerCommand: (name) => sharedCommands.push({ name }),
+  });
+  const second = createApiStub({
+    getCommands: () => sharedCommands,
+    registerCommand: (name) => sharedCommands.push({ name }),
+  });
+
+  ensureToolDisplayHost(first.api);
+  ensureToolDisplayHost(second.api);
+
+  assert.equal(sharedCommands.filter((command) => command.name === "tool-display").length, 1);
+  assert.equal(first.capturedCommands.filter((command) => command.name === "tool-display").length, 1);
+  assert.equal(second.capturedCommands.filter((command) => command.name === "tool-display").length, 0);
+});
+
 test("entry point registers tool-display command", () => {
   const { api, capturedCommands } = createApiStub();
   toolDisplayExtension(api);


### PR DESCRIPTION
## Problem

When `pi-distill` and `pi-tool-supervisor` both initialize the embedded display host, Pi exposes duplicate `/tool-display` command entries because each extension owns a separate registration map.

## Fix

- Check the shared runtime command list through `getCommands()` before registering the host command.
- Keep per-extension host initialization intact while preventing duplicate command completion entries.
- Add regression coverage for separate feature APIs sharing one runtime command list.

## Validation

- `npm run check`
- `npm test --workspace=pi-extensions-tool-display`