### PR TITLE
fix: load tool display as a dependency extension

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -44,7 +44,7 @@ It does not register a second `bash`, `read`, `grep`, or `find` tool.
 pi install npm:pi-distill
 ```
 
-The shared `pi-extensions-tool-display` dependency initializes the display host automatically; no separate host package is required.
+The package manifest also loads the shared `pi-extensions-tool-display` dependency as one extension entry; no separate host package is required.
 
 Reload Pi after installation:
 

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -44,7 +44,7 @@
 pi install npm:pi-distill
 ```
 
-共享依赖 `pi-extensions-tool-display` 会自动初始化展示宿主，不需要额外安装宿主包。
+包清单会把共享依赖 `pi-extensions-tool-display` 作为一个扩展入口加载，不需要额外安装宿主包。
 
 安装后重新加载 Pi：
 

--- a/packages/pi-distill/package.json
+++ b/packages/pi-distill/package.json
@@ -20,7 +20,8 @@
   },
   "pi": {
     "extensions": [
-      "./index.ts"
+      "./index.ts",
+      "../pi-extensions-tool-display/index.ts"
     ]
   },
   "engines": {

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -28,7 +28,6 @@ import type {
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
 import { performance } from "node:perf_hooks";
-import { ensureToolDisplayHost } from "pi-extensions-tool-display";
 import {
   appendDistillFallbackAudit,
   registerDistillFallbackRenderer,
@@ -713,7 +712,6 @@ function registerDistillConfigCommand(pi: ExtensionAPI): void {
 }
 
 export default function piDistillExtension(pi: ExtensionAPI) {
-  ensureToolDisplayHost(pi);
   const pendingCalls = new Map<string, PendingDistillCall>();
   let originalUserPrompt = "";
   const disposeToolDisplayMiddleware = registerDistillToolDisplayMiddleware();

--- a/packages/pi-extensions-tool-display/README.md
+++ b/packages/pi-extensions-tool-display/README.md
@@ -8,7 +8,7 @@ It provides:
 - a pending registration queue for when the Pi display host loads later;
 - safe component detection and a helper for appending an audit panel to the original tool result.
 
-It is also a standalone Pi extension. Install or include this package in Pi's package list to load the actual tool-display host. Feature packages such as `pi-distill` and `pi-tool-supervisor` initialize the same host through this runtime dependency, so installing either feature package is sufficient and does not require a second host package.
+It is also a standalone Pi extension. Install or include this package in Pi's package list to load the actual tool-display host. Feature package manifests include this dependency's extension entry, so installing either feature package loads one shared host without requiring a second host package.
 
 ## Boundary
 
@@ -28,7 +28,7 @@ Install this package directly when you want only the tool-display host:
 pi install npm:pi-extensions-tool-display
 ```
 
-`pi-distill` and `pi-tool-supervisor` also initialize the host automatically when they are loaded.
+`pi-distill` and `pi-tool-supervisor` declare this host entry in their package manifests when they are installed.
 
 ## Development
 

--- a/packages/pi-extensions-tool-display/README.zh-CN.md
+++ b/packages/pi-extensions-tool-display/README.zh-CN.md
@@ -8,7 +8,7 @@
 - Pi 展示宿主尚未加载时的 pending 注册队列；
 - 安全识别组件，以及把审计面板追加到原始工具结果后的通用组件组合。
 
-它同时是一个独立的 Pi 扩展。可以把这个包直接加入 Pi 的 package 列表加载工具展示宿主；`pi-distill`、`pi-tool-supervisor` 等功能包加载时也会通过这个运行时依赖自动初始化同一个宿主，不需要额外安装第二份宿主包。
+它同时是一个独立的 Pi 扩展。可以把这个包直接加入 Pi 的 package 列表加载工具展示宿主；`pi-distill`、`pi-tool-supervisor` 的包清单也会声明这个依赖的扩展入口，因此安装功能包时只会加载一个公共宿主，不需要额外安装第二份宿主包。
 
 ## 设计边界
 
@@ -28,7 +28,7 @@
 pi install npm:pi-extensions-tool-display
 ```
 
-安装 `pi-distill` 或 `pi-tool-supervisor` 时，宿主也会由共享运行时自动初始化。
+安装 `pi-distill` 或 `pi-tool-supervisor` 时，它们的包清单会同时加载这个宿主扩展入口。
 
 ## 开发
 

--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -24,7 +24,7 @@ It observes Pi's native events and does not register a replacement `edit` or `wr
 pi install npm:pi-tool-supervisor
 ```
 
-The shared `pi-extensions-tool-display` dependency initializes the display host automatically; no separate host package is required.
+The package manifest also loads the shared `pi-extensions-tool-display` dependency as one extension entry; no separate host package is required.
 
 Reload Pi after installation:
 

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -24,7 +24,7 @@
 pi install npm:pi-tool-supervisor
 ```
 
-共享依赖 `pi-extensions-tool-display` 会自动初始化展示宿主，不需要额外安装宿主包。
+包清单会把共享依赖 `pi-extensions-tool-display` 作为一个扩展入口加载，不需要额外安装宿主包。
 
 安装后重新加载 Pi：
 

--- a/packages/pi-tool-supervisor/package.json
+++ b/packages/pi-tool-supervisor/package.json
@@ -19,7 +19,8 @@
   },
   "pi": {
     "extensions": [
-      "./index.ts"
+      "./index.ts",
+      "../pi-extensions-tool-display/index.ts"
     ]
   },
   "engines": {

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -16,7 +16,6 @@ import type {
   ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
 import { performance } from "node:perf_hooks";
-import { ensureToolDisplayHost } from "pi-extensions-tool-display";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
@@ -614,7 +613,6 @@ function registerReviewConfigCommand(pi: ExtensionAPI): void {
 }
 
 export default function piSupervisorExtension(pi: ExtensionAPI) {
-  ensureToolDisplayHost(pi);
   const pendingCalls = new Map<string, PendingFileReviewCall>();
   const disposeToolDisplayMiddleware = registerSupervisorToolDisplayMiddleware();
   registerSupervisorFallbackRenderer(pi);


### PR DESCRIPTION
## 问题
`pi-distill` 和 `pi-tool-supervisor` 各自初始化共享宿主时，在全新 Pi 实例中仍可能注册出两个 `tool-display` 命令。

## 改动
- 在两个功能包的 `pi.extensions` manifest 中声明同一个 `../pi-extensions-tool-display/index.ts` 入口。
- 移除两个功能包中的运行时宿主初始化。
- 更新中英文包文档，说明公共宿主通过依赖扩展入口加载。

Pi 会在资源收集阶段按解析后的扩展路径去重，因此两个功能包共用一个宿主实例。

## 验证
- `npm run check`
- 验证两个 manifest 的宿主路径均解析到 `packages/pi-extensions-tool-display/index.ts`
- `npm pack --dry-run` 检查两个包均包含更新后的 `package.json`
