### PR TITLE
refactor: real-time save for config UIs and fix audit text color

### DIFF
--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -27,10 +27,6 @@
     "zh-CN": "Distill 已保存，但有警告：{warnings}",
     "en-US": "Distill saved with warnings: {warnings}"
   },
-  "saved": {
-    "zh-CN": "Distill 设置已保存；下一次工具调用生效。",
-    "en-US": "Distill settings saved; changes apply to the next tool call."
-  },
   "interactiveOnly": {
     "zh-CN": "交互式设置需要在带 UI 的 Pi 会话中运行。",
     "en-US": "Interactive settings require a Pi session with UI."
@@ -94,14 +90,6 @@
   "showSummary": {
     "zh-CN": "显示摘要：{value}",
     "en-US": "Show summary: {value}"
-  },
-  "saveExit": {
-    "zh-CN": "保存并退出",
-    "en-US": "Save and exit"
-  },
-  "discard": {
-    "zh-CN": "放弃修改",
-    "en-US": "Discard changes"
   },
   "minOutputTitle": {
     "zh-CN": "最小输出字符数",

--- a/packages/pi-distill/src/fallback-renderer.ts
+++ b/packages/pi-distill/src/fallback-renderer.ts
@@ -71,12 +71,12 @@ function renderDistillAuditLine(audit: DistillAuditView, line: string, index: nu
   if (section) {
     const [, branch, label, gap, content] = section;
     const labelTone = label === "Summary" ? "success" : label === "Error" ? "error" : label === "Warning" ? "warning" : "accent";
-    return `${theme.fg("dim", branch ?? "")}${theme.fg(labelTone, label ?? "")}${gap ?? ""}${theme.fg("text", content ?? "")}`;
+    return `${theme.fg("dim", branch ?? "")}${theme.fg(labelTone, label ?? "")}${gap ?? ""}${content ?? ""}`;
   }
 
   const continuation = line.match(/^(│       |        )(.*)$/);
   if (continuation) {
-    return `${theme.fg("dim", continuation[1] ?? "")}${theme.fg("text", continuation[2] ?? "")}`;
+    return `${theme.fg("dim", continuation[1] ?? "")}${continuation[2] ?? ""}`;
   }
   return theme.fg("muted", line);
 }
@@ -103,7 +103,7 @@ function wrapDistillAuditLine(
     const renderedPrefix = `${theme.fg("dim", branch)}${theme.fg(labelTone, label)}${gap}`;
     const renderedContinuation = theme.fg("dim", branch.startsWith("├") ? "│       " : "        ");
     const contentWidth = Math.max(1, width - visibleWidth(renderedPrefix));
-    const wrappedContent = wrapTextWithAnsi(theme.fg("text", content), contentWidth);
+    const wrappedContent = wrapTextWithAnsi(content, contentWidth);
     return wrappedContent.map((part, partIndex) => padLine(
       `${partIndex === 0 ? renderedPrefix : renderedContinuation}${part}`,
       width,
@@ -115,7 +115,7 @@ function wrapDistillAuditLine(
     const [, prefix = "", content = ""] = continuation;
     const renderedPrefix = theme.fg("dim", prefix);
     const contentWidth = Math.max(1, width - visibleWidth(renderedPrefix));
-    const wrappedContent = wrapTextWithAnsi(theme.fg("text", content), contentWidth);
+    const wrappedContent = wrapTextWithAnsi(content, contentWidth);
     return wrappedContent.map((part) => padLine(`${renderedPrefix}${part}`, width));
   }
 

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -630,6 +630,19 @@ async function editDistillModel(
   return normalized;
 }
 
+async function saveDistillConfigFile(
+  ctx: ExtensionCommandContext,
+  config: DistillUiConfig,
+  configPath: string,
+): Promise<void> {
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  const saved = loadDistillConfig();
+  if (saved.warnings.length > 0) {
+    ctx.ui.notify(i18n.t("savedWarnings", { warnings: saved.warnings.join(" ") }), "warning");
+  }
+}
+
 async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: string): Promise<void> {
   const loaded = loadDistillConfig();
   if (loaded.warnings.length > 0) {
@@ -650,50 +663,61 @@ async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: stri
       i18n.t("auditRenderer", { value: config.render.enabled ? i18n.t("on") : i18n.t("off") }),
       i18n.t("showPrompt", { value: config.render.showPrompt ? i18n.t("on") : i18n.t("off") }),
       i18n.t("showSummary", { value: config.render.showResult ? i18n.t("on") : i18n.t("off") }),
-      i18n.t("saveExit"),
-      i18n.t("discard"),
     ];
     const choice = await ctx.ui.select(i18n.t("settingsTitle"), choices);
-    if (choice === undefined || choice === i18n.t("discard")) return;
+    if (choice === undefined) return;
 
     if (choice === choices[0]) {
       config.enabled = !config.enabled;
+      await saveDistillConfigFile(ctx, config, configPath);
     } else if (choice === choices[1]) {
       const value = await editDistillModel(ctx, config.model);
-      if (value !== undefined) config.model = value;
+      if (value !== undefined) {
+        config.model = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[2]) {
       const value = await editDistillNumber(ctx, i18n.t("minOutputTitle"), config.minChars);
-      if (value !== undefined) config.minChars = value;
+      if (value !== undefined) {
+        config.minChars = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[3]) {
       const value = await editDistillNumber(ctx, i18n.t("summaryLimitTitle"), config.maxChars);
-      if (value !== undefined) config.maxChars = value;
+      if (value !== undefined) {
+        config.maxChars = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[4]) {
       const value = await editDistillNumber(ctx, i18n.t("finalLimitTitle"), config.maxOutputChars);
-      if (value !== undefined) config.maxOutputChars = value;
+      if (value !== undefined) {
+        config.maxOutputChars = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[5]) {
       const value = await editDistillNumber(ctx, i18n.t("timeoutTitle"), config.timeoutSeconds);
-      if (value !== undefined) config.timeoutSeconds = value;
+      if (value !== undefined) {
+        config.timeoutSeconds = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[6]) {
       const value = await editDistillNumber(ctx, i18n.t("thresholdTitle"), config.missedCompressionRatio);
-      if (value !== undefined) config.missedCompressionRatio = value;
+      if (value !== undefined) {
+        config.missedCompressionRatio = value;
+        await saveDistillConfigFile(ctx, config, configPath);
+      }
     } else if (choice === choices[7]) {
       config.summarizeErrors = !config.summarizeErrors;
+      await saveDistillConfigFile(ctx, config, configPath);
     } else if (choice === choices[8]) {
       config.render.enabled = !config.render.enabled;
+      await saveDistillConfigFile(ctx, config, configPath);
     } else if (choice === choices[9]) {
       config.render.showPrompt = !config.render.showPrompt;
+      await saveDistillConfigFile(ctx, config, configPath);
     } else if (choice === choices[10]) {
       config.render.showResult = !config.render.showResult;
-    } else if (choice === choices[11]) {
-      await mkdir(dirname(configPath), { recursive: true });
-      await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
-      const saved = loadDistillConfig();
-      if (saved.warnings.length > 0) {
-        ctx.ui.notify(i18n.t("savedWarnings", { warnings: saved.warnings.join(" ") }), "warning");
-      } else {
-        ctx.ui.notify(i18n.t("saved"), "info");
-      }
-      return;
+      await saveDistillConfigFile(ctx, config, configPath);
     }
   }
 }

--- a/packages/pi-tool-supervisor/locales/index.json
+++ b/packages/pi-tool-supervisor/locales/index.json
@@ -87,10 +87,6 @@
     "zh-CN": "文件评审配置已保存，但有警告：{warnings}",
     "en-US": "File review configuration saved with warnings: {warnings}"
   },
-  "saved": {
-    "zh-CN": "文件评审配置已保存，下一次 edit/write 生效。",
-    "en-US": "File review configuration saved; changes apply to the next edit/write."
-  },
   "configWarnings": {
     "zh-CN": "当前配置有警告，将以可用值打开：{warnings}",
     "en-US": "The current configuration has warnings; opening with usable values: {warnings}"
@@ -126,14 +122,6 @@
   "rulesConfig": {
     "zh-CN": "规则最大行数：{value}",
     "en-US": "Maximum rule lines: {value}"
-  },
-  "saveExit": {
-    "zh-CN": "保存并退出",
-    "en-US": "Save and exit"
-  },
-  "discard": {
-    "zh-CN": "放弃修改",
-    "en-US": "Discard changes"
   },
   "commandDescription": {
     "zh-CN": "通过交互式菜单配置 edit/write 文件评审",

--- a/packages/pi-tool-supervisor/src/fallback-renderer.ts
+++ b/packages/pi-tool-supervisor/src/fallback-renderer.ts
@@ -147,7 +147,7 @@ function renderSupervisorAuditLine(audit: SupervisorAuditView, line: string, ind
   const section = line.match(/^([├└]─ )([^ ]+)(  )(.*)$/);
   if (section) {
     const [, branch = "", label = "", gap = "  ", content = ""] = section;
-    return `${theme.fg("dim", branch)}${theme.fg(sectionLabelTone(label), label)}${gap}${theme.fg("text", content)}`;
+    return `${theme.fg("dim", branch)}${theme.fg(sectionLabelTone(label), label)}${gap}${content}`;
   }
 
   const continuation = line.match(/^(│       |        )(.*)$/);
@@ -155,9 +155,9 @@ function renderSupervisorAuditLine(audit: SupervisorAuditView, line: string, ind
     const [, prefix = "", content = ""] = continuation;
     const nested = content.match(/^([^ ]+)(  )(.*)$/);
     if (nested && [i18n.t("summary"), i18n.t("finding"), i18n.t("rules")].includes(nested[1] ?? "")) {
-      return `${theme.fg("dim", prefix)}${theme.fg(sectionLabelTone(nested[1] ?? ""), nested[1] ?? "")}${nested[2] ?? "  "}${theme.fg("text", nested[3] ?? "")}`;
+      return `${theme.fg("dim", prefix)}${theme.fg(sectionLabelTone(nested[1] ?? ""), nested[1] ?? "")}${nested[2] ?? "  "}${nested[3] ?? ""}`;
     }
-    return `${theme.fg("dim", prefix)}${theme.fg("text", content)}`;
+    return `${theme.fg("dim", prefix)}${content}`;
   }
   return theme.fg("muted", line);
 }
@@ -183,7 +183,7 @@ function wrapSupervisorAuditLine(
     const renderedPrefix = `${theme.fg("dim", branch)}${theme.fg(sectionLabelTone(label), label)}${gap}`;
     const renderedContinuation = theme.fg("dim", branch.startsWith("├") ? "│       " : "        ");
     const contentWidth = Math.max(1, width - visibleWidth(renderedPrefix));
-    const wrappedContent = wrapTextWithAnsi(theme.fg("text", content), contentWidth);
+    const wrappedContent = wrapTextWithAnsi(content, contentWidth);
     return wrappedContent.map((part, partIndex) => padLine(
       `${partIndex === 0 ? renderedPrefix : renderedContinuation}${part}`,
       width,
@@ -195,7 +195,7 @@ function wrapSupervisorAuditLine(
     const [, prefix = "", content = ""] = continuation;
     const renderedPrefix = theme.fg("dim", prefix);
     const contentWidth = Math.max(1, width - visibleWidth(renderedPrefix));
-    const wrappedContent = wrapTextWithAnsi(theme.fg("text", content), contentWidth);
+    const wrappedContent = wrapTextWithAnsi(content, contentWidth);
     return wrappedContent.map((part) => padLine(`${renderedPrefix}${part}`, width));
   }
 

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -529,14 +529,31 @@ async function editReviewer(
   }
 }
 
-async function addReviewer(ctx: ExtensionCommandContext, reviewers: FileEditReviewReviewerConfig[]): Promise<void> {
+async function saveFileEditReviewConfig(
+  ctx: ExtensionCommandContext,
+  config: FileEditReviewConfig,
+  configPath: string,
+): Promise<void> {
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  const saved = loadFileEditReviewConfig(configPath);
+  if (saved.warnings.length > 0) {
+    ctx.ui.notify(i18n.t("savedWarnings", { warnings: saved.warnings.join(" ") }), "warning");
+  }
+}
+
+async function addReviewer(
+  ctx: ExtensionCommandContext,
+  reviewers: FileEditReviewReviewerConfig[],
+): Promise<boolean> {
   const name = await ctx.ui.input(i18n.t("reviewerName"), `reviewer-${reviewers.length + 1}`);
-  if (!name?.trim()) return;
+  if (!name?.trim()) return false;
   const model = await inputModel(ctx, "llm-proxy/LOW");
-  if (!model) return;
+  if (!model) return false;
   const rulesFiles = await inputList(ctx, i18n.t("listInput"), [], true);
-  if (!rulesFiles) return;
+  if (!rulesFiles) return false;
   reviewers.push({ name: name.trim(), model, rulesFiles, enabled: true });
+  return true;
 }
 
 async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: string): Promise<void> {
@@ -560,40 +577,40 @@ async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: strin
       i18n.t("rulesConfig", { value: config.maxRuleLines }),
       ...reviewerChoices,
       i18n.t("addReviewer"),
-      i18n.t("saveExit"),
-      i18n.t("discard"),
     ];
     const choice = await ctx.ui.select(i18n.t("configTitle"), choices);
-    if (choice === undefined || choice === i18n.t("discard")) return;
+    if (choice === undefined) return;
 
     if (choice === choices[0]) {
       config.enabled = !config.enabled;
+      await saveFileEditReviewConfig(ctx, config, configPath);
     } else if (choice === choices[1]) {
       const value = await inputPositiveInteger(ctx, i18n.t("timeoutInput"), config.timeoutSeconds);
-      if (value !== undefined) config.timeoutSeconds = value;
+      if (value !== undefined) {
+        config.timeoutSeconds = value;
+        await saveFileEditReviewConfig(ctx, config, configPath);
+      }
     } else if (choice === choices[2]) {
       const value = await inputPositiveInteger(ctx, i18n.t("outputInput"), config.maxOutputChars);
-      if (value !== undefined) config.maxOutputChars = value;
+      if (value !== undefined) {
+        config.maxOutputChars = value;
+        await saveFileEditReviewConfig(ctx, config, configPath);
+      }
     } else if (choice === choices[3]) {
       const value = await inputPositiveInteger(ctx, i18n.t("rulesInput"), config.maxRuleLines);
-      if (value !== undefined) config.maxRuleLines = value;
-    } else if (choice === choices[4 + config.reviewers.length]) {
-      await addReviewer(ctx, config.reviewers);
-    } else if (choice === choices[5 + config.reviewers.length]) {
-      await mkdir(dirname(configPath), { recursive: true });
-      await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
-      const saved = loadFileEditReviewConfig(configPath);
-      if (saved.warnings.length > 0) {
-        ctx.ui.notify(i18n.t("savedWarnings", { warnings: saved.warnings.join(" ") }), "warning");
-      } else {
-        ctx.ui.notify(i18n.t("saved"), "info");
+      if (value !== undefined) {
+        config.maxRuleLines = value;
+        await saveFileEditReviewConfig(ctx, config, configPath);
       }
-      return;
+    } else if (choice === choices[4 + config.reviewers.length]) {
+      const added = await addReviewer(ctx, config.reviewers);
+      if (added) await saveFileEditReviewConfig(ctx, config, configPath);
     } else if (choice.startsWith("● ") || choice.startsWith("○ ")) {
       const index = reviewerChoices.indexOf(choice);
       if (index >= 0) {
         const result = await editReviewer(ctx, config.reviewers[index]);
         if (result === "deleted") config.reviewers.splice(index, 1);
+        await saveFileEditReviewConfig(ctx, config, configPath);
       }
     }
   }


### PR DESCRIPTION
## 变更内容

- pi-distill 与 pi-tool-supervisor 的交互式配置菜单改为**实时保存**，每次修改后立即写入 config.json，避免手动保存遗漏。
- 移除原来的「保存并退出 / 放弃修改」选项，按 ESC 直接退出。
- 修复 distill 与 supervisor 审计面板中 prompt/summary/finding/rules 等正文内容被强制渲染为黑色的问题，改为使用终端默认文字色，与其他文本保持一致。

## 验证

- `npm run check` 通过（typecheck + 全部测试 + i18n 对齐 + 本机解耦门禁）。
