### PR TITLE
feat: 新增 pi-terminal-mux 终端多路复用器抽象包

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "packages/pi-extensions-i18n": "0.3.0",
   "packages/pi-distill": "0.4.3",
   "packages/pi-tool-supervisor": "0.3.3",
-  "packages/pi-extensions-tool-display": "0.2.2"
+  "packages/pi-extensions-tool-display": "0.2.2",
+  "packages/pi-terminal-mux": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ pi-extensions/
 │   ├── pi-extensions-i18n/      # Shared locale and catalog runtime
 │   ├── pi-extensions-tool-display/ # Tool-display host and shared rendering protocol
 │   ├── pi-distill/              # Tool-output distillation
-│   └── pi-tool-supervisor/      # Post-edit file review
+│   ├── pi-tool-supervisor/      # Post-edit file review
+│   └── pi-terminal-mux/         # Terminal multiplexer abstraction (muxy/cmux/tmux/zellij/wezterm/herdr/otty + headless fallback)
 ├── scripts/                     # Repository checks and workspace helpers
 ├── .github/workflows/           # CI and release automation
 ├── README.md                    # English project documentation
@@ -27,6 +28,7 @@ Each package owns its entrypoint, tests, configuration example, localization res
 - `pi-tool-supervisor` reviews the actual before/after diff of `edit` and `write` against configured rule files. It reports findings but is not an operating-system sandbox or an edit rollback mechanism.
 - `pi-extensions-tool-display` owns the actual Pi tool-display host, built-in tool renderer overrides, and the shared result-rendering middleware protocol. Feature packages register domain-specific panels through it.
 - `pi-extensions-i18n` owns locale selection, catalog validation, interpolation, and the `/pi-language` command. Feature packages use it instead of implementing separate locale runtimes.
+- `pi-terminal-mux` owns terminal multiplexer detection and pane/surface operations. Extensions that need terminal interaction depend on it instead of re-implementing backend detection.
 
 Keep packages composable and independently installable. Avoid coupling one extension to another extension's private implementation details or display state.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3469,6 +3469,10 @@
       "resolved": "packages/pi-extensions-tool-display",
       "link": true
     },
+    "node_modules/pi-terminal-mux": {
+      "resolved": "packages/pi-terminal-mux",
+      "link": true
+    },
     "node_modules/pi-tool-supervisor": {
       "resolved": "packages/pi-tool-supervisor",
       "link": true
@@ -3686,6 +3690,22 @@
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
         "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
+      }
+    },
+    "packages/pi-terminal-mux": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "24.12.4",
+        "pi-extensions-i18n": "^0.3.0",
+        "tsx": "4.23.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "pi-extensions-i18n": "^0.3.0"
       }
     },
     "packages/pi-tool-supervisor": {

--- a/packages/pi-terminal-mux/README.md
+++ b/packages/pi-terminal-mux/README.md
@@ -1,0 +1,115 @@
+# pi-terminal-mux
+
+Terminal multiplexer abstraction for pi extensions — one unified surface API across **muxy, cmux, tmux, zellij, wezterm, herdr and otty**, with automatic **headless fallback** (background child process + log file) when no multiplexer is detected.
+
+Any pi extension that needs terminal interaction (splitting panes, sending commands, reading screens, closing panes, waiting for process exit) should depend on this package instead of re-implementing backend detection and command assembly.
+
+[中文文档](./README.zh-CN.md)
+
+## Install
+
+```bash
+npm install pi-terminal-mux
+```
+
+## Quick start
+
+```ts
+import {
+  isMuxAvailable,
+  muxSetupHint,
+  createSurface,
+  createSurfaceSplit,
+  sendCommand,
+  sendLongCommand,
+  sendEscape,
+  readScreen,
+  closeSurface,
+  pollForExit,
+} from "pi-terminal-mux";
+
+if (!isMuxAvailable()) {
+  console.warn(muxSetupHint()); // localized setup hint via pi-extensions-i18n
+}
+
+// Smart placement: split / stack / new tab depending on the backend strategy
+// (returns a headless surface when no multiplexer is available)
+const surface = createSurface("my-agent");
+
+// Long commands are written to a script file first to avoid terminal line wrapping
+const scriptPath = sendLongCommand(surface, "pi --session abc", {
+  scriptPreamble: "export MY_FLAG=1",
+});
+
+const tail = readScreen(surface, 50);
+sendEscape(surface);
+closeSurface(surface);
+```
+
+## Backend detection
+
+| Backend | Detection |
+|---------|-----------|
+| muxy | `MUXY_SOCKET_PATH` + `muxy` command |
+| cmux | `CMUX_SOCKET_PATH` + `cmux` command |
+| tmux | `TMUX` + `tmux` command |
+| zellij | `ZELLIJ` / `ZELLIJ_SESSION_NAME` + `zellij` command |
+| wezterm | `WEZTERM_UNIX_SOCKET` + `wezterm` command |
+| herdr | `HERDR_ENV=1` + `HERDR_PANE_ID` + `herdr` command |
+| otty | `TERM_PROGRAM=otty` + `otty` command |
+
+Default priority follows the table order (muxy first). Force a backend with:
+
+- `PI_TERMINAL_MUX` (preferred): `muxy | cmux | tmux | zellij | wezterm | herdr | otty`
+- `PI_SUBAGENT_MUX`: backward-compatible alias
+
+If the forced backend's runtime is unavailable, `getMuxBackend()` returns `null` — it never silently falls back to another backend.
+
+## API overview
+
+### Unified surface API (same semantics across backends)
+
+| Function | Description |
+|----------|-------------|
+| `createSurface(name)` | Smart placement (cmux: first right-split then tabs; zellij: tab-aware tiled/stacked; muxy/otty: breadth-first splits), returns a surface handle |
+| `createSurfaceSplit(name, direction, fromSurface?)` | Split in an explicit direction (left/right/up/down) |
+| `sendCommand(surface, command)` | Send a command and press Enter |
+| `sendLongCommand(surface, command, opts?)` | Write long commands to a script file first; `opts.scriptPreamble` injects env exports; returns the script path |
+| `sendEscape(surface)` | Send one ESC keypress |
+| `readScreen(surface, lines?)` / `readScreenAsync` | Read the last N screen lines |
+| `closeSurface(surface)` | Close the surface |
+| `renameSurface(surface, name)` / `renameCurrentTab(title)` / `renameAgent(surface, name)` / `renameWorkspace(title)` | Naming, degrading per backend capability |
+| `pollForExit(surface, signal, opts)` | Wait for the process in a surface to exit: `.exit` sidecar file first, then a screen sentinel (`__SUBAGENT_DONE_<code>__`); headless uses child process exit |
+| `getLastSplitSource()` / `clearLastSplitSource()` | Source pane of the most recent split (for UI display) |
+
+### Detection and utilities
+
+`getMuxBackend()`, `isMuxAvailable()`, `isHeadlessMode()`, `muxSetupHint()`, `getAgentPaneId(backend?)`, `backendAgentPaneEnvVar(backend)`, `shellEscape()`, `isFishShell()`, `exitStatusVar()`, plus zellij placement planning (`selectZellijPlacement` etc.) and cmux/otty JSON parsing helpers — all pure and unit-testable.
+
+### Backend-native APIs
+
+Backend-native functions are also re-exported (e.g. `createHerdrSurface`, `splitHerdrPane`, `readHerdrScreen`, `sendOttyCommand`, `renameOttyTab`, ...). Subpath imports are available too: `pi-terminal-mux/mux`, `pi-terminal-mux/herdr`, `pi-terminal-mux/otty`.
+
+## Headless mode
+
+When no backend is detected, `createSurface` returns a `headless:`-prefixed surface, `sendLongCommand` spawns a background child process writing to a log file, and `readScreen` / `pollForExit` / `closeSurface` keep the same semantics — callers need no special-casing.
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` | Force a backend |
+| `PI_SUBAGENT_ZELLIJ_MIN_COLUMNS` / `PI_SUBAGENT_ZELLIJ_MIN_ROWS` | Minimum usable size for zellij splits (default 50x10; stacks instead when smaller) |
+| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | Allow renameCurrentTab / renameWorkspace on tmux (user naming untouched by default) |
+| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | Allow renameWorkspace on herdr |
+| `PI_EXTENSIONS_LOCALE` | Hint language (`zh-CN` / `en-US` / `auto`), provided by pi-extensions-i18n |
+
+## Design constraints
+
+- **No machine coupling**: every backend is selected via runtime detection (env vars + command availability); no hardcoded local paths; missing CLIs degrade backend-by-backend down to headless.
+- **Localized user-facing text**: setup hints go through the [pi-extensions-i18n](https://www.npmjs.com/package/pi-extensions-i18n) catalog with complete `zh-CN` and `en-US` entries.
+- **Agent pane anchoring**: the agent's own pane ID on muxy/herdr/otty is captured at module load (`AGENT_MUXY_PANE_ID` etc.), immune to later focus switches.
+
+## License
+
+MIT

--- a/packages/pi-terminal-mux/README.zh-CN.md
+++ b/packages/pi-terminal-mux/README.zh-CN.md
@@ -1,0 +1,114 @@
+# pi-terminal-mux
+
+终端多路复用器统一抽象层，供 pi 扩展复用。任何涉及终端交互（分屏、发命令、读屏、关屏、等待退出）的插件都应依赖本包，而不是各自重新实现 backend 探测与命令拼装。
+
+一套统一的 surface API 跨 **muxy、cmux、tmux、zellij、wezterm、herdr、otty** 七个后端，探测不到任何后端时自动降级为 **headless**（后台子进程 + 日志文件）。
+
+[English README](./README.md)
+
+## 安装
+
+```bash
+npm install pi-terminal-mux
+```
+
+## 快速上手
+
+```ts
+import {
+  isMuxAvailable,
+  muxSetupHint,
+  createSurface,
+  createSurfaceSplit,
+  sendCommand,
+  sendLongCommand,
+  sendEscape,
+  readScreen,
+  closeSurface,
+  pollForExit,
+} from "pi-terminal-mux";
+
+if (!isMuxAvailable()) {
+  console.warn(muxSetupHint()); // 中英文安装提示，由 pi-extensions-i18n 决定语言
+}
+
+// 智能放置：按后端策略分屏 / 堆叠 / 开 tab（headless 时返回 headless surface）
+const surface = createSurface("my-agent");
+
+// 长命令自动落脚本文件，避免终端宽度截断
+const scriptPath = sendLongCommand(surface, "pi --session abc", {
+  scriptPreamble: "export MY_FLAG=1",
+});
+
+const tail = readScreen(surface, 50);
+sendEscape(surface);
+closeSurface(surface);
+```
+
+## 后端探测
+
+| 后端 | 探测条件 |
+|------|----------|
+| muxy | `MUXY_SOCKET_PATH` + `muxy` 命令 |
+| cmux | `CMUX_SOCKET_PATH` + `cmux` 命令 |
+| tmux | `TMUX` + `tmux` 命令 |
+| zellij | `ZELLIJ` / `ZELLIJ_SESSION_NAME` + `zellij` 命令 |
+| wezterm | `WEZTERM_UNIX_SOCKET` + `wezterm` 命令 |
+| herdr | `HERDR_ENV=1` + `HERDR_PANE_ID` + `herdr` 命令 |
+| otty | `TERM_PROGRAM=otty` + `otty` 命令 |
+
+默认优先级即上表顺序（muxy 优先）。可用环境变量强制指定后端：
+
+- `PI_TERMINAL_MUX`（推荐）：`muxy | cmux | tmux | zellij | wezterm | herdr | otty`
+- `PI_SUBAGENT_MUX`：同上的向后兼容别名
+
+指定的后端运行环境不满足时 `getMuxBackend()` 返回 `null`，不会悄悄降级到其他后端。
+
+## API 概览
+
+### 统一 surface API（跨后端语义一致）
+
+| 函数 | 说明 |
+|------|------|
+| `createSurface(name)` | 智能放置新 surface（cmux 首次右分屏后续开 tab、zellij tab 感知平铺/堆叠、muxy/otty 广度优先分屏），返回 surface 标识 |
+| `createSurfaceSplit(name, direction, fromSurface?)` | 指定方向（left/right/up/down）分屏 |
+| `sendCommand(surface, command)` | 发送命令并回车执行 |
+| `sendLongCommand(surface, command, opts?)` | 长命令先写脚本文件再执行；`opts.scriptPreamble` 可注入 env export；返回脚本路径 |
+| `sendEscape(surface)` | 发送一次 ESC |
+| `readScreen(surface, lines?)` / `readScreenAsync` | 读取屏幕尾部 N 行 |
+| `closeSurface(surface)` | 关闭 surface |
+| `renameSurface(surface, name)` / `renameCurrentTab(title)` / `renameAgent(surface, name)` / `renameWorkspace(title)` | 命名（按后端能力降级或跳过） |
+| `pollForExit(surface, signal, opts)` | 等待 surface 内进程退出：优先 `.exit` sidecar 文件，其次屏幕 sentinel（`__SUBAGENT_DONE_<code>__`），headless 走子进程 exit |
+| `getLastSplitSource()` / `clearLastSplitSource()` | 最近一次分屏的来源 pane（用于 UI 展示） |
+
+### 探测与工具
+
+`getMuxBackend()`、`isMuxAvailable()`、`isHeadlessMode()`、`muxSetupHint()`、`getAgentPaneId(backend?)`、`backendAgentPaneEnvVar(backend)`、`shellEscape()`、`isFishShell()`、`exitStatusVar()`，以及 zellij 放置规划（`selectZellijPlacement` 等）与 cmux/otty JSON 解析等纯函数，均可直接引用做单元测试。
+
+### 后端原生 API
+
+各后端原生函数也从包入口透出（如 `createHerdrSurface`、`splitHerdrPane`、`readHerdrScreen`、`sendOttyCommand`、`renameOttyTab`……），子路径导入亦可：`pi-terminal-mux/mux`、`pi-terminal-mux/herdr`、`pi-terminal-mux/otty`。
+
+## Headless 模式
+
+探测不到任何后端时，`createSurface` 返回 `headless:` 前缀的 surface，`sendLongCommand` 直接 spawn 后台子进程并把输出写入日志文件，`readScreen`/`pollForExit`/`closeSurface` 语义保持不变，调用方无需特判。
+
+## 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` | 强制指定后端 |
+| `PI_SUBAGENT_ZELLIJ_MIN_COLUMNS` / `PI_SUBAGENT_ZELLIJ_MIN_ROWS` | zellij 分屏最小可用尺寸（默认 50×10，不满足时改堆叠） |
+| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | tmux 下允许 renameCurrentTab / renameWorkspace（默认不动用户命名） |
+| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | herdr 下允许 renameWorkspace |
+| `PI_EXTENSIONS_LOCALE` | 提示文案语言（`zh-CN` / `en-US` / `auto`），由 pi-extensions-i18n 提供 |
+
+## 设计约束
+
+- **不绑定具体机器**：全部后端通过运行时探测（环境变量 + 命令存在性）选择，零硬编码本机路径；外部 CLI 缺失时按后端逐个降级，最终落到 headless。
+- **用户文案国际化**：面向用户的提示走 [pi-extensions-i18n](https://www.npmjs.com/package/pi-extensions-i18n) catalog，中英文齐全。
+- **agent pane 锚定**：muxy/herdr/otty 的 agent 自身 pane ID 在模块加载时捕获（`AGENT_MUXY_PANE_ID` 等），不受用户后续焦点切换影响。
+
+## License
+
+MIT

--- a/packages/pi-terminal-mux/index.ts
+++ b/packages/pi-terminal-mux/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.ts";

--- a/packages/pi-terminal-mux/locales/mux.json
+++ b/packages/pi-terminal-mux/locales/mux.json
@@ -1,0 +1,46 @@
+{
+  "setupHint.none": {
+    "zh-CN": "未检测到可用的终端多路复用器。",
+    "en-US": "No supported terminal multiplexer found."
+  },
+  "setupHint.cmux": {
+    "zh-CN": "请在 cmux 中启动 pi（`cmux pi`）。",
+    "en-US": "Start pi inside cmux (`cmux pi`)."
+  },
+  "setupHint.muxy": {
+    "zh-CN": "请在 Muxy 终端中启动 pi。",
+    "en-US": "Start pi inside Muxy terminal."
+  },
+  "setupHint.tmux": {
+    "zh-CN": "请在 tmux 中启动 pi（`tmux new -A -s pi 'pi'`）。",
+    "en-US": "Start pi inside tmux (`tmux new -A -s pi 'pi'`)."
+  },
+  "setupHint.zellij": {
+    "zh-CN": "请在 zellij 中启动 pi（`zellij --session pi`，然后运行 `pi`）。",
+    "en-US": "Start pi inside zellij (`zellij --session pi`, then run `pi`)."
+  },
+  "setupHint.wezterm": {
+    "zh-CN": "请在 WezTerm 中启动 pi。",
+    "en-US": "Start pi inside WezTerm."
+  },
+  "setupHint.herdr": {
+    "zh-CN": "请在终端中运行 herdr（`herdr`），拆分一个 pane（prefix+v 或 prefix+-），然后在该 pane 中运行 `pi`。herdr 会自动注入 HERDR_ENV=1 和 HERDR_PANE_ID 供 pi 检测。",
+    "en-US": "Start herdr in your terminal (`herdr`), split a pane (prefix+v or prefix+-), then run `pi` in that pane. herdr auto-injects HERDR_ENV=1 + HERDR_PANE_ID for pi to detect."
+  },
+  "setupHint.otty": {
+    "zh-CN": "请在 Otty 中运行 pi（Otty 会自动设置 TERM_PROGRAM=otty）。",
+    "en-US": "Run pi inside Otty (Otty sets TERM_PROGRAM=otty automatically)."
+  },
+  "setupHint.generic": {
+    "zh-CN": "请在 Muxy、cmux（`cmux pi`）、tmux（`tmux new -A -s pi 'pi'`）、zellij（`zellij --session pi`，然后运行 `pi`）、WezTerm、herdr（运行 `herdr`，拆分 pane 后在其中运行 `pi`）或 Otty（Otty 会自动设置 TERM_PROGRAM=otty）中启动 pi。",
+    "en-US": "Start pi inside Muxy, cmux (`cmux pi`), tmux (`tmux new -A -s pi 'pi'`), zellij (`zellij --session pi`, then run `pi`), WezTerm, herdr (run `herdr`, split a pane, then run `pi` in it), or Otty (Otty sets TERM_PROGRAM=otty automatically)."
+  },
+  "setupHint.herdrPreferred": {
+    "zh-CN": "请在 herdr 中启动 pi（必须设置 HERDR_ENV=1；先运行 herdr，再在 pane 中启动 pi）。",
+    "en-US": "Start pi inside herdr (HERDR_ENV=1 must be set; run herdr, then start pi in a pane)."
+  },
+  "setupHint.ottySendKeys": {
+    "zh-CN": "Otty 的 `ipc-allow-send-keys` 未启用。如需让 pi 驱动子 agent 分屏，请在 ~/.config/otty/config.toml 中添加 `ipc-allow-send-keys = true` 并重新加载 Otty。",
+    "en-US": "Otty's `ipc-allow-send-keys` is disabled. To let pi drive subagent panes, add `ipc-allow-send-keys = true` to ~/.config/otty/config.toml and reload Otty."
+  }
+}

--- a/packages/pi-terminal-mux/package.json
+++ b/packages/pi-terminal-mux/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "pi-terminal-mux",
+  "version": "0.1.0",
+  "description": "Terminal multiplexer abstraction for pi extensions — unified surface API across muxy, cmux, tmux, zellij, wezterm, herdr and otty, with headless fallback",
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./mux": "./src/mux.ts",
+    "./herdr": "./src/herdr.ts",
+    "./otty": "./src/otty.ts"
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "locales",
+    "README.md",
+    "README.zh-CN.md",
+    "tsconfig.json"
+  ],
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit --pretty false",
+    "build": "npm run typecheck",
+    "check": "npm run typecheck && npm test && npm pack --dry-run --json > /dev/null"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "author": "maplezzk",
+  "homepage": "https://github.com/maplezzk/pi-extensions/tree/main/packages/pi-terminal-mux",
+  "bugs": "https://github.com/maplezzk/pi-extensions/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maplezzk/pi-extensions.git",
+    "directory": "packages/pi-terminal-mux"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-extension",
+    "terminal",
+    "multiplexer",
+    "tmux",
+    "zellij",
+    "wezterm",
+    "coding-agent"
+  ],
+  "peerDependencies": {
+    "pi-extensions-i18n": ">=0.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.4",
+    "pi-extensions-i18n": "^0.3.0",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/pi-terminal-mux/src/herdr.ts
+++ b/packages/pi-terminal-mux/src/herdr.ts
@@ -1,0 +1,499 @@
+/**
+ * herdr.ts — herdr multiplexer backend for pi-interactive-subagents
+ *
+ * herdr 是一个终端原生 agent multiplexer（参见 https://herdr.dev）。
+ * 当 pi 在 herdr 管理的 pane 内运行时，herdr 会注入：
+ *   HERDR_ENV=1
+ *   HERDR_WORKSPACE_ID（公开 id，如 "1"）
+ *   HERDR_TAB_ID（公开 id，如 "1:1"）
+ *   HERDR_PANE_ID（公开 id，如 "1-1"）
+ *
+ * 所有 pane 操作通过 `herdr` CLI 完成，详见 SKILL.md。
+ */
+
+import { execFileSync, execSync, spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { i18n } from "./i18n.ts";
+
+// ── 日志（herdr 独立文件，便于区分后端） ──
+const HERDR_SPLIT_LOG = "/tmp/pi-herdr-split.log";
+function herdrLog(msg: string): void {
+  try {
+    appendFileSync(HERDR_SPLIT_LOG, `[${new Date().toISOString()}] ${msg}`);
+  } catch {
+    /* 写日志失败不影响主流程 */
+  }
+}
+
+/**
+ * 捕获于模块加载时的 agent pane id。
+ * herdr 在启动 pane 的子进程时注入 HERDR_PANE_ID（公开 id 格式，如 "1-1"）。
+ * 模块加载后再读取 env 可能反映用户切换焦点后的值，所以冻结到常量。
+ */
+export const AGENT_HERDR_PANE_ID = process.env.HERDR_PANE_ID;
+export const AGENT_HERDR_WORKSPACE_ID = process.env.HERDR_WORKSPACE_ID;
+export const AGENT_HERDR_TAB_ID = process.env.HERDR_TAB_ID;
+
+// ── 命令可用性缓存 ──
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  try {
+    execFileSync("which", [command], { stdio: "ignore" });
+    available = true;
+  } catch {
+    available = false;
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}
+
+/**
+ * 检测 herdr backend 是否可用：
+ *   1. `herdr` 命令在 PATH 中
+ *   2. 当前进程在 herdr pane 内运行（HERDR_ENV=1）
+ *   3. HERDR_PANE_ID 已注入
+ *
+ * 注意：即使 socket 暂时不通，只要命令存在且 env 注入，就认为"runtime available"。
+ * 子 agent 创建时会用 `herdr pane split` 触发 socket 调用，那时报错即可。
+ */
+export function isHerdrRuntimeAvailable(): boolean {
+  return (
+    !!process.env.HERDR_ENV &&
+    process.env.HERDR_ENV === "1" &&
+    !!process.env.HERDR_PANE_ID &&
+    hasCommand("herdr")
+  );
+}
+
+// ── herdr CLI 调用的薄封装 ──
+
+/**
+ * 调用 `herdr` 命令并返回 stdout。
+ * 失败时 stderr 写入 log，原样抛错（调用方决定如何处理）。
+ */
+function herdrExec(args: string[]): string {
+  herdrLog(`[herdr exec] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}\n`);
+  const out = execFileSync("herdr", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  herdrLog(`[herdr exec] -> ${JSON.stringify(out.trim().slice(0, 200))}\n`);
+  return out;
+}
+
+/**
+ * 调用 `herdr` 命令，丢弃 stdout。用于 sendCommand / sendKeys / closePane 这类
+ * 无输出的命令，遵循 SKILL.md 中"pane send-text/send-keys/run print nothing on success"。
+ */
+function herdrExecSilent(args: string[]): void {
+  herdrLog(`[herdr exec silent] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}\n`);
+  execFileSync("herdr", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * 解析 herdr JSON 输出，失败返回 null。
+ * SKILL.md 说明：`workspace list`、`tab create`、`pane split` 等成功命令打印 JSON。
+ */
+function parseHerdrJson(output: string): unknown {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 从 herdr JSON 响应中提取 pane 的公开 id。
+ * pane split 响应格式：`{ "id": "...", "result": { "type": "pane_info", "pane": { "pane_id": "1-2", ... } } }`
+ */
+function extractPaneId(json: unknown): string | null {
+  if (!json || typeof json !== "object") return null;
+  const obj = json as Record<string, unknown>;
+  const result = obj.result;
+  if (!result || typeof result !== "object") return null;
+  const r = result as Record<string, unknown>;
+  // 多种结果类型都包含 pane：pane_info、pane_created 等
+  const pane = (r.pane ?? r.root_pane) as Record<string, unknown> | undefined;
+  if (pane && typeof pane.pane_id === "string") return pane.pane_id;
+  return null;
+}
+
+// ── mux state 缓存 ──
+//
+// herdr 没有 tmux `last_split_source` 之类的明确"上一个 split 的父 pane"语义。
+// 我们记录每个 surface 的"父 pane id"，用于 close 时清理（herdr 不需要这个，但保留
+// 以便将来扩展 — closePane 实际上只看 surface id）。
+const herdrPaneSources = new Map<string, string>();
+
+// ── 对外 API：createSurface 系列 ──
+
+/**
+ * 创建一个新的 subagent pane。
+ *
+ * 实现：split 当前 agent pane 右侧（--no-focus 保持 agent 焦点不变）。
+ * 后续 subagent 按 breadth-first 模式轮转 right/down/right/down…（与 cmux/muxy 行为一致）。
+ */
+export function createHerdrSurface(name: string): string {
+  if (!AGENT_HERDR_PANE_ID) {
+    throw new Error(
+      "HERDR_PANE_ID not set; cannot determine parent pane for subagent split. " +
+        "Start pi inside herdr so HERDR_PANE_ID is injected at launch.",
+    );
+  }
+
+  // 与 muxy 同样的广度优先分屏策略：
+  //   第一轮：从 agent pane 向右分，pos=0, base=1
+  //   第二轮：从第一个 pane 向下分，pos=0, base=1
+  //   第三轮：从第一个 pane 向右、第二个 pane 向右，pos=0, base=2
+  //   ……
+  // 状态文件：/tmp/herdr-subagent-pane-<agent_pane_id>.json
+  const markerFile = `/tmp/herdr-subagent-pane-${AGENT_HERDR_PANE_ID.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
+  const lockFile = `${markerFile}.lock`;
+
+  // 全局锁：所有分屏操作串行化
+  const acquired = (() => {
+    for (let i = 0; i < 60; i++) {
+      if (!existsSync(lockFile)) {
+        try {
+          writeFileSync(lockFile, `${process.pid}`, { flag: "wx" });
+          return true;
+        } catch {
+          // 竞争失败，继续等待
+        }
+      }
+      spawnSync("sleep", ["0.05"]);
+    }
+    return false;
+  })();
+
+  if (!acquired) {
+    herdrLog(`[herdr split] failed to acquire lock ${lockFile}\n`);
+    return "";
+  }
+
+  try {
+    let state: { panes: string[]; pos: number; base: number; dir: "right" | "down" } = {
+      panes: [],
+      pos: 0,
+      base: 0,
+      dir: "right",
+    };
+    try {
+      state = JSON.parse(readFileSync(markerFile, "utf8"));
+    } catch {
+      /* 文件不存在或损坏，用初始状态 */
+    }
+
+    // 首次 split
+    if (state.panes.length === 0) {
+      const output = herdrExec([
+        "pane",
+        "split",
+        AGENT_HERDR_PANE_ID,
+        "--direction",
+        "right",
+        "--no-focus",
+      ]);
+      const json = parseHerdrJson(output);
+      const newPaneId = extractPaneId(json);
+      if (newPaneId) {
+        state.panes = [newPaneId];
+        state.pos = 0;
+        state.base = 1;
+        state.dir = "down";
+        writeFileSync(markerFile, JSON.stringify(state));
+        herdrPaneSources.set(newPaneId, AGENT_HERDR_PANE_ID);
+        renameHerdrPane(newPaneId, name);
+        herdrLog(
+          `[herdr split] mode=first dir=right from=${AGENT_HERDR_PANE_ID} new=${newPaneId} name=${JSON.stringify(name)}\n`,
+        );
+        return newPaneId;
+      }
+      herdrLog(`[herdr split] first split returned no pane id, output=${JSON.stringify(output)}\n`);
+      return "";
+    }
+
+    // 本轮结束？翻转方向
+    if (state.pos >= state.base) {
+      state.pos = 0;
+      state.base = state.panes.length;
+      state.dir = state.dir === "right" ? "down" : "right";
+    }
+
+    let targetPane = state.panes[state.pos];
+    if (!targetPane) {
+      herdrLog(`[herdr split] state.panes[${state.pos}] is undefined\n`);
+      return "";
+    }
+
+    // 若 targetPane 过期（pane 被关闭 / session 重启），自动重置状态从 agent pane 重新分屏
+    let output: string;
+    let sourcePane = targetPane;
+    try {
+      output = herdrExec([
+        "pane",
+        "split",
+        targetPane,
+        "--direction",
+        state.dir,
+        "--no-focus",
+      ]);
+    } catch {
+      try { rmSync(markerFile); } catch { /* ignore */ }
+      herdrLog(
+        `[herdr split] pane ${targetPane} gone, resetting from agent pane ${AGENT_HERDR_PANE_ID}\n`,
+      );
+      state = { panes: [], pos: 0, base: 0, dir: "right" };
+      targetPane = AGENT_HERDR_PANE_ID;
+      sourcePane = AGENT_HERDR_PANE_ID;
+      output = herdrExec([
+        "pane",
+        "split",
+        AGENT_HERDR_PANE_ID,
+        "--direction",
+        "right",
+        "--no-focus",
+      ]);
+    }
+    const json = parseHerdrJson(output);
+    const newPaneId = extractPaneId(json);
+    if (newPaneId) {
+      state.panes.push(newPaneId);
+      state.pos++;
+      writeFileSync(markerFile, JSON.stringify(state));
+      herdrPaneSources.set(newPaneId, sourcePane);
+      renameHerdrPane(newPaneId, name);
+      herdrLog(
+        `[herdr split] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=${targetPane} new=${newPaneId} name=${JSON.stringify(name)}\n`,
+      );
+      return newPaneId;
+    }
+    herdrLog(`[herdr split] next split returned no pane id, output=${JSON.stringify(output)}\n`);
+    return "";
+  } finally {
+    try {
+      rmSync(lockFile);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/**
+ * 从指定 pane 直接分屏（不走广度优先状态机），供 createSurfaceSplit 使用。
+ * herdr 文档仅明确 right/down，left/up 分别归一到 right/down。
+ * 返回新 pane 的公开 id；识别失败时抛错。
+ */
+export function splitHerdrPane(
+  fromPane: string,
+  direction: "left" | "right" | "up" | "down",
+  name?: string,
+): string {
+  const dir = direction === "down" || direction === "up" ? "down" : "right";
+  const output = herdrExec(["pane", "split", fromPane, "--direction", dir, "--no-focus"]);
+  const newPaneId = extractPaneId(parseHerdrJson(output));
+  if (!newPaneId) {
+    throw new Error(`Unexpected herdr pane split output: ${output.trim() || "(empty)"}`);
+  }
+  herdrPaneSources.set(newPaneId, fromPane);
+  if (name) renameHerdrPane(newPaneId, name);
+  herdrLog(
+    `[herdr split] mode=direct dir=${dir} from=${fromPane} new=${newPaneId} name=${JSON.stringify(name ?? "")}\n`,
+  );
+  return newPaneId;
+}
+
+/**
+ * 用 herdr CLI 重命名 pane 的 label（pane 名称）。
+ * 格式: workspace_label[name]
+ */
+export function renameHerdrPane(paneId: string, name: string): void {
+  try {
+    const wsLabel = getWorkspaceLabel();
+    const paneLabel = wsLabel ? `${wsLabel}[${name}]` : name;
+    herdrExecSilent(["pane", "rename", paneId, paneLabel]);
+  } catch (e) {
+    herdrLog(`[herdr rename pane] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+  }
+}
+
+/**
+ * 用 herdr CLI 重命名 agent 标题（左侧侧栏显示的名字）。
+ * 需要在 pi 启动并被 herdr 检测到 agent 后才能生效。
+ * 若 agent 尚未检测到则静默失败。
+ */
+export function renameHerdrAgent(paneId: string, name: string): void {
+  try {
+    herdrExecSilent(["agent", "rename", paneId, name]);
+  } catch (e) {
+    herdrLog(`[herdr rename agent] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+  }
+}
+
+/**
+ * 获取当前 workspace 的 label。
+ */
+function getWorkspaceLabel(): string | null {
+  if (!AGENT_HERDR_WORKSPACE_ID) return null;
+  try {
+    const output = herdrExec(["workspace", "get", AGENT_HERDR_WORKSPACE_ID]);
+    const parsed = parseHerdrJson(output);
+    if (!parsed || typeof parsed !== "object") return null;
+    const result = (parsed as Record<string, unknown>).result as Record<string, unknown> | undefined;
+    const workspace = result?.workspace as Record<string, unknown> | undefined;
+    return (workspace?.label as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 用 herdr CLI 重命名 pane 对应的 tab。
+ * tab label 格式: workspace_label[name]
+ */
+export function renameHerdrTab(paneId: string, name: string): void {
+  const ws = parseWorkspaceIdFromPaneId(paneId);
+  if (!ws) return;
+  try {
+    const wsLabel = getWorkspaceLabel();
+    const tabLabel = wsLabel ? `${wsLabel}[${name}]` : name;
+    const tabsJson = herdrExec(["tab", "list", "--workspace", ws]);
+    const parsed = parseHerdrJson(tabsJson);
+    if (!parsed || typeof parsed !== "object") return;
+    const result = (parsed as Record<string, unknown>).result as Record<string, unknown> | undefined;
+    const tabs = (result?.tabs as Array<Record<string, unknown>>) ?? [];
+    if (tabs.length > 0) {
+      const firstTab = tabs[0];
+      if (firstTab && typeof firstTab.tab_id === "string") {
+        herdrExecSilent(["tab", "rename", firstTab.tab_id, tabLabel]);
+      }
+    }
+  } catch (e) {
+    herdrLog(`[herdr rename tab] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+  }
+}
+
+/**
+ * 重命名 workspace。herdr 中 workspace rename 命令是 `herdr workspace rename <id> <label>`。
+ * 仅当环境变量 PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1 时启用（保守策略，避免影响用户命名）。
+ */
+export function renameHerdrWorkspace(title: string): void {
+  if (process.env.PI_SUBAGENT_RENAME_HERDR_WORKSPACE !== "1") return;
+  if (!AGENT_HERDR_WORKSPACE_ID) return;
+  try {
+    herdrExecSilent(["workspace", "rename", AGENT_HERDR_WORKSPACE_ID, title]);
+  } catch (e) {
+    herdrLog(`[herdr rename workspace] title=${JSON.stringify(title)} failed: ${(e as Error).message}\n`);
+  }
+}
+
+// ── 对外 API：pane 操作 ──
+
+/**
+ * 给 pane 发送命令 + Enter。
+ * 使用 `herdr pane run <id> <cmd>` 一条命令搞定（SKILL.md 保证会发真实 Enter）。
+ */
+export function sendHerdrCommand(paneId: string, command: string): void {
+  herdrExecSilent(["pane", "run", paneId, command]);
+}
+
+/**
+ * 给 pane 发送 Escape。
+ * `herdr pane send-keys <id> Escape`（SKILL.md 中 send-keys 接受 "Escape" 这种 key name）。
+ */
+export function sendHerdrEscape(paneId: string): void {
+  herdrExecSilent(["pane", "send-keys", paneId, "Escape"]);
+}
+
+/**
+ * 读取 pane 屏幕内容。
+ * SKILL.md：`herdr pane read <id> --source <src> --lines N` 直接打印文本（非 JSON）。
+ *
+ * 默认 source 用 `visible`，与其他 backend (cmux / wezterm) 的 readScreen 语义一致：
+ * 读当前 viewport，新 pane 没 scrollback 时不会返回空。
+ *
+ * wait output 机制如果需要 recent_unwrapped 语义，请另行包装 — 这里只服务 subagent
+ * 状态检测和实时读屏，不需要 soft-wrap 合并。
+ */
+export function readHerdrScreen(paneId: string, lines = 50, source: "visible" | "recent" | "recent_unwrapped" = "visible"): string {
+  // SKILL.md 列出的 source 选项
+  const sourceFlag = source === "recent_unwrapped" ? "recent-unwrapped" : source;
+  return herdrExec(["pane", "read", paneId, "--source", sourceFlag, "--lines", String(lines)]);
+}
+
+/**
+ * 关闭 pane。
+ * `herdr pane close <id>` 是 herdr CLI 子命令。
+ */
+export function closeHerdrSurface(paneId: string): void {
+  herdrExecSilent(["pane", "close", paneId]);
+
+  // 清理 mux state marker（与 muxy 的 close 逻辑一致）
+  const markerFile = `/tmp/herdr-subagent-pane-${(AGENT_HERDR_PANE_ID ?? "default").replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
+  try {
+    const parsed = JSON.parse(readFileSync(markerFile, "utf8"));
+    if (parsed && Array.isArray(parsed.panes)) {
+      const idx = parsed.panes.indexOf(paneId);
+      if (idx >= 0) {
+        const beforePanes = [...parsed.panes];
+        const beforePos = parsed.pos;
+        parsed.panes.splice(idx, 1);
+        if (typeof parsed.pos === "number" && idx < parsed.pos) {
+          parsed.pos = Math.max(0, parsed.pos - 1);
+        }
+        if (parsed.panes.length === 0) {
+          rmSync(markerFile);
+          herdrLog(
+            `[herdr close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
+          );
+        } else {
+          writeFileSync(markerFile, JSON.stringify(parsed));
+          herdrLog(
+            `[herdr close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(parsed.panes)} pos=${beforePos} -> ${parsed.pos}\n`,
+          );
+        }
+      } else {
+        herdrLog(`[herdr close] pane=${paneId} (not in marker state.panes)\n`);
+      }
+    }
+  } catch {
+    herdrLog(`[herdr close] pane=${paneId} (no marker, nothing to clean)\n`);
+  }
+  herdrPaneSources.delete(paneId);
+}
+
+// ── 辅助：从 pane id 解析 workspace id ──
+//
+// herdr 公开 id 格式：
+//   workspace: "1", "2" 或 "wA"
+//   tab:      "1:1", "wA:t1"
+//   pane:     "1-1", "wA-3", "wA:p3"
+//
+// pane id 的 workspace 段总是位于 "-" 或 ":p" 之前。
+function parseWorkspaceIdFromPaneId(paneId: string): string | null {
+  // "1-1" -> "1", "wA-3" -> "wA", "wA:p3" -> "wA"
+  const dashMatch = paneId.match(/^([^-:]+)-/);
+  if (dashMatch) return dashMatch[1] ?? null;
+  const colonMatch = paneId.match(/^([^:]+):p/);
+  if (colonMatch) return colonMatch[1] ?? null;
+  return null;
+}
+
+// ── 与 mux 检测 / setup hint 的集成辅助 ──
+
+/**
+ * herdr setup hint —— 用户没在 herdr pane 内时提示。
+ */
+export function herdrSetupHint(preferred: boolean): string {
+  if (preferred) {
+    return i18n.t("setupHint.herdrPreferred");
+  }
+  return "";
+}

--- a/packages/pi-terminal-mux/src/i18n.ts
+++ b/packages/pi-terminal-mux/src/i18n.ts
@@ -1,0 +1,3 @@
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+
+export const i18n = createTranslator(loadCatalog(new URL("../locales/mux.json", import.meta.url)));

--- a/packages/pi-terminal-mux/src/index.ts
+++ b/packages/pi-terminal-mux/src/index.ts
@@ -1,0 +1,111 @@
+/**
+ * pi-terminal-mux — 终端多路复用器统一抽象层
+ *
+ * 支持后端：muxy / cmux / tmux / zellij / wezterm / herdr / otty，
+ * 探测不到任何后端时自动降级为 headless（后台子进程 + 日志文件）。
+ *
+ * 统一 surface API（跨后端一致语义）：
+ *   - createSurface(name)              智能放置（分屏/堆叠/新 tab，按后端策略）
+ *   - createSurfaceSplit(name, dir, from?)  指定方向分屏
+ *   - sendCommand / sendLongCommand / sendEscape
+ *   - readScreen / readScreenAsync
+ *   - closeSurface
+ *   - renameCurrentTab / renameAgent / renameWorkspace
+ *   - pollForExit                      等待 surface 内进程退出（.exit sidecar / sentinel）
+ *
+ * 后端探测：
+ *   - getMuxBackend()                  当前命中的后端（含 PI_TERMINAL_MUX / PI_SUBAGENT_MUX 偏好）
+ *   - isMuxAvailable() / isHeadlessMode()
+ *   - muxSetupHint()                   面向用户的安装提示（中英文，走 pi-extensions-i18n）
+ *
+ * 各后端原生函数（createHerdrSurface、sendOttyCommand 等）也可按需直接引用。
+ */
+
+// ── 统一抽象层（含类型与 headless 降级） ──
+export * from "./mux.ts";
+
+// ── herdr 后端原生 API（renameHerdrTab / renameHerdrWorkspace 已由 mux.ts 透出，避免冲突） ──
+export {
+  AGENT_HERDR_PANE_ID,
+  AGENT_HERDR_WORKSPACE_ID,
+  AGENT_HERDR_TAB_ID,
+  isHerdrRuntimeAvailable,
+  createHerdrSurface,
+  splitHerdrPane,
+  renameHerdrPane,
+  renameHerdrAgent,
+  sendHerdrCommand,
+  sendHerdrEscape,
+  readHerdrScreen,
+  closeHerdrSurface,
+  herdrSetupHint,
+} from "./herdr.ts";
+
+// ── otty 后端原生 API ──
+export {
+  AGENT_OTTY_PANE_ID,
+  getOttyAgentPaneId,
+  isOttyRuntimeAvailable,
+  isOttySendKeysEnabled,
+  parseOttyJson,
+  readOttyPanes,
+  readOttyTabs,
+  getTabIdForPane,
+  createOttySurface,
+  sendOttyCommand,
+  sendOttyEscape,
+  readOttyScreen,
+  closeOttySurface,
+  renameOttyTab,
+  ottySetupHint,
+} from "./otty.ts";
+export type { OttyPaneSnapshot } from "./otty.ts";
+
+// ── 便捷函数 ──
+import {
+  AGENT_MUXY_PANE_ID,
+  getMuxBackend,
+  type MuxBackend,
+} from "./mux.ts";
+import { AGENT_HERDR_PANE_ID } from "./herdr.ts";
+import { AGENT_OTTY_PANE_ID } from "./otty.ts";
+
+/**
+ * 返回各后端注入 agent pane 标识的环境变量名（用于错误提示）。
+ * otty 不通过 env 注入（走 IPC 探测），返回 null。
+ */
+export function backendAgentPaneEnvVar(backend: MuxBackend): string | null {
+  switch (backend) {
+    case "muxy":
+      return "MUXY_PANE_ID";
+    case "cmux":
+      return "CMUX_SURFACE_ID";
+    case "tmux":
+      return "TMUX_PANE";
+    case "zellij":
+      return "ZELLIJ_PANE_ID";
+    case "wezterm":
+      return "WEZTERM_PANE";
+    case "herdr":
+      return "HERDR_PANE_ID";
+    case "otty":
+      return null;
+  }
+}
+
+/**
+ * 返回 agent 自身所在 pane 的标识（按当前或指定后端）。
+ * muxy/herdr/otty 使用模块加载时捕获的 ID（不受焦点切换影响），
+ * 其余后端动态读取对应环境变量。
+ */
+export function getAgentPaneId(backend?: MuxBackend | null): string | null {
+  const resolved = backend ?? getMuxBackend();
+  if (resolved === "muxy") return AGENT_MUXY_PANE_ID ?? null;
+  if (resolved === "herdr") return AGENT_HERDR_PANE_ID ?? null;
+  if (resolved === "otty") return AGENT_OTTY_PANE_ID ?? null;
+  if (resolved === "tmux") return process.env.TMUX_PANE ?? null;
+  if (resolved === "wezterm") return process.env.WEZTERM_PANE ?? null;
+  if (resolved === "zellij") return process.env.ZELLIJ_PANE_ID ?? null;
+  if (resolved === "cmux") return process.env.CMUX_SURFACE_ID ?? null;
+  return null;
+}

--- a/packages/pi-terminal-mux/src/mux.ts
+++ b/packages/pi-terminal-mux/src/mux.ts
@@ -1,0 +1,2110 @@
+import { execSync, execFile, execFileSync, spawnSync, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync, statSync, createWriteStream, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import type { WriteStream } from "node:fs";
+import { i18n } from "./i18n.ts";
+
+/**
+ * 分屏调试日志写入文件，避免污染 TUI 终端。
+ * 日志路径: /tmp/pi-muxy-split.log
+ *
+ * 注意：必须用 /tmp/，不能用 os.tmpdir()。herdr 的日志已经写到
+ * /tmp/pi-herdr-split.log，用户排查问题时只看 /tmp/ 即可。
+ * 之前用 tmpdir() 导致 macOS 上日志落到 /var/folders/.../T/，与
+ * /tmp/ 分裂，用户 grep /tmp 找不到，调试时被坑过。
+ */
+const MUXY_SPLIT_LOG = "/tmp/pi-muxy-split.log";
+
+export function muxLog(msg: string): void {
+  try {
+    appendFileSync(MUXY_SPLIT_LOG, `[${new Date().toISOString()}] ${msg}`);
+  } catch {
+    // 写日志失败不影响主流程
+  }
+}
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Agent's own pane ID in Muxy, captured at module load time.
+ * Unlike reading process.env.MUXY_PANE_ID dynamically (which may reflect
+ * the user's currently focused pane after switching projects in Muxy),
+ * this constant always points to the pane where the agent/pi was launched.
+ */
+export const AGENT_MUXY_PANE_ID = process.env.MUXY_PANE_ID;
+
+export type MuxBackend = "cmux" | "muxy" | "tmux" | "zellij" | "wezterm" | "herdr" | "otty";
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  if (process.platform === "win32") {
+    try {
+      execFileSync("where.exe", [command], { stdio: "ignore" });
+      available = true;
+    } catch {
+      try {
+        execSync(`command -v ${command}`, { stdio: "ignore" });
+        available = true;
+      } catch {
+        available = false;
+      }
+    }
+  } else {
+    try {
+      execSync(`command -v ${command}`, { stdio: "ignore" });
+      available = true;
+    } catch {
+      available = false;
+    }
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}
+
+function muxPreference(): MuxBackend | null {
+  // PI_TERMINAL_MUX 为通用包的首选变量；PI_SUBAGENT_MUX 保留向后兼容。
+  const pref = (process.env.PI_TERMINAL_MUX ?? process.env.PI_SUBAGENT_MUX ?? "").trim().toLowerCase();
+  if (
+    pref === "cmux" ||
+    pref === "muxy" ||
+    pref === "tmux" ||
+    pref === "zellij" ||
+    pref === "wezterm" ||
+    pref === "herdr" ||
+    pref === "otty"
+  )
+    return pref;
+  return null;
+}
+
+function isCmuxRuntimeAvailable(): boolean {
+  return !!process.env.CMUX_SOCKET_PATH && hasCommand("cmux");
+}
+
+function isMuxyRuntimeAvailable(): boolean {
+  return !!process.env.MUXY_SOCKET_PATH && hasCommand("muxy");
+}
+
+function isTmuxRuntimeAvailable(): boolean {
+  return !!process.env.TMUX && hasCommand("tmux");
+}
+
+function isZellijRuntimeAvailable(): boolean {
+  return !!(process.env.ZELLIJ || process.env.ZELLIJ_SESSION_NAME) && hasCommand("zellij");
+}
+
+function isWezTermRuntimeAvailable(): boolean {
+  return !!process.env.WEZTERM_UNIX_SOCKET && hasCommand("wezterm");
+}
+
+import {
+  isHerdrRuntimeAvailable,
+  createHerdrSurface,
+  splitHerdrPane,
+  renameHerdrPane,
+  renameHerdrAgent,
+  renameHerdrTab,
+  renameHerdrWorkspace,
+  sendHerdrCommand,
+  sendHerdrEscape,
+  readHerdrScreen,
+  closeHerdrSurface,
+  AGENT_HERDR_PANE_ID,
+} from "./herdr.ts";
+import {
+  isOttyRuntimeAvailable,
+  createOttySurface,
+  sendOttyCommand,
+  sendOttyEscape,
+  readOttyScreen,
+  closeOttySurface,
+  renameOttyTab,
+  ottySetupHint,
+  AGENT_OTTY_PANE_ID,
+} from "./otty.ts";
+
+export function isCmuxAvailable(): boolean {
+  return isCmuxRuntimeAvailable();
+}
+
+export function isTmuxAvailable(): boolean {
+  return isTmuxRuntimeAvailable();
+}
+
+export function isZellijAvailable(): boolean {
+  return isZellijRuntimeAvailable();
+}
+
+export function isWezTermAvailable(): boolean {
+  return isWezTermRuntimeAvailable();
+}
+
+export function isHerdrAvailable(): boolean {
+  return isHerdrRuntimeAvailable();
+}
+
+export function isOttyAvailable(): boolean {
+  return isOttyRuntimeAvailable();
+}
+
+export function getMuxBackend(): MuxBackend | null {
+  const pref = muxPreference();
+  if (pref === "cmux") return isCmuxRuntimeAvailable() ? "cmux" : null;
+  if (pref === "muxy") return isMuxyRuntimeAvailable() ? "muxy" : null;
+  if (pref === "tmux") return isTmuxRuntimeAvailable() ? "tmux" : null;
+  if (pref === "zellij") return isZellijRuntimeAvailable() ? "zellij" : null;
+  if (pref === "wezterm") return isWezTermRuntimeAvailable() ? "wezterm" : null;
+  if (pref === "herdr") return isHerdrRuntimeAvailable() ? "herdr" : null;
+  if (pref === "otty") return isOttyRuntimeAvailable() ? "otty" : null;
+
+  if (isMuxyRuntimeAvailable()) return "muxy";
+  if (isCmuxRuntimeAvailable()) return "cmux";
+  if (isTmuxRuntimeAvailable()) return "tmux";
+  if (isZellijRuntimeAvailable()) return "zellij";
+  if (isWezTermRuntimeAvailable()) return "wezterm";
+  if (isHerdrRuntimeAvailable()) return "herdr";
+  if (isOttyRuntimeAvailable()) return "otty";
+  return null;
+}
+
+export function isMuxAvailable(): boolean {
+  return getMuxBackend() !== null;
+}
+
+export function muxSetupHint(): string {
+  const pref = muxPreference();
+  if (pref) {
+    const hint = i18n.t(`setupHint.${pref}`);
+    // otty 在 send-keys 未启用时补充更具体的提示
+    if (pref === "otty") {
+      return ottySetupHint() || hint;
+    }
+    return hint;
+  }
+  return i18n.t("setupHint.generic");
+}
+
+// ── Headless mode (no terminal multiplexer available) ──
+
+const HEADLESS_SURFACE_PREFIX = "headless:";
+
+interface HeadlessProcess {
+  child: ChildProcess;
+  exitPromise: Promise<{ exitCode: number }>;
+  resolveExit: ((value: { exitCode: number }) => void) | null;
+  logStream: WriteStream;
+  logFile: string;
+}
+
+const headlessProcesses = new Map<string, HeadlessProcess>();
+
+export function createHeadlessSurface(name: string): string {
+  const id = `${HEADLESS_SURFACE_PREFIX}${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  return id;
+}
+
+export function spawnHeadlessProcess(
+  surface: string,
+  name: string,
+  command: string,
+  options?: { cwd?: string; env?: Record<string, string> },
+): { logFile: string } {
+  const safeId = surface.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const logFile = join(tmpdir(), `pi-subagent-${safeId}.log`);
+  const logStream = createWriteStream(logFile, { flags: "w" });
+
+  const env = { ...process.env };
+  if (options?.env) {
+    Object.assign(env, options.env);
+  }
+  env.PI_SUBAGENT_HEADLESS = "1";
+
+  const child = spawn("bash", ["-c", command], {
+    cwd: options?.cwd || process.cwd(),
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+  });
+
+  child.stdout.pipe(logStream);
+  child.stderr.pipe(logStream);
+  child.stdout.resume();
+  child.stderr.resume();
+
+  let resolveExit: ((value: { exitCode: number }) => void) | null = null;
+  const exitPromise = new Promise<{ exitCode: number }>((resolve) => {
+    resolveExit = resolve;
+    child.on("exit", (code) => {
+      logStream.end();
+      resolve({ exitCode: code ?? 1 });
+    });
+    child.on("error", () => {
+      logStream.end();
+      resolve({ exitCode: 1 });
+    });
+  });
+
+  headlessProcesses.set(surface, { child, exitPromise, resolveExit, logStream, logFile });
+
+  return { logFile };
+}
+
+export function closeHeadlessSurface(surface: string): void {
+  const proc = headlessProcesses.get(surface);
+  if (!proc) return;
+  try {
+    proc.child.kill("SIGTERM");
+  } catch {}
+  setTimeout(() => {
+    try {
+      proc.child.kill("SIGKILL");
+    } catch {}
+    headlessProcesses.delete(surface);
+  }, 3000).unref();
+}
+
+export function sendHeadlessEscape(surface: string): void {
+  const proc = headlessProcesses.get(surface);
+  if (!proc) return;
+  try {
+    proc.child.kill("SIGINT");
+  } catch {}
+}
+
+export function readHeadlessScreen(surface: string, lines = 50): string {
+  const proc = headlessProcesses.get(surface);
+  if (!proc) return "";
+  try {
+    const content = readFileSync(proc.logFile, "utf8");
+    const split = content.split("\n");
+    return split.slice(-lines).join("\n");
+  } catch {
+    return "";
+  }
+}
+
+export async function readHeadlessScreenAsync(surface: string, lines = 50): Promise<string> {
+  return readHeadlessScreen(surface, lines);
+}
+
+export function isHeadlessSurface(surface: string): boolean {
+  return surface.startsWith(HEADLESS_SURFACE_PREFIX) || headlessProcesses.has(surface);
+}
+
+export function isHeadlessMode(): boolean {
+  return !isMuxAvailable();
+}
+
+export function cleanupHeadlessProcesses(): void {
+  for (const [surface, proc] of headlessProcesses) {
+    try {
+      proc.child.kill("SIGTERM");
+    } catch {}
+  }
+  headlessProcesses.clear();
+}
+
+export function getHeadlessProcessExit(surface: string): Promise<{ exitCode: number }> | null {
+  const proc = headlessProcesses.get(surface);
+  return proc?.exitPromise ?? null;
+}
+
+export function drainHeadlessProcess(surface: string): void {
+  headlessProcesses.delete(surface);
+}
+
+function requireMuxBackend(): MuxBackend {
+  const backend = getMuxBackend();
+  if (!backend) {
+    throw new Error(`${i18n.t("setupHint.none")} ${muxSetupHint()}`);
+  }
+  return backend;
+}
+
+/**
+ * Detect if the user's default shell is fish.
+ * Fish uses $status instead of $? for exit codes.
+ */
+export function isFishShell(): boolean {
+  const shell = process.env.SHELL ?? "";
+  return basename(shell) === "fish";
+}
+
+/**
+ * Return the shell-appropriate exit status variable ($? for bash/zsh, $status for fish).
+ */
+export function exitStatusVar(): string {
+  return isFishShell() ? "$status" : "$?";
+}
+
+export function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function tailLines(text: string, lines: number): string {
+  const split = text.split("\n");
+  if (split.length <= lines) return text;
+  return split.slice(-lines).join("\n");
+}
+
+function zellijPaneId(surface: string): string {
+  return surface.startsWith("pane:") ? surface.slice("pane:".length) : surface;
+}
+
+function zellijEnv(surface?: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (surface) {
+    env.ZELLIJ_PANE_ID = zellijPaneId(surface);
+  }
+  return env;
+}
+
+/**
+ * Pane-scoped zellij actions that must target a specific pane via --pane-id
+ * (the ZELLIJ_PANE_ID env var is ignored by most of these).
+ * See https://github.com/HazAT/pi-interactive-subagents/issues/19
+ */
+const ZELLIJ_PANE_SCOPED_ACTIONS = new Set([
+  "close-pane",
+  "dump-screen",
+  "rename-pane",
+  "move-pane",
+  "write",
+  "write-chars",
+  "send-keys",
+]);
+
+function zellijActionArgs(args: string[], surface?: string): string[] {
+  if (!surface) return ["action", ...args];
+  const action = args[0];
+  if (!ZELLIJ_PANE_SCOPED_ACTIONS.has(action)) return ["action", ...args];
+  // Don't double-add if caller already specified it.
+  if (args.includes("--pane-id") || args.includes("-p")) return ["action", ...args];
+  return ["action", action, "--pane-id", zellijPaneId(surface), ...args.slice(1)];
+}
+
+function zellijActionSync(args: string[], surface?: string): string {
+  return execFileSync("zellij", zellijActionArgs(args, surface), {
+    encoding: "utf8",
+    env: zellijEnv(surface),
+  });
+}
+
+async function zellijActionAsync(args: string[], surface?: string): Promise<string> {
+  const { stdout } = await execFileAsync("zellij", zellijActionArgs(args, surface), {
+    encoding: "utf8",
+    env: zellijEnv(surface),
+  });
+  return stdout;
+}
+
+/** Tracked subagent pane for cmux — reused across subagent launches. */
+let cmuxSubagentPane: string | null = null;
+
+/**
+ * 最近一次 createSurface / createSurfaceSplit 的来源 pane。
+ * 用于在 pi TUI 中展示「新分屏来自哪个 pane」。
+ * 每次调用 createSurface 时更新，调用方读取后可重置。
+ */
+let lastSplitSource: string | null = null;
+
+export function getLastSplitSource(): string | null {
+  return lastSplitSource;
+}
+
+export function clearLastSplitSource(): void {
+  lastSplitSource = null;
+}
+
+// Mirrors Zellij 0.44.x tab minimums, used to predict which pane Zellij itself
+// will choose for a directionless split.
+const ZELLIJ_MIN_TERMINAL_WIDTH = 5;
+const ZELLIJ_MIN_TERMINAL_HEIGHT = 5;
+const ZELLIJ_CURSOR_HEIGHT_WIDTH_RATIO = 4;
+
+// Pi subagents need more usable space than Zellij's internal minimum. These can
+// be tuned per session without another code change.
+const DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS = 50;
+const DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS = 10;
+
+export interface ZellijPaneSnapshot {
+  id: number;
+  is_plugin?: boolean;
+  is_floating?: boolean;
+  is_selectable?: boolean;
+  exited?: boolean;
+  pane_rows?: number;
+  pane_columns?: number;
+  tab_id?: number;
+  is_focused?: boolean;
+}
+
+export type ZellijSplitDirection = "down" | "right";
+
+export type ZellijPlacementPlan =
+  | {
+      mode: "split";
+      anchorPaneId: number;
+      targetPaneId: number;
+      tabId: number;
+      splitDirection: ZellijSplitDirection;
+    }
+  | { mode: "stack"; anchorPaneId: number; targetPaneId: number; tabId: number };
+
+function paneArea(pane: ZellijPaneSnapshot): number {
+  return (pane.pane_rows ?? 0) * (pane.pane_columns ?? 0);
+}
+
+function isUsableZellijTiledPane(pane: ZellijPaneSnapshot): boolean {
+  return (
+    !pane.is_plugin &&
+    !pane.is_floating &&
+    pane.is_selectable !== false &&
+    !pane.exited &&
+    typeof pane.pane_rows === "number" &&
+    typeof pane.pane_columns === "number"
+  );
+}
+
+export function predictZellijSplitDirection(pane: ZellijPaneSnapshot): ZellijSplitDirection | null {
+  const columns = pane.pane_columns ?? 0;
+  const rows = pane.pane_rows ?? 0;
+  if (columns < ZELLIJ_MIN_TERMINAL_WIDTH || rows < ZELLIJ_MIN_TERMINAL_HEIGHT) return null;
+
+  if (
+    rows * ZELLIJ_CURSOR_HEIGHT_WIDTH_RATIO > columns &&
+    rows > ZELLIJ_MIN_TERMINAL_HEIGHT * 2
+  ) {
+    return "down";
+  }
+
+  if (columns > ZELLIJ_MIN_TERMINAL_WIDTH * 2) {
+    return "right";
+  }
+
+  return null;
+}
+
+export function canSplitZellijPane(
+  pane: ZellijPaneSnapshot,
+  minColumns = ZELLIJ_MIN_TERMINAL_WIDTH,
+  minRows = ZELLIJ_MIN_TERMINAL_HEIGHT,
+): boolean {
+  const columns = pane.pane_columns ?? 0;
+  const rows = pane.pane_rows ?? 0;
+  const direction = predictZellijSplitDirection(pane);
+  if (!direction) return false;
+
+  if (direction === "down") {
+    return columns >= minColumns && Math.floor(rows / 2) >= minRows;
+  }
+
+  return rows >= minRows && Math.floor(columns / 2) >= minColumns;
+}
+
+function zellijTabPanesForParent(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+): { parentPane: ZellijPaneSnapshot; tabPanes: ZellijPaneSnapshot[] } | null {
+  const parentPane = panes.find((pane) => !pane.is_plugin && pane.id === parentPaneId);
+  if (!parentPane || typeof parentPane.tab_id !== "number") return null;
+
+  const tabPanes = panes
+    .filter((pane) => pane.tab_id === parentPane.tab_id)
+    .filter(isUsableZellijTiledPane);
+
+  return { parentPane, tabPanes };
+}
+
+export function selectZellijStackPlacement(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+): ZellijPlacementPlan | null {
+  const tabInfo = zellijTabPanesForParent(panes, parentPaneId);
+  if (!tabInfo) return null;
+
+  const stackTarget = tabInfo.tabPanes
+    .filter((pane) => pane.id !== parentPaneId)
+    .sort((a, b) => paneArea(b) - paneArea(a))[0];
+  if (!stackTarget) return null;
+
+  return {
+    mode: "stack",
+    anchorPaneId: stackTarget.id,
+    targetPaneId: stackTarget.id,
+    tabId: tabInfo.parentPane.tab_id!,
+  };
+}
+
+export function selectZellijPlacement(
+  panes: ZellijPaneSnapshot[],
+  parentPaneId: number,
+  minColumns = DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS,
+  minRows = DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS,
+): ZellijPlacementPlan | null {
+  const tabInfo = zellijTabPanesForParent(panes, parentPaneId);
+  if (!tabInfo) return null;
+
+  const zellijSplitCandidates = tabInfo.tabPanes
+    .map((pane) => ({ pane, splitDirection: predictZellijSplitDirection(pane) }))
+    .filter(
+      (candidate): candidate is { pane: ZellijPaneSnapshot; splitDirection: ZellijSplitDirection } =>
+        candidate.splitDirection !== null &&
+        canSplitZellijPane(candidate.pane, ZELLIJ_MIN_TERMINAL_WIDTH, ZELLIJ_MIN_TERMINAL_HEIGHT),
+    );
+
+  const safeSplitCandidates = zellijSplitCandidates.filter((candidate) =>
+    canSplitZellijPane(candidate.pane, minColumns, minRows),
+  );
+
+  // Split creation is tab-scoped, so Zellij chooses the concrete split pane.
+  // Only split when every pane Zellij might split would remain usable.
+  if (
+    zellijSplitCandidates.length > 0 &&
+    safeSplitCandidates.length === zellijSplitCandidates.length
+  ) {
+    const splitTarget = safeSplitCandidates.sort((a, b) => paneArea(b.pane) - paneArea(a.pane))[0];
+    return {
+      mode: "split",
+      anchorPaneId: splitTarget.pane.id,
+      targetPaneId: splitTarget.pane.id,
+      tabId: tabInfo.parentPane.tab_id!,
+      splitDirection: splitTarget.splitDirection,
+    };
+  }
+
+  return selectZellijStackPlacement(panes, parentPaneId);
+}
+
+function parseZellijPaneSurface(rawId: string, context: string): string {
+  const idMatch = rawId.match(/(\d+)/);
+  if (!idMatch) {
+    throw new Error(`Unexpected zellij pane id from ${context}: ${rawId || "(empty)"}`);
+  }
+  return `pane:${idMatch[1]}`;
+}
+
+function readZellijPanes(): ZellijPaneSnapshot[] {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const output = zellijActionSync(["list-panes", "--json", "--geometry", "--state", "--tab"]);
+      if (!output.trim()) {
+        throw new Error("Unexpected zellij list-panes output: empty");
+      }
+      const parsed = JSON.parse(output);
+      if (!Array.isArray(parsed)) {
+        throw new Error("Unexpected zellij list-panes output: not an array");
+      }
+      return parsed as ZellijPaneSnapshot[];
+    } catch (error) {
+      lastError = error;
+      if (attempt < 2) sleepSync(50);
+    }
+  }
+  throw lastError;
+}
+
+function createZellijTiledPane(name: string, tabId: number): string {
+  const args = ["new-pane", "--tab-id", String(tabId), "--name", name, "--cwd", process.cwd()];
+  return parseZellijPaneSurface(zellijActionSync(args).trim(), "new-pane");
+}
+
+function createZellijStackedPane(name: string, anchorSurface: string): string {
+  const args = [
+    "new-pane",
+    "--stacked",
+    "--near-current-pane",
+    "--name",
+    name,
+    "--cwd",
+    process.cwd(),
+  ];
+  return parseZellijPaneSurface(zellijActionSync(args, anchorSurface).trim(), "new-pane --stacked");
+}
+
+function createZellijTab(name: string): string {
+  const tabIdRaw = zellijActionSync(["new-tab", "--name", name, "--cwd", process.cwd()]).trim();
+  const tabId = Number(tabIdRaw);
+  if (!Number.isInteger(tabId)) {
+    throw new Error(`Unexpected zellij tab id from new-tab: ${tabIdRaw || "(empty)"}`);
+  }
+
+  try {
+    const panes = readZellijPanes();
+    const pane = panes.find(
+      (candidate) =>
+        candidate.tab_id === tabId &&
+        isUsableZellijTiledPane(candidate) &&
+        typeof candidate.id === "number",
+    );
+    if (!pane) {
+      throw new Error(`Could not find initial pane for zellij tab ${tabId}`);
+    }
+
+    const surface = `pane:${pane.id}`;
+    try {
+      zellijActionSync(["rename-pane", name], surface);
+    } catch {
+      // Optional.
+    }
+    return surface;
+  } catch (error) {
+    try {
+      zellijActionSync(["close-tab", "--tab-id", String(tabId)]);
+    } catch {
+      // Best effort cleanup for tabs created before post-creation inspection failed.
+    }
+    throw error;
+  }
+}
+
+function envPositiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function zellijSurfaceLockPath(): string {
+  const session = (process.env.ZELLIJ_SESSION_NAME ?? process.env.ZELLIJ ?? "default").replace(
+    /[^A-Za-z0-9_.-]/g,
+    "_",
+  );
+  return join(tmpdir(), `pi-zellij-surface-${session}.lock`);
+}
+
+function withZellijSurfaceLock<T>(callback: () => T): T {
+  const lockPath = zellijSurfaceLockPath();
+  const deadline = Date.now() + 10000;
+
+  while (true) {
+    try {
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, "owner"), `${process.pid}\n`);
+      break;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw error;
+
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > 30000) {
+          rmSync(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch {}
+
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for zellij surface lock: ${lockPath}`);
+      }
+      sleepSync(50);
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+function createZellijSurfaceUnlocked(name: string): string {
+  const parentPaneIdRaw = process.env.ZELLIJ_PANE_ID;
+  const parentPaneId = parentPaneIdRaw ? Number(parentPaneIdRaw) : NaN;
+  const minColumns = envPositiveInteger(
+    "PI_SUBAGENT_ZELLIJ_MIN_COLUMNS",
+    DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS,
+  );
+  const minRows = envPositiveInteger(
+    "PI_SUBAGENT_ZELLIJ_MIN_ROWS",
+    DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS,
+  );
+
+  const plan = Number.isInteger(parentPaneId)
+    ? selectZellijPlacement(readZellijPanes(), parentPaneId, minColumns, minRows)
+    : null;
+
+  if (plan?.mode === "split") {
+    return createZellijTiledPane(name, plan.tabId);
+  }
+
+  if (plan?.mode === "stack") {
+    return createZellijStackedPane(name, `pane:${plan.targetPaneId}`);
+  }
+
+  return createZellijTab(name);
+}
+
+function createZellijSurface(name: string): string {
+  return withZellijSurfaceLock(() => createZellijSurfaceUnlocked(name));
+}
+
+type CmuxFocusSnapshot = {
+  surfaceRef?: string;
+  paneRef?: string;
+};
+
+type CmuxCreatedSurface = {
+  surface: string;
+  paneRef?: string;
+};
+
+type CmuxIdentifySnapshot = {
+  focused: CmuxFocusSnapshot | null;
+  caller: CmuxFocusSnapshot | null;
+};
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function parseCmuxFocusedSnapshot(value: unknown): CmuxFocusSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+
+  const focused = (value as { focused?: unknown }).focused;
+  if (!focused || typeof focused !== "object") return null;
+
+  const record = focused as { surface_ref?: unknown; pane_ref?: unknown };
+  const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
+  const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+
+  if (!surfaceRef && !paneRef) return null;
+  return { surfaceRef, paneRef };
+}
+
+export function parseCmuxJson(value: string): unknown | null {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    void error;
+    return null;
+  }
+}
+
+export function parseCmuxFocusedSnapshotFromJson(value: string): CmuxFocusSnapshot | null {
+  return parseCmuxFocusedSnapshot(parseCmuxJson(value));
+}
+
+function parseCmuxCallerSnapshot(value: unknown): CmuxFocusSnapshot | null {
+  if (!value || typeof value !== "object") return null;
+
+  const caller = (value as { caller?: unknown }).caller;
+  if (!caller || typeof caller !== "object") return null;
+
+  const record = caller as { surface_ref?: unknown; pane_ref?: unknown };
+  const surfaceRef = nonEmptyString(record.surface_ref) ? record.surface_ref : undefined;
+  const paneRef = nonEmptyString(record.pane_ref) ? record.pane_ref : undefined;
+
+  if (!surfaceRef && !paneRef) return null;
+  return { surfaceRef, paneRef };
+}
+
+export function parseCmuxPaneRefForSurface(value: unknown, surface: string): string | null {
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as { surface_ref?: unknown; pane_ref?: unknown; caller?: unknown };
+  if (record.surface_ref === surface && nonEmptyString(record.pane_ref)) return record.pane_ref;
+
+  const caller = record.caller;
+  if (!caller || typeof caller !== "object") return null;
+
+  const callerRecord = caller as { surface_ref?: unknown; pane_ref?: unknown };
+  if (callerRecord.surface_ref === surface && nonEmptyString(callerRecord.pane_ref)) {
+    return callerRecord.pane_ref;
+  }
+
+  return null;
+}
+
+export function parseCmuxPaneRefForSurfaceFromJson(value: string, surface: string): string | null {
+  return parseCmuxPaneRefForSurface(parseCmuxJson(value), surface);
+}
+
+function readCmux(args: string[]): string | null {
+  const result = spawnSync("cmux", args, { encoding: "utf8" });
+  if (result.error || result.status !== 0 || !result.stdout.trim()) return null;
+  return result.stdout;
+}
+
+function parseCmuxIdentifySnapshot(value: string | null): CmuxIdentifySnapshot {
+  const parsed = value ? parseCmuxJson(value) : null;
+  return {
+    focused: parseCmuxFocusedSnapshot(parsed),
+    caller: parseCmuxCallerSnapshot(parsed),
+  };
+}
+
+function captureCmuxIdentifySnapshot(): CmuxIdentifySnapshot {
+  return parseCmuxIdentifySnapshot(readCmux(["identify", "--json"]));
+}
+
+function captureCmuxFocusSnapshot(): CmuxFocusSnapshot | null {
+  return captureCmuxIdentifySnapshot().focused;
+}
+
+function readCmuxPaneRefForSurface(surface: string): string | null {
+  const info = readCmux(["identify", "--surface", surface]);
+  return info ? parseCmuxPaneRefForSurfaceFromJson(info, surface) : null;
+}
+
+function restoreCmuxFocusSnapshot(snapshot: CmuxFocusSnapshot | null): void {
+  if (!snapshot) return;
+
+  if (snapshot.paneRef) {
+    spawnSync("cmux", ["focus-pane", "--pane", snapshot.paneRef], { encoding: "utf8" });
+  }
+
+  if (snapshot.surfaceRef) {
+    spawnSync("cmux", ["focus-panel", "--panel", snapshot.surfaceRef], { encoding: "utf8" });
+  }
+}
+
+function waitForCmuxFocusSettle(): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+}
+
+function cmuxFocusMatchesChild(
+  currentFocus: CmuxFocusSnapshot | null,
+  child: CmuxCreatedSurface,
+): boolean {
+  if (!currentFocus) return false;
+  if (currentFocus.surfaceRef === child.surface) return true;
+  return !!currentFocus.paneRef && currentFocus.paneRef === child.paneRef;
+}
+
+function cmuxFocusMatchesSurfaceRef(
+  currentFocus: CmuxFocusSnapshot | null,
+  surfaceRef: string | undefined,
+): boolean {
+  return !!surfaceRef && currentFocus?.surfaceRef === surfaceRef;
+}
+
+function cmuxFocusMatchesPaneRef(
+  currentFocus: CmuxFocusSnapshot | null,
+  paneRef: string | undefined,
+): boolean {
+  return !!paneRef && currentFocus?.paneRef === paneRef;
+}
+
+function restoreCmuxFocusIfLaunchSurfaceFocused(
+  snapshot: CmuxFocusSnapshot | null,
+  child: CmuxCreatedSurface,
+  options?: { sourceSurfaceRef?: string; callerSnapshot?: CmuxFocusSnapshot | null },
+): void {
+  if (!snapshot) return;
+
+  waitForCmuxFocusSettle();
+  const currentFocus = captureCmuxFocusSnapshot();
+  if (
+    cmuxFocusMatchesChild(currentFocus, child) ||
+    cmuxFocusMatchesSurfaceRef(currentFocus, options?.sourceSurfaceRef) ||
+    cmuxFocusMatchesSurfaceRef(currentFocus, options?.callerSnapshot?.surfaceRef) ||
+    // cmux can settle focus onto another active surface in the caller pane after creating a split/surface.
+    cmuxFocusMatchesPaneRef(currentFocus, options?.callerSnapshot?.paneRef)
+  ) {
+    restoreCmuxFocusSnapshot(snapshot);
+  }
+}
+
+function parseCmuxCreatedSurface(output: string, command: string): CmuxCreatedSurface {
+  const surfaceMatch = output.match(/surface:\d+/);
+  if (!surfaceMatch) {
+    throw new Error(`Unexpected cmux ${command} output: ${output}`);
+  }
+
+  return {
+    surface: surfaceMatch[0],
+    paneRef: output.match(/pane:\d+/)?.[0],
+  };
+}
+
+function renameCmuxSurface(surface: string, name: string): void {
+  execFileSync("cmux", ["rename-tab", "--surface", surface, name], { encoding: "utf8" });
+}
+
+function renameMuxySurface(surface: string, name: string): void {
+  try {
+    execFileSync("muxy", ["rename-pane", "--pane", surface, name], { encoding: "utf8" });
+  } catch {}
+}
+
+function createCmuxSplitSurface(
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): CmuxCreatedSurface {
+  const identifySnapshot = captureCmuxIdentifySnapshot();
+  const focusSnapshot = identifySnapshot.focused;
+  const callerSnapshot = identifySnapshot.caller;
+  let child: CmuxCreatedSurface | null = null;
+
+  try {
+    const args = ["new-split", direction];
+    if (fromSurface) args.push("--surface", fromSurface);
+
+    const output = execFileSync("cmux", args, { encoding: "utf8" }).trim();
+    child = parseCmuxCreatedSurface(output, "new-split");
+    child.paneRef ??= readCmuxPaneRefForSurface(child.surface) ?? undefined;
+    renameCmuxSurface(child.surface, name);
+    return child;
+  } finally {
+    if (child) {
+      restoreCmuxFocusIfLaunchSurfaceFocused(focusSnapshot, child, {
+        sourceSurfaceRef: fromSurface,
+        callerSnapshot,
+      });
+    } else {
+      restoreCmuxFocusSnapshot(focusSnapshot);
+    }
+  }
+}
+
+/**
+ * Create a new terminal surface for a subagent.
+ *
+ * For cmux: the first call creates a right-split pane; subsequent calls add
+ * tabs to that same pane (avoiding ever-narrower splits).
+ * For zellij: chooses a tab-aware tiled or stacked placement.
+ * For tmux/wezterm: falls back to split behavior.
+ *
+ * Returns an identifier (`surface:42` in cmux, `%12` in tmux, `pane:7` in zellij, `42` in wezterm).
+ */
+export function createSurface(name: string): string {
+  // Fall back to headless mode when no terminal multiplexer is available
+  if (!isMuxAvailable()) {
+    return createHeadlessSurface(name);
+  }
+
+  const backend = getMuxBackend();
+
+  if (backend === "cmux" && cmuxSubagentPane) {
+    // Verify the pane still exists before adding a tab to it
+    try {
+      const tree = execSync(`cmux tree`, { encoding: "utf8" });
+      if (tree.includes(cmuxSubagentPane)) {
+        return createSurfaceInPane(name, cmuxSubagentPane);
+      }
+    } catch {}
+    // Pane is gone — fall through to create a new split
+    cmuxSubagentPane = null;
+  }
+
+  if (backend === "muxy") {
+    const markerFile = `/tmp/muxy-subagent-pane-${AGENT_MUXY_PANE_ID || "default"}`;
+    const lockFile = `${markerFile}.lock`;
+
+    // ── 全局锁：所有分屏操作串行化，防止并发竞争 ──
+    const acquired = (() => {
+      for (let i = 0; i < 60; i++) {
+        if (!existsSync(lockFile)) {
+          try {
+            writeFileSync(lockFile, `${process.pid}`, { flag: "wx" });
+            return true;
+          } catch {
+            // 竞争失败，继续等待
+          }
+        }
+        spawnSync("sleep", ["0.05"]);
+      }
+      return false;
+    })();
+
+    if (!acquired) return "";
+
+    try {
+      // ── 广度优先分屏 ──
+      // 状态（JSON）：{ panes: string[], pos: number, base: number, dir: "right"|"down" }
+      // panes: 所有 subagent pane ID 列表
+      // pos:   本轮下一个要 split 的 pane 索引
+      // base:  本轮开始时 pane 总数（本轮要分 base 个）
+      // dir:   当前方向
+      // 每来一个 subagent：从 panes[pos] 分 → 新 pane 追加到列表尾
+      // pos 走完 base 个后 → 翻转方向，重置 pos，更新 base
+      let state: { panes: string[]; pos: number; base: number; dir: "right" | "down" } = {
+        panes: [], pos: 0, base: 0, dir: "right",
+      };
+      try {
+        state = JSON.parse(readFileSync(markerFile, "utf8"));
+      } catch {}
+
+      // 首次：split-right from parent
+      if (state.panes.length === 0) {
+        // 必须从 agent 启动时的 pane 拆，不能 fallback 到当前焦点 pane。
+        // 如果 MUXY_PANE_ID 没注入（pi 是从 muxy 外面启动的，或模块加载时 env 尚未注入），
+        // 抛错让用户明确知道根因，而不是静默从当前激活 pane 拆出。
+        if (!AGENT_MUXY_PANE_ID) {
+          throw new Error(
+            "MUXY_PANE_ID not set; cannot determine parent pane for first subagent split. " +
+            "Start pi inside Muxy so MUXY_PANE_ID is injected at launch.",
+          );
+        }
+        const args = ["split-right", "--from", AGENT_MUXY_PANE_ID];
+        lastSplitSource = AGENT_MUXY_PANE_ID;
+        muxLog(
+          `[muxy split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=<pending> name=${JSON.stringify(name)}\n`,
+        );
+        const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
+        if (output) {
+          state.panes = [output];
+          state.pos = 0;
+          state.base = 1;
+          state.dir = "down";
+          writeFileSync(markerFile, JSON.stringify(state));
+          renameMuxySurface(output, name);
+          muxLog(
+            `[muxy split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=${output} name=${JSON.stringify(name)}\n`,
+          );
+        }
+        return output;
+      }
+
+      // 本轮结束？翻转方向
+      if (state.pos >= state.base) {
+        state.pos = 0;
+        state.base = state.panes.length;
+        state.dir = state.dir === "right" ? "down" : "right";
+      }
+
+      const targetPane = state.panes[state.pos];
+      lastSplitSource = targetPane ?? null;
+      const muxyDir = state.dir === "right" ? "split-right" : "split-down";
+      const args = [muxyDir];
+      if (targetPane) args.push("--from", targetPane);
+
+      muxLog(
+        `[muxy split] mode=next pos=${state.pos} base=${state.base} dir=${state.dir} from=state.panes[${state.pos}]=${targetPane} new=<pending> name=${JSON.stringify(name)}\n`,
+      );
+      const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
+
+      if (output) {
+        state.panes.push(output);
+        state.pos++;
+        writeFileSync(markerFile, JSON.stringify(state));
+        renameMuxySurface(output, name);
+        muxLog(
+          `[muxy split] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=state.panes[${state.pos - 1}]=${targetPane} new=${output} name=${JSON.stringify(name)}\n`,
+        );
+      }
+
+      return output;
+    } finally {
+      try { rmSync(lockFile); } catch {}
+    }
+  }
+
+  if (backend === "cmux") {
+    lastSplitSource = process.env.CMUX_SURFACE_ID ?? null;
+    const created = createCmuxSplitSurface(name, "right", process.env.CMUX_SURFACE_ID);
+    cmuxSubagentPane = created.paneRef ?? null;
+    return created.surface;
+  }
+
+  if (backend === "zellij") {
+    return createZellijSurface(name);
+  }
+
+  if (backend === "herdr") {
+    return createHerdrSurface(name);
+  }
+
+  if (backend === "otty") {
+    lastSplitSource = AGENT_OTTY_PANE_ID ?? null;
+    return createOttySurface(name);
+  }
+
+  // On tmux, target the parent pi's pane so splits follow the agent, not the user's focus.
+  // See https://github.com/HazAT/pi-interactive-subagents/issues/12
+  const fromSurface = backend === "tmux" ? process.env.TMUX_PANE : undefined;
+  lastSplitSource = fromSurface ?? null;
+  return createSurfaceSplit(name, "right", fromSurface);
+}
+
+/**
+ * Create a new surface (tab) in an existing cmux pane.
+ */
+function createSurfaceInPane(name: string, pane: string): string {
+  const identifySnapshot = captureCmuxIdentifySnapshot();
+  const focusSnapshot = identifySnapshot.focused;
+  const callerSnapshot = identifySnapshot.caller;
+  let child: CmuxCreatedSurface | null = null;
+
+  try {
+    const output = execFileSync("cmux", ["new-surface", "--pane", pane], { encoding: "utf8" }).trim();
+    child = parseCmuxCreatedSurface(output, "new-surface");
+    child.paneRef ??= pane;
+    renameCmuxSurface(child.surface, name);
+    return child.surface;
+  } finally {
+    if (child) {
+      restoreCmuxFocusIfLaunchSurfaceFocused(focusSnapshot, child, {
+        callerSnapshot,
+      });
+    } else {
+      restoreCmuxFocusSnapshot(focusSnapshot);
+    }
+  }
+}
+
+/**
+ * Create a new split in the given direction from an optional source pane.
+ * Returns an identifier (`surface:42` in cmux, `%12` in tmux, `pane:7` in zellij, `42` in wezterm).
+ */
+export function createSurfaceSplit(
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): string {
+  const backend = requireMuxBackend();
+
+  if (backend === "muxy") {
+    const dir = direction === "down" || direction === "up" ? "down" : "right";
+    // 优先用入参 fromSurface（与 cmux/zellij/tmux/wezterm 保持一致），fallback 到
+    // agent 启动时的 pane。两者都没有就抛错，避免静默 fallback 到当前焦点 pane。
+    const sourcePane = fromSurface ?? AGENT_MUXY_PANE_ID;
+    const sourceOrigin = fromSurface
+      ? `fromSurface=${fromSurface}`
+      : `AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID ?? "<unset>"}`;
+    if (!sourcePane) {
+      throw new Error(
+        "MUXY_PANE_ID not set and no fromSurface provided; cannot determine source pane for split. " +
+        "Start pi inside Muxy so MUXY_PANE_ID is injected at launch.",
+      );
+    }
+    const args = [`split-${dir}`, "--from", sourcePane];
+    lastSplitSource = sourcePane;
+    muxLog(
+      `[muxy split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=<pending> name=${JSON.stringify(name)}\n`,
+    );
+    const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
+    if (output) {
+      renameMuxySurface(output, name);
+      muxLog(
+        `[muxy split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=${output} name=${JSON.stringify(name)}\n`,
+      );
+    }
+    return output;
+  }
+
+  if (backend === "cmux") {
+    return createCmuxSplitSurface(name, direction, fromSurface).surface;
+  }
+
+  if (backend === "tmux") {
+    const args = ["split-window", "-d"];
+    if (direction === "left" || direction === "right") {
+      args.push("-h");
+    } else {
+      args.push("-v");
+    }
+    if (direction === "left" || direction === "up") {
+      args.push("-b");
+    }
+    if (fromSurface) {
+      args.push("-t", fromSurface);
+    }
+    args.push("-P", "-F", "#{pane_id}");
+
+    const pane = execFileSync("tmux", args, { encoding: "utf8" }).trim();
+    if (!pane.startsWith("%")) {
+      throw new Error(`Unexpected tmux split-window output: ${pane}`);
+    }
+
+    return pane;
+  }
+
+  if (backend === "wezterm") {
+    const args = ["cli", "split-pane"];
+    if (direction === "left") args.push("--left");
+    else if (direction === "right") args.push("--right");
+    else if (direction === "up") args.push("--top");
+    else args.push("--bottom");
+    args.push("--cwd", process.cwd());
+    if (fromSurface) {
+      args.push("--pane-id", fromSurface);
+    }
+    const paneId = execFileSync("wezterm", args, { encoding: "utf8" }).trim();
+    if (!paneId || !/^\d+$/.test(paneId)) {
+      throw new Error(`Unexpected wezterm split-pane output: ${paneId || "(empty)"}`);
+    }
+    try {
+      execFileSync("wezterm", ["cli", "set-tab-title", "--pane-id", paneId, name], {
+        encoding: "utf8",
+      });
+    } catch {
+      // Optional — tab title is cosmetic.
+    }
+    return paneId;
+  }
+
+  if (backend === "herdr") {
+    const sourcePane = fromSurface ?? AGENT_HERDR_PANE_ID;
+    if (!sourcePane) {
+      throw new Error(
+        "HERDR_PANE_ID not set and no fromSurface provided; cannot determine source pane for split. " +
+          "Start pi inside herdr so HERDR_PANE_ID is injected at launch.",
+      );
+    }
+    lastSplitSource = sourcePane;
+    return splitHerdrPane(sourcePane, direction, name);
+  }
+
+  if (backend === "otty") {
+    // otty 用 --direction right|down|left|up + --pane <parent>，且不返回新 pane id。
+    // createOttySurface 内部用广度优先策略，对外只暴露"加一个 pane"。
+    // 这里为了接口一致（返回 surface id），调用 createOttySurface
+    // 并把 fromSurface / direction 作为 hint 注入。
+    // 注：direction 在 otty 的广度优先策略中被忽略（顺序固定），
+    // 但 fromSurface 会作为 fallback parent（如果提供）。
+    lastSplitSource = fromSurface ?? AGENT_OTTY_PANE_ID ?? null;
+    return createOttySurface(name);
+  }
+
+  // zellij
+  const directionArg = direction === "left" || direction === "right" ? "right" : "down";
+  const args = ["new-pane", "--direction", directionArg, "--name", name, "--cwd", process.cwd()];
+
+  let rawId: string;
+  try {
+    rawId = zellijActionSync(args, fromSurface).trim();
+  } catch {
+    if (!fromSurface) throw new Error("Failed to create zellij pane");
+    rawId = zellijActionSync(args).trim();
+  }
+
+  // zellij returns the pane ID as e.g. "terminal_7" — extract the numeric part.
+  // Previously we sent `write-chars "echo $ZELLIJ_PANE_ID"` to a temp file, but
+  // `write-chars` without --pane-id targets the focused pane, which raced on tab switches.
+  const surface = parseZellijPaneSurface(rawId, "new-pane");
+
+  if (direction === "left" || direction === "up") {
+    try {
+      zellijActionSync(["move-pane", direction], surface);
+    } catch {
+      // Optional layout polish.
+    }
+  }
+
+  try {
+    zellijActionSync(["rename-pane", name], surface);
+  } catch {
+    // Optional.
+  }
+
+  return surface;
+}
+
+/**
+ * Rename the current tab/window.
+ */
+export function renameCurrentTab(title: string): void {
+  if (isHeadlessMode()) return; // no tab to rename
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    const surfaceId = process.env.CMUX_SURFACE_ID;
+    if (!surfaceId) throw new Error("CMUX_SURFACE_ID not set");
+    execSync(`cmux rename-tab --surface ${shellEscape(surfaceId)} ${shellEscape(title)}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "muxy") {
+    const paneId = AGENT_MUXY_PANE_ID;
+    if (!paneId) throw new Error("MUXY_PANE_ID not set");
+    execFileSync("muxy", ["rename-pane", "--pane", paneId, title], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    if (process.env.PI_SUBAGENT_RENAME_TMUX_WINDOW !== "1") {
+      return;
+    }
+    const paneId = process.env.TMUX_PANE;
+    if (!paneId) throw new Error("TMUX_PANE not set");
+    const windowId = execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{window_id}"], {
+      encoding: "utf8",
+    }).trim();
+    execFileSync("tmux", ["rename-window", "-t", windowId, title], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    const paneId = process.env.WEZTERM_PANE;
+    const args = ["cli", "set-tab-title"];
+    if (paneId) args.push("--pane-id", paneId);
+    args.push(title);
+    execFileSync("wezterm", args, { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "herdr") {
+    // herdr 中 agent 自己 pane 的 tab 名就是用户最关心的。
+    renameHerdrTab(AGENT_HERDR_PANE_ID ?? "", title);
+    return;
+  }
+
+  if (backend === "otty") {
+    // 与 herdr 一致：重命名 agent 自己 pane 所属的 tab，避免覆盖用户的 tab title。
+    renameOttyTab(AGENT_OTTY_PANE_ID ?? "", title);
+    return;
+  }
+
+  // zellij: rename the agent's own pane, not the whole tab. In multi-pane layouts,
+  // rename-tab clobbers the user's tab title whenever a subagent starts or /plan runs.
+  // Closes #21.
+  const paneId = process.env.ZELLIJ_PANE_ID;
+  if (paneId) {
+    zellijActionSync(["rename-pane", title], `pane:${paneId}`);
+  } else {
+    zellijActionSync(["rename-pane", title]);
+  }
+}
+
+/**
+ * Rename the agent pane itself when no tab concept exists. For herdr we
+ * delegate to renameHerdrTab which targets the pane's containing tab.
+ */
+export { renameHerdrTab };
+
+/**
+ * 重命名指定 surface（跨后端统一）。
+ * headless surface 无实体 pane，直接 no-op。
+ */
+export function renameSurface(surface: string, name: string): void {
+  if (isHeadlessSurface(surface)) return;
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    renameCmuxSurface(surface, name);
+    return;
+  }
+  if (backend === "muxy") {
+    renameMuxySurface(surface, name);
+    return;
+  }
+  if (backend === "tmux") {
+    // tmux 没有 pane 级命名，退化为所在 window 命名（调用方只对自建 surface 使用）
+    const windowId = execFileSync("tmux", ["display-message", "-p", "-t", surface, "#{window_id}"], {
+      encoding: "utf8",
+    }).trim();
+    execFileSync("tmux", ["rename-window", "-t", windowId, name], { encoding: "utf8" });
+    return;
+  }
+  if (backend === "wezterm") {
+    execFileSync("wezterm", ["cli", "set-tab-title", "--pane-id", surface, name], {
+      encoding: "utf8",
+    });
+    return;
+  }
+  if (backend === "herdr") {
+    renameHerdrPane(surface, name);
+    return;
+  }
+  if (backend === "otty") {
+    renameOttyTab(surface, name);
+    return;
+  }
+  // zellij
+  zellijActionSync(["rename-pane", name], surface);
+}
+
+/**
+ * Rename the agent display name on a subagent surface (left sidebar title in herdr).
+ * This requires the agent to be detected first, so call it after pi starts.
+ * Silently no-ops on non-herdr backends or if the agent hasn't been detected yet.
+ */
+export function renameAgent(surface: string, name: string): void {
+  if (isHeadlessMode()) return;
+  const backend = getMuxBackend();
+  if (backend === "herdr") {
+    renameHerdrAgent(surface, name);
+  }
+}
+
+/**
+ * Rename the current workspace/session where supported.
+ */
+export function renameWorkspace(title: string): void {
+  if (isHeadlessMode()) return; // no workspace to rename
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execSync(`cmux workspace-action --action rename --title ${shellEscape(title)}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "muxy") {
+    // Muxy doesn't have a separate workspace concept; rename is handled at pane level
+    return;
+  }
+
+  if (backend === "tmux") {
+    if (process.env.PI_SUBAGENT_RENAME_TMUX_SESSION !== "1") {
+      return;
+    }
+
+    const paneId = process.env.TMUX_PANE;
+    if (!paneId) throw new Error("TMUX_PANE not set");
+    const sessionId = execFileSync(
+      "tmux",
+      ["display-message", "-p", "-t", paneId, "#{session_id}"],
+      {
+        encoding: "utf8",
+      },
+    ).trim();
+    execFileSync("tmux", ["rename-session", "-t", sessionId, title], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    const paneId = process.env.WEZTERM_PANE;
+    const args = ["cli", "set-window-title"];
+    if (paneId) args.push("--pane-id", paneId);
+    args.push(title);
+    try {
+      execFileSync("wezterm", args, { encoding: "utf8" });
+    } catch {
+      // Optional — window title is cosmetic.
+    }
+    return;
+  }
+
+  if (backend === "herdr") {
+    renameHerdrWorkspace(title);
+    return;
+  }
+
+  if (backend === "otty") {
+    // Otty 没有显式 workspace rename 命令；rename-tab 已在 renameCurrentTab 中调用。
+    return;
+  }
+
+  // Skip session rename for zellij. rename-session renames the socket file
+  // but the ZELLIJ_SESSION_NAME env var in the parent process keeps the old
+  // name, so all subsequent `zellij action ...` CLI calls fail with
+  // "There is no active session!" because the CLI can't find the socket.
+  // Additionally, pi titles often contain special characters (em dashes,
+  // spaces) that fail zellij's session name validation on lookup.
+  // rename-tab (called separately) is sufficient for user-visible naming.
+}
+
+/**
+ * Re-export herdr workspace rename so callers can swap implementations by backend.
+ * Internal: gated by PI_SUBAGENT_RENAME_HERDR_WORKSPACE env var.
+ */
+export { renameHerdrWorkspace };
+
+/**
+ * Send a command string to a pane and execute it.
+ */
+export function sendCommand(surface: string, command: string): void {
+  // Headless mode: commands are sent via sendLongCommand which spawns the process directly.
+  // Standalone sendCommand on a headless surface is a no-op — there's no running pane to send to.
+  if (isHeadlessSurface(surface)) {
+    return;
+  }
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux" || backend === "muxy") {
+    if (backend === "muxy") {
+      execFileSync("muxy", ["send", "--pane", surface, command], { encoding: "utf8" });
+      execFileSync("muxy", ["send-keys", "--pane", surface, "Enter"], { encoding: "utf8" });
+      return;
+    }
+    execSync(`cmux send --surface ${shellEscape(surface)} ${shellEscape(command + "\n")}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["send-keys", "-t", surface, "-l", command], { encoding: "utf8" });
+    execFileSync("tmux", ["send-keys", "-t", surface, "Enter"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    execFileSync(
+      "wezterm",
+      ["cli", "send-text", "--pane-id", surface, "--no-paste", command + "\n"],
+      { encoding: "utf8" },
+    );
+    return;
+  }
+
+  if (backend === "herdr") {
+    sendHerdrCommand(surface, command);
+    return;
+  }
+
+  if (backend === "otty") {
+    sendOttyCommand(surface, command);
+    return;
+  }
+
+  zellijActionSync(["write-chars", command], surface);
+  zellijActionSync(["write", "13"], surface);
+}
+
+/**
+ * Send one Escape keypress to an active pane.
+ */
+export function sendEscape(surface: string): void {
+  if (isHeadlessSurface(surface)) {
+    sendHeadlessEscape(surface);
+    return;
+  }
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execFileSync("cmux", ["send", "--surface", surface, "\u001b"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "muxy") {
+    // Use send (raw bytes) instead of send-keys Escape — send-keys may not
+    // correctly translate the "Escape" key name to an actual ESC at the PTY level.
+    // This matches how cmux and wezterm send the actual escape character (0x1B).
+    execFileSync("muxy", ["send", "--pane", surface, "\u001b"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["send-keys", "-t", surface, "Escape"], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    execFileSync("wezterm", ["cli", "send-text", "--pane-id", surface, "--no-paste", "\u001b"], {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "herdr") {
+    sendHerdrEscape(surface);
+    return;
+  }
+
+  if (backend === "otty") {
+    sendOttyEscape(surface);
+    return;
+  }
+
+  zellijActionSync(["write", "27"], surface);
+}
+
+/**
+ * Send a long command to a pane by writing it to a script file first.
+ * This avoids terminal line-wrapping issues that break commands exceeding the
+ * pane's column width when sent character-by-character via sendCommand.
+ *
+ * By default the script is written to a temp directory, but callers can pass a
+ * stable path (for example under session artifacts) so the exact invocation is
+ * preserved for debugging.
+ *
+ * Returns the script path.
+ */
+export function sendLongCommand(
+  surface: string,
+  command: string,
+  options?: { scriptPath?: string; scriptPreamble?: string },
+): string {
+  // Headless mode: spawn as a background child process instead of sending to a mux pane
+  if (isHeadlessSurface(surface)) {
+    const logFile = options?.scriptPath
+      ? options.scriptPath.replace(/\.sh$/, ".log")
+      : undefined;
+    // Write the script file for debugging even in headless mode
+    const scriptPath =
+      options?.scriptPath ??
+      join(
+        tmpdir(),
+        "pi-subagent-scripts",
+        `cmd-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sh`,
+      );
+    mkdirSync(dirname(scriptPath), { recursive: true });
+    const scriptParts = ["#!/bin/bash"];
+    if (options?.scriptPreamble) {
+      scriptParts.push(options.scriptPreamble.trimEnd());
+    }
+    scriptParts.push(command);
+    writeFileSync(scriptPath, scriptParts.join("\n") + "\n", { mode: 0o755 });
+
+    spawnHeadlessProcess(surface, "subagent", `bash ${shellEscape(scriptPath)}`, {
+      cwd: process.cwd(),
+      env: { PI_SUBAGENT_HEADLESS: "1" },
+    });
+    return scriptPath;
+  }
+
+  const scriptPath =
+    options?.scriptPath ??
+    join(
+      tmpdir(),
+      "pi-subagent-scripts",
+      `cmd-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.sh`,
+    );
+  mkdirSync(dirname(scriptPath), { recursive: true });
+
+  const scriptParts = ["#!/bin/bash"];
+  if (options?.scriptPreamble) {
+    scriptParts.push(options.scriptPreamble.trimEnd());
+  }
+  scriptParts.push(command);
+
+  writeFileSync(scriptPath, scriptParts.join("\n") + "\n", {
+    mode: 0o755,
+  });
+  sendCommand(surface, `bash ${shellEscape(scriptPath)}`);
+  return scriptPath;
+}
+
+/**
+ * Read the screen contents of a pane (sync).
+ */
+export function readScreen(surface: string, lines = 50): string {
+  if (isHeadlessSurface(surface)) {
+    return readHeadlessScreen(surface, lines);
+  }
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    return execSync(`cmux read-screen --surface ${shellEscape(surface)} --lines ${lines}`, {
+      encoding: "utf8",
+    });
+  }
+
+  if (backend === "muxy") {
+    return execFileSync("muxy", ["read-screen", "--pane", surface, "--lines", String(lines)], {
+      encoding: "utf8",
+    });
+  }
+
+  if (backend === "tmux") {
+    return execFileSync(
+      "tmux",
+      ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`],
+      {
+        encoding: "utf8",
+      },
+    );
+  }
+
+  if (backend === "wezterm") {
+    const raw = execFileSync(
+      "wezterm",
+      ["cli", "get-text", "--pane-id", surface],
+      { encoding: "utf8" },
+    );
+    return tailLines(raw, lines);
+  }
+
+  if (backend === "herdr") {
+    // 用 recent 读最近 scrollback，确保 sentinel 检测可靠。
+    // visible 只读当前 viewport，pi 退出后终端恢复主缓冲区，sentinel 可能不在 viewport 内，
+    // 导致 pollForExit 检测不到退出、closeSurface 不执行、分屏关不掉。
+    return readHerdrScreen(surface, lines, "recent");
+  }
+
+  if (backend === "otty") {
+    return readOttyScreen(surface, lines);
+  }
+
+  // Zellij 0.44+: use --pane-id flag + stdout instead of env var + temp file.
+  // The ZELLIJ_PANE_ID env var doesn't reliably target other panes for dump-screen,
+  // and --path may silently fail to create the file. Stdout capture is robust.
+  const paneId = zellijPaneId(surface);
+  const raw = execFileSync(
+    "zellij",
+    ["action", "dump-screen", "--pane-id", paneId],
+    { encoding: "utf8" },
+  );
+  return tailLines(raw, lines);
+}
+
+/**
+ * Read the screen contents of a pane (async).
+ */
+export async function readScreenAsync(surface: string, lines = 50): Promise<string> {
+  if (isHeadlessSurface(surface)) {
+    return readHeadlessScreen(surface, lines);
+  }
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    const { stdout } = await execFileAsync(
+      "cmux",
+      ["read-screen", "--surface", surface, "--lines", String(lines)],
+      { encoding: "utf8" },
+    );
+    return stdout;
+  }
+
+  if (backend === "muxy") {
+    const { stdout } = await execFileAsync(
+      "muxy",
+      ["read-screen", "--pane", surface, "--lines", String(lines)],
+      { encoding: "utf8" },
+    );
+    return stdout;
+  }
+
+  if (backend === "tmux") {
+    const { stdout } = await execFileAsync(
+      "tmux",
+      ["capture-pane", "-p", "-t", surface, "-S", `-${Math.max(1, lines)}`],
+      { encoding: "utf8" },
+    );
+    return stdout;
+  }
+
+  if (backend === "wezterm") {
+    const { stdout } = await execFileAsync(
+      "wezterm",
+      ["cli", "get-text", "--pane-id", surface],
+      { encoding: "utf8" },
+    );
+    return tailLines(stdout, lines);
+  }
+
+  if (backend === "herdr") {
+    return readHerdrScreen(surface, lines, "recent");
+  }
+
+  if (backend === "otty") {
+    return readOttyScreen(surface, lines);
+  }
+
+  // Zellij 0.44+: use --pane-id flag + stdout instead of env var + temp file.
+  const paneId = zellijPaneId(surface);
+  const { stdout } = await execFileAsync(
+    "zellij",
+    ["action", "dump-screen", "--pane-id", paneId],
+    { encoding: "utf8" },
+  );
+  return tailLines(stdout, lines);
+}
+
+/**
+ * Close a pane.
+ */
+export function closeSurface(surface: string): void {
+  if (isHeadlessSurface(surface)) {
+    closeHeadlessSurface(surface);
+    return;
+  }
+
+  const backend = requireMuxBackend();
+
+  if (backend === "cmux") {
+    execSync(`cmux close-surface --surface ${shellEscape(surface)}`, {
+      encoding: "utf8",
+    });
+    return;
+  }
+
+  if (backend === "muxy") {
+    execFileSync("muxy", ["close-pane", "--pane", surface], { encoding: "utf8" });
+    // 从 state.panes 移除已关闭的 subagent，避免僵尸 ID 累积导致
+    // 后续 `muxy split-* --from <死ID>` 走 fallback 行为（从当前焦点 pane 拆出）。
+    // 解析 JSON 状态，splice 掉已关闭的 surface，pos 相应回退；
+    // 全部 subagent 都关闭后删除整个 marker，下次创建走"首次"分支。
+    const markerFile = `/tmp/muxy-subagent-pane-${AGENT_MUXY_PANE_ID || "default"}`;
+    try {
+      const parsed = JSON.parse(readFileSync(markerFile, "utf8"));
+      if (parsed && Array.isArray(parsed.panes)) {
+        const idx = parsed.panes.indexOf(surface);
+        if (idx >= 0) {
+          const beforePanes = [...parsed.panes];
+          const beforePos = parsed.pos;
+          parsed.panes.splice(idx, 1);
+          // pos 指向"下一个要 split 的索引"，左侧删除时 pos 需要回退
+          if (typeof parsed.pos === "number" && idx < parsed.pos) {
+            parsed.pos = Math.max(0, parsed.pos - 1);
+          }
+          if (parsed.panes.length === 0) {
+            rmSync(markerFile);
+            muxLog(
+              `[muxy close] pane=${surface} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
+            );
+          } else {
+            writeFileSync(markerFile, JSON.stringify(parsed));
+            muxLog(
+              `[muxy close] pane=${surface} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(parsed.panes)} pos=${beforePos} -> ${parsed.pos}\n`,
+            );
+          }
+        } else {
+          muxLog(
+            `[muxy close] pane=${surface} (not in marker state.panes, marker unchanged)\n`,
+          );
+        }
+      }
+    } catch (e) {
+      muxLog(
+        `[muxy close] pane=${surface} (no marker found or parse error, nothing to clean)\n`,
+      );
+    }
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["kill-pane", "-t", surface], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "wezterm") {
+    execFileSync("wezterm", ["cli", "kill-pane", "--pane-id", surface], {
+      encoding: "utf8" },
+    );
+    return;
+  }
+
+  if (backend === "herdr") {
+    closeHerdrSurface(surface);
+    return;
+  }
+
+  if (backend === "otty") {
+    closeOttySurface(surface);
+    return;
+  }
+
+  zellijActionSync(["close-pane"], surface);
+}
+
+export interface PollResult {
+  /** How the subagent exited */
+  reason: "done" | "ping" | "structured_output" | "sentinel";
+  /** Shell exit code (from sentinel). 0 for file-based exits. */
+  exitCode: number;
+  /** Ping data if reason is "ping" */
+  ping?: { name: string; message: string };
+  /** Validated structured output if reason is "structured_output" */
+  structuredOutput?: unknown;
+}
+
+/**
+ * Poll until the subagent exits. Checks for a `.exit` sidecar file first
+ * (written by subagent_done / caller_ping), falling back to the terminal
+ * sentinel for crash detection.
+ */
+export async function pollForExit(
+  surface: string,
+  signal: AbortSignal,
+  options: {
+    interval: number;
+    sessionFile?: string;
+    sentinelFile?: string;
+    onTick?: (elapsed: number) => void;
+  },
+): Promise<PollResult> {
+  const start = Date.now();
+  const isHeadless = isHeadlessSurface(surface);
+
+  for (;;) {
+    if (signal.aborted) {
+      muxLog(`[pollForExit] ABORTED at loop start surface=${surface} elapsed=${Date.now() - start}ms — signal was aborted before/synchronously after watchSubagent entered poll loop (likely stale POLL_ABORT_KEY controller). Throwing "Aborted while waiting..."\n`);
+      throw new Error("Aborted while waiting for subagent to finish");
+    }
+
+    // Fast path: check for .exit sidecar file (written by subagent_done / caller_ping / structured_output)
+    if (options.sessionFile) {
+      const exitFile = `${options.sessionFile}.exit`;
+      try {
+        if (existsSync(exitFile)) {
+          let data: any;
+          try {
+            data = JSON.parse(readFileSync(exitFile, "utf8"));
+          } catch (parseErr: any) {
+            // .exit 文件存在但解析失败 — subagent 可能被 SIGKILL 半截写入。
+            // 不删文件，留着供事后诊断；下次循环再试一次，如果始终半截则由超时兜底。
+            muxLog(
+              `[pollForExit] FAST PATH BUG: ${exitFile} exists but JSON.parse failed: ${parseErr?.message ?? String(parseErr)}\n` +
+                `[pollForExit] contents(raw)=${JSON.stringify((() => { try { return readFileSync(exitFile, "utf8"); } catch { return "<unreadable>"; } })())}\n`,
+            );
+            throw parseErr; // 跳到外层 catch 不静默吞
+          }
+          // 双重确认：子 pi 进程必须已启动（.jsonl 存在 + 非空）。
+          // 防止 herdr 后端在子 pi 根本没启动时 existsSync 假阳性命中
+          // 残留 .exit 文件，导致 6ms/28ms 内 false positive return。
+          const sessionJsonl = options.sessionFile;
+          try {
+            if (!existsSync(sessionJsonl) || statSync(sessionJsonl).size === 0) {
+              rmSync(exitFile, { force: true });
+              muxLog(
+                `[pollForExit] fast path FALSE POSITIVE: ${exitFile} type=${data?.type} but ${sessionJsonl} is ` +
+                  `${existsSync(sessionJsonl) ? `empty (0 bytes)` : `missing`} — subagent never started, ` +
+                  `deleting stale .exit and continuing poll\n`,
+              );
+              // 跳到外层 sleep + 继续循环（不是 return）
+              throw Object.assign(new Error("subprocess not started"), { code: "SUBPROCESS_NOT_STARTED" });
+            }
+          } catch (e2: any) {
+            if (e2?.code === "SUBPROCESS_NOT_STARTED") throw e2;
+            // stat 失败不影响 — 继续正常 fast path
+            muxLog(`[pollForExit] session jsonl check failed (non-fatal): ${e2?.message ?? String(e2)}\n`);
+          }
+          rmSync(exitFile, { force: true });
+          muxLog(`[pollForExit] fast path hit exitFile=${exitFile} type=${data?.type}\n`);
+          if (data.type === "ping") {
+            return { reason: "ping", exitCode: 0, ping: { name: data.name, message: data.message } };
+          }
+          if (data.type === "structured_output") {
+            return { reason: "structured_output", exitCode: 0, structuredOutput: data.value };
+          }
+          return { reason: "done", exitCode: 0 };
+        }
+      } catch (e: any) {
+        if (e?.code === "SUBPROCESS_NOT_STARTED") {
+          // 不是真正的错误 — .exit 是残留文件，已删除。继续 slow path。
+          // 这里不 return，让循环继续到 slow path 轮询。
+        } else if (e?.code !== "ENOENT") {
+          muxLog(
+            `[pollForExit] fast path error sessionFile=${options.sessionFile} err=${e?.message ?? String(e)}\n`,
+          );
+        }
+      }
+    }
+
+    // Check Claude sentinel file (written by plugin Stop hook)
+    if (options.sentinelFile) {
+      try {
+        if (existsSync(options.sentinelFile)) {
+          muxLog(`[pollForExit] sentinel file hit path=${options.sentinelFile}\n`);
+          return { reason: "sentinel", exitCode: 0 };
+        }
+      } catch (e: any) {
+        muxLog(
+          `[pollForExit] sentinel file check error path=${options.sentinelFile} err=${e?.message ?? String(e)}\n`,
+        );
+      }
+    }
+
+    // Headless mode: check if the child process has exited
+    if (isHeadless) {
+      const headlessExit = getHeadlessProcessExit(surface);
+      if (headlessExit) {
+        const { exitCode } = await Promise.race([
+          headlessExit,
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout")), 100),
+          ),
+        ]).catch(() => ({ exitCode: null as number | null }));
+        if (exitCode !== null && exitCode !== undefined) {
+          drainHeadlessProcess(surface);
+          return { reason: "sentinel", exitCode };
+        }
+      }
+    }
+
+    // Slow path: read terminal screen for sentinel (crash detection).
+    // 后台 tab 的 herdr 可能节流/陈旧化屏幕 buffer，所以多读一些行提高命中率。
+    if (!isHeadless) {
+      let screen = "";
+      let readErr: unknown = null;
+      try {
+        screen = await readScreenAsync(surface, 200);
+      } catch (e) {
+        readErr = e;
+      }
+
+      if (readErr) {
+        // Surface may have been destroyed — check if .exit file appeared in the meantime
+        muxLog(
+          `[pollForExit] slow path read screen FAILED surface=${surface} err=${(readErr as Error)?.message ?? String(readErr)}\n`,
+        );
+        if (options.sessionFile) {
+          const exitFile = `${options.sessionFile}.exit`;
+          try {
+            if (existsSync(exitFile)) {
+              const data = JSON.parse(readFileSync(exitFile, "utf8"));
+              rmSync(exitFile, { force: true });
+              muxLog(`[pollForExit] recovery via .exit after screen read failure file=${exitFile} type=${data?.type}\n`);
+              if (data.type === "ping") {
+                return { reason: "ping", exitCode: 0, ping: { name: data.name, message: data.message } };
+              }
+              if (data.type === "structured_output") {
+                return { reason: "structured_output", exitCode: 0, structuredOutput: data.value };
+              }
+              return { reason: "done", exitCode: 0 };
+            }
+          } catch (e2: any) {
+            muxLog(
+              `[pollForExit] recovery .exit check FAILED file=${exitFile} err=${e2?.message ?? String(e2)}\n`,
+            );
+          }
+        }
+      } else {
+        const match = screen.match(/__SUBAGENT_DONE_(\d+)__/);
+        if (match) {
+          muxLog(`[pollForExit] slow path sentinel hit surface=${surface} exitCode=${match[1]}\n`);
+          return { reason: "sentinel", exitCode: parseInt(match[1], 10) };
+        }
+        // 每 10 秒记一次屏幕尾部快照，方便事后看到底是屏幕没更新还是 sentinel 滚出。
+        if (Date.now() - start > 0 && Math.floor((Date.now() - start) / 1000) % 10 === 0) {
+          muxLog(
+            `[pollForExit] slow path no sentinel surface=${surface} tail=${JSON.stringify(screen.slice(-200))}\n`,
+          );
+        }
+      }
+    } else if (options.sessionFile) {
+      // Headless mode: check .exit sidecar as fallback in case process exited without sidecar
+      const exitFile = `${options.sessionFile}.exit`;
+      try {
+        if (existsSync(exitFile)) {
+          const data = JSON.parse(readFileSync(exitFile, "utf8"));
+          rmSync(exitFile, { force: true });
+          muxLog(`[pollForExit] headless .exit hit file=${exitFile} type=${data?.type}\n`);
+          if (data.type === "ping") {
+            return { reason: "ping", exitCode: 0, ping: { name: data.name, message: data.message } };
+          }
+          if (data.type === "structured_output") {
+            return { reason: "structured_output", exitCode: 0, structuredOutput: data.value };
+          }
+          return { reason: "done", exitCode: 0 };
+        }
+      } catch (e: any) {
+        muxLog(
+          `[pollForExit] headless .exit check FAILED file=${exitFile} err=${e?.message ?? String(e)}\n`,
+        );
+      }
+    }
+
+    const elapsed = Math.floor((Date.now() - start) / 1000);
+    options.onTick?.(elapsed);
+
+    await new Promise<void>((resolve, reject) => {
+      if (signal.aborted) return reject(new Error("Aborted"));
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, options.interval);
+      function onAbort() {
+        clearTimeout(timer);
+        reject(new Error("Aborted"));
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}

--- a/packages/pi-terminal-mux/src/otty.ts
+++ b/packages/pi-terminal-mux/src/otty.ts
@@ -1,0 +1,766 @@
+/**
+ * otty.ts — Otty 终端模拟器 backend for pi-interactive-subagents
+ *
+ * Otty 是一个 macOS 终端模拟器（参见 https://otty.sh / https://docs.otty.sh）。
+ * 与 cmux / tmux / zellij / wezterm / herdr 类似，它通过 `otty` CLI 提供
+ * pane / tab / window 编程化控制能力。
+ *
+ * 与其他 backend 的关键差异：
+ *   1. Otty 不像 cmux 那样注入 `CMUX_SURFACE_ID`。当前 agent pane id 需要
+ *      通过 `otty panes --json` 查询 "active=true" 的 pane 来获取，并在
+ *      模块加载时冻结到常量。
+ *   2. `otty pane send-keys` 默认 disabled（需要 `ipc-allow-send-keys = true`）。
+ *      backend 启动时会检测该开关，未启用时 setup hint 提示用户。
+ *   3. `otty pane close --pane <id>` 在 v1.0.4 行为不稳定（实测仅打印 "Pane split"
+ *      但 pane 列表未变）。close 走 best-effort 路径：先 close pane，失败/超时
+ *      时降级为 close tab，最后兜底为 log warn 不 throw —— 避免 pollForExit 退出
+ *      流程被 close 错误打断。
+ *   4. pane id 是字符串（如 `p_19eefc5b4a2_11`），不像 tmux 是 `%12`。
+ *
+ * Otty 关键 IPC 接口（参见 https://docs.otty.sh/reference/cli）：
+ *   - `otty panes --json`                    列出所有 pane
+ *   - `otty pane split --direction <dir> --pane <id> --no-focus --command <cmd> --title <name>`
+ *   - `otty pane send-keys --pane <id> -- "..." key:Enter`
+ *   - `otty pane send-keys --pane <id> -- key:Escape`
+ *   - `otty pane capture --pane <id> --lines <N>`
+ *   - `otty pane close --pane <id> [--force]`
+ *   - `otty pane focus <id>`
+ *   - `otty tab list --json`                 列出所有 tab
+ *   - `otty tab rename --tab <tab_id> <title>`
+ *   - `otty tab close <tab_id>`
+ */
+
+import {
+  execFileSync,
+  execSync,
+  spawnSync,
+} from "node:child_process";
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { i18n } from "./i18n.ts";
+
+// ── 日志（otty 独立文件，便于区分后端） ──
+const OTTY_SPLIT_LOG = "/tmp/pi-otty-split.log";
+function ottyLog(msg: string): void {
+  try {
+    appendFileSync(OTTY_SPLIT_LOG, `[${new Date().toISOString()}] ${msg}`);
+  } catch {
+    /* 写日志失败不影响主流程 */
+  }
+}
+
+// ── 命令可用性缓存 ──
+
+const commandAvailability = new Map<string, boolean>();
+
+function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+  let available = false;
+  try {
+    execFileSync("which", [command], { stdio: "ignore" });
+    available = true;
+  } catch {
+    available = false;
+  }
+  commandAvailability.set(command, available);
+  return available;
+}
+
+// ── Otty 检测 ──
+
+/**
+ * 检测 otty backend 是否可用：
+ *   1. `otty` 命令在 PATH 中
+ *   2. 当前进程在 Otty 终端内运行（TERM_PROGRAM=otty）
+ *   3. Otty 应用正在运行（`otty panes --json` 成功）
+ *
+ * 注意：cwd 不在 `/Applications/Otty.app` 内（这是 app bundle 路径，
+ * Otty CLI 不在那里执行），所以只看 env 与 CLI 可用性。
+ */
+export function isOttyRuntimeAvailable(): boolean {
+  if (process.env.TERM_PROGRAM !== "otty") return false;
+  if (!hasCommand("otty")) return false;
+
+  // 最后一道闸：otty 命令存在但 app 没启动时 `otty panes` 会失败。
+  // 提前 200ms 超时探一下，避免后续每次调用都等满 3s。
+  try {
+    const result = spawnSync("otty", ["panes", "--json", "--timeout", "500"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.error || result.status !== 0) return false;
+    return Boolean(result.stdout.trim());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * send-keys 在 otty 默认 disabled。
+ * 提前检测一次（缓存），避免每次 sendCommand 都试一遍并抛错。
+ */
+let sendKeysEnabledCache: boolean | null = null;
+
+export function isOttySendKeysEnabled(): boolean {
+  if (sendKeysEnabledCache !== null) return sendKeysEnabledCache;
+  try {
+    // 用一个无害的"noop"探针：给 agent 自己 pane 发一个不会执行的 key:End + Escape
+    // 序列的低成本命令，或者直接探测配置项。
+    // 优先用 ipc 命令问 otty 是否允许 send-keys，避免触发误判。
+    // 退路：直接试一次 `pane send-keys` 看错误信息。
+    const result = spawnSync(
+      "otty",
+      ["pane", "send-keys", "--pane", getOttyAgentPaneId(), "--", "key:End"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const enabled = result.status === 0;
+    sendKeysEnabledCache = enabled;
+    if (!enabled) {
+      ottyLog(
+        `[otty detect] send-keys DISABLED stderr=${JSON.stringify(
+          (result.stderr ?? "").trim().slice(0, 200),
+        )}\n`,
+      );
+    }
+    return enabled;
+  } catch (e) {
+    sendKeysEnabledCache = false;
+    ottyLog(`[otty detect] send-keys probe failed: ${(e as Error).message}\n`);
+    return false;
+  }
+}
+
+// ── Agent pane id 缓存 ──
+
+/**
+ * 捕获于模块加载时的 agent pane id。
+ * Otty 不像 cmux 那样注入 surface id；需要在启动时通过 `otty panes --json`
+ * 找 `active=true` 的 pane 并冻结到常量。模块加载后再查 env 可能反映
+ * 用户切换焦点后的值（虽然这里走的是 IPC 而非 env，但为了一致性也冻结）。
+ *
+ * 如果暂时拿不到（Otty 刚启动、panes 还没列出来），返回 null，
+ * 调用方在第一次 createSurface 时重试。
+ */
+export const AGENT_OTTY_PANE_ID: string | null = (() => {
+  try {
+    const panes = readOttyPanes();
+    // active=true 是当前 focus pane。但用户启动 pi 后焦点可能在 pi pane，
+    // 也可能在另一个 pane —— 必须按 process 名称筛选。
+    const piPane = panes.find(
+      (p) =>
+        p.active &&
+        /(^|\s)(π|pi)($|\s|-)/i.test(p.process),
+    );
+    if (piPane) return piPane.id;
+    // 退路：取 active=true 的 pane（不严谨，但能跑）
+    const active = panes.find((p) => p.active);
+    return active?.id ?? null;
+  } catch (e) {
+    ottyLog(`[otty init] failed to capture agent pane id: ${(e as Error).message}\n`);
+    return null;
+  }
+})();
+
+/**
+ * 获取 agent pane id，必要时重试。
+ * 用于 AGENT_OTTY_PANE_ID 启动时为 null 的情况（panes 还没就绪），
+ * 以及 pane 失效后的 fallback。
+ */
+export function getOttyAgentPaneId(): string {
+  if (AGENT_OTTY_PANE_ID && ottyPaneExists(AGENT_OTTY_PANE_ID)) {
+    return AGENT_OTTY_PANE_ID;
+  }
+  // 重试一次
+  const refreshed = (() => {
+    try {
+      const panes = readOttyPanes();
+      const piPane = panes.find(
+        (p) => p.active && /(^|\s)(π|pi)($|\s|-)/i.test(p.process),
+      );
+      if (piPane) return piPane.id;
+      return panes.find((p) => p.active)?.id ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  if (refreshed) return refreshed;
+  throw new Error(
+    "Could not determine Otty agent pane id. " +
+      "Make sure Otty is running and `otty panes --json` returns a list.",
+  );
+}
+
+function ottyPaneExists(paneId: string): boolean {
+  try {
+    return readOttyPanes().some((p) => p.id === paneId);
+  } catch {
+    return false;
+  }
+}
+
+// ── Otty CLI 调用的薄封装 ──
+
+/**
+ * 调用 `otty` 命令并返回 stdout。
+ * 失败时 stderr 写入 log，原样抛错（调用方决定如何处理）。
+ */
+function ottyExec(args: string[]): string {
+  const cmdline = `otty ${args
+    .map((a) => (a.includes(" ") || a.includes('"') ? JSON.stringify(a) : a))
+    .join(" ")}`;
+  ottyLog(`[otty exec] ${cmdline}\n`);
+  const result = spawnSync("otty", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    ottyLog(`[otty exec] ERROR (spawn): ${result.error.message}\n`);
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? "").trim();
+    ottyLog(`[otty exec] ERROR status=${result.status} stderr=${JSON.stringify(stderr)}\n`);
+    throw new Error(`otty ${args[0]} failed (status=${result.status}): ${stderr}`);
+  }
+  ottyLog(`[otty exec] -> ${JSON.stringify(result.stdout.trim().slice(0, 200))}\n`);
+  return result.stdout;
+}
+
+/**
+ * 调用 `otty` 命令，丢弃 stdout。用于 sendCommand / sendKeys / closePane 这类
+ * 无输出的命令。
+ */
+function ottyExecSilent(args: string[]): void {
+  const cmdline = `otty ${args
+    .map((a) => (a.includes(" ") || a.includes('"') ? JSON.stringify(a) : a))
+    .join(" ")}`;
+  ottyLog(`[otty exec silent] ${cmdline}\n`);
+  const result = spawnSync("otty", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0) {
+    ottyLog(
+      `[otty exec silent] ERROR status=${result.status} stderr=${JSON.stringify(
+        (result.stderr ?? "").trim().slice(0, 200),
+      )}\n`,
+    );
+  }
+}
+
+// ── Pane 数据结构 ──
+
+export interface OttyPaneSnapshot {
+  id: string;
+  tab_id: string;
+  window_id: string;
+  index: number;
+  active: boolean;
+  cwd: string;
+  process: string;
+  cols: number;
+  rows: number;
+}
+
+interface OttyListResponse<T> {
+  ok: boolean;
+  command: string;
+  data: T;
+}
+
+export function parseOttyJson(output: string): unknown {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch (e) {
+    ottyLog(`[otty parse json] failed: ${(e as Error).message} raw=${JSON.stringify(trimmed.slice(0, 200))}\n`);
+    return null;
+  }
+}
+
+export function readOttyPanes(): OttyPaneSnapshot[] {
+  const raw = ottyExec(["panes", "--json"]);
+  const parsed = parseOttyJson(raw) as OttyListResponse<OttyPaneSnapshot[]> | null;
+  if (!parsed?.ok || !Array.isArray(parsed.data)) return [];
+  return parsed.data;
+}
+
+export function readOttyTabs(): Array<Record<string, unknown>> {
+  try {
+    const raw = ottyExec(["tab", "list", "--json"]);
+    const parsed = parseOttyJson(raw) as
+      | OttyListResponse<Array<Record<string, unknown>>>
+      | null;
+    if (!parsed?.ok || !Array.isArray(parsed.data)) return [];
+    return parsed.data;
+  } catch (e) {
+    ottyLog(`[otty tabs] list failed: ${(e as Error).message}\n`);
+    return [];
+  }
+}
+
+/**
+ * 从 pane id 解析 tab id。
+ * 优先走 `panes --json` 反查（无需走 tab list），回退到 panes-by-id 查找。
+ */
+export function getTabIdForPane(paneId: string): string | null {
+  try {
+    const pane = readOttyPanes().find((p) => p.id === paneId);
+    return pane?.tab_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── mux state 持久化 ──
+//
+// 与 muxy / herdr 同样的广度优先分屏策略：
+//   panes: 所有 subagent pane id 列表
+//   pos:   本轮下一个要 split 的索引
+//   base:  本轮开始时 pane 总数（本轮要分 base 个）
+//   dir:   当前方向（"right" | "down"）
+//
+// 第一轮：从 agent pane 向右分（pos=0, base=1）
+// 第二轮：从第一个 pane 向下分（pos=0, base=1）
+// 第三轮：第一个 pane 向右、第二个 pane 向右（pos=0, base=2）
+// ……
+// 每来一个 subagent：从 panes[pos] 拆 → 新 pane 追加到列表尾
+// pos 走完 base 个后 → 翻转方向，重置 pos，更新 base
+
+interface OttySplitState {
+  panes: string[];
+  pos: number;
+  base: number;
+  dir: "right" | "down";
+}
+
+function ottyStateFile(): string {
+  const agentId = AGENT_OTTY_PANE_ID ?? "default";
+  const safe = agentId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return `${tmpdir()}/otty-subagent-pane-${safe}.json`;
+}
+
+function ottyStateLockFile(): string {
+  return `${ottyStateFile()}.lock`;
+}
+
+function readOttyState(): OttySplitState {
+  try {
+    return JSON.parse(readFileSync(ottyStateFile(), "utf8"));
+  } catch {
+    return { panes: [], pos: 0, base: 0, dir: "right" };
+  }
+}
+
+function writeOttyState(state: OttySplitState): void {
+  writeFileSync(ottyStateFile(), JSON.stringify(state));
+}
+
+function acquireOttyLock(timeoutMs = 3000): boolean {
+  const lock = ottyStateLockFile();
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!existsSync(lock)) {
+      try {
+        writeFileSync(lock, `${process.pid}`, { flag: "wx" });
+        return true;
+      } catch {
+        /* 竞争失败，继续等 */
+      }
+    }
+    spawnSync("sleep", ["0.05"]);
+  }
+  return false;
+}
+
+function releaseOttyLock(): void {
+  try {
+    rmSync(ottyStateLockFile());
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * 找到 agent pane 之后的最新 pane id，用于 split 时作为父 pane。
+ *
+ * Otty 的 `pane split --pane <parent>` 把目标 pane 拆成两个，但返回的
+ * stdout 在 v1.0.4 不会输出新 pane id —— 必须通过比较 split 前后的
+ * `otty panes --json` 列表差集来推断。
+ *
+ * 为了避免并发竞争（两次 split 之间有人插队），先记下 split 前的 pane id 集合，
+ * split 后差集 = 新 pane id。
+ */
+function capturePaneIds(): Set<string> {
+  return new Set(readOttyPanes().map((p) => p.id));
+}
+
+function diffNewPane(before: Set<string>): string | null {
+  try {
+    const after = readOttyPanes();
+    const newOnes = after.filter((p) => !before.has(p.id));
+    if (newOnes.length === 0) return null;
+    if (newOnes.length === 1) return newOnes[0]!.id;
+    // 多于 1 个 → 取最后出现（split 后追加的通常在尾部）
+    ottyLog(
+      `[otty diff] multiple new panes after split: ${JSON.stringify(
+        newOnes.map((p) => p.id),
+      )}\n`,
+    );
+    return newOnes[newOnes.length - 1]!.id;
+  } catch (e) {
+    ottyLog(`[otty diff] failed: ${(e as Error).message}\n`);
+    return null;
+  }
+}
+
+// ── 对外 API：createSurface ──
+
+/**
+ * 创建一个新的 subagent pane。
+ *
+ * 实现：广度优先分屏（与 muxy / herdr 一致）。
+ * 第一次 split：从 agent pane 向右拆（--no-focus 保持 agent 焦点不变）。
+ * 后续 split：按 state 轮转 right/down，绕圈拆分已有 subagent pane。
+ *
+ * 已知问题：
+ *   - `otty pane split` v1.0.4 不返回新 pane id，必须靠 panes --json 差集推断。
+ *   - 若 agent pane 失效（用户切换到别的 tab），getOttyAgentPaneId() 会抛错，
+ *     createSurface 也跟着失败 —— 这是 fail-fast 设计，避免静默从错误位置拆。
+ */
+export function createOttySurface(name: string): string {
+  const agentId = getOttyAgentPaneId();
+
+  // send-keys 没开时无法在子 pane 里发送 Enter，必须改用 --command 注入启动命令。
+  // 见 sendOttyCommand 的注释。
+  if (!isOttySendKeysEnabled()) {
+    ottyLog(`[otty create] send-keys disabled; createSurface will succeed but pane will be empty until otty config enables it\n`);
+  }
+
+  if (!acquireOttyLock()) {
+    ottyLog(`[otty create] failed to acquire lock\n`);
+    return "";
+  }
+
+  try {
+    const state = readOttyState();
+
+    // ── 首次 split ──
+    if (state.panes.length === 0) {
+      const before = capturePaneIds();
+      try {
+        ottyExec([
+          "pane",
+          "split",
+          "--direction",
+          "right",
+          "--pane",
+          agentId,
+          "--no-focus",
+          "--title",
+          name,
+        ]);
+      } catch (e) {
+        ottyLog(`[otty create] first split failed: ${(e as Error).message}\n`);
+        return "";
+      }
+      const newId = diffNewPane(before);
+      if (!newId) {
+        ottyLog(`[otty create] first split produced no new pane id\n`);
+        return "";
+      }
+      state.panes = [newId];
+      state.pos = 0;
+      state.base = 1;
+      state.dir = "down";
+      writeOttyState(state);
+      // 改名 tab
+      renameOttyTab(newId, name);
+      ottyLog(
+        `[otty create] mode=first dir=right from=${agentId} new=${newId} name=${JSON.stringify(name)}\n`,
+      );
+      return newId;
+    }
+
+    // ── 后续 split：先判断本轮是否结束 ──
+    if (state.pos >= state.base) {
+      state.pos = 0;
+      state.base = state.panes.length;
+      state.dir = state.dir === "right" ? "down" : "right";
+    }
+
+    let target = state.panes[state.pos];
+    if (!target) {
+      ottyLog(`[otty create] state.panes[${state.pos}] is undefined, fallback to agent\n`);
+      target = agentId;
+    }
+
+    const before = capturePaneIds();
+    let splitSucceeded = false;
+    try {
+      ottyExec([
+        "pane",
+        "split",
+        "--direction",
+        state.dir,
+        "--pane",
+        target,
+        "--no-focus",
+        "--title",
+        name,
+      ]);
+      splitSucceeded = true;
+    } catch (e) {
+      // target 失效 → 重置 state，从 agent pane 重新拆
+      ottyLog(
+        `[otty create] pane ${target} gone (${(e as Error).message}), reset and retry from agent pane\n`,
+      );
+      try {
+        rmSync(ottyStateFile());
+      } catch {
+        /* ignore */
+      }
+      target = agentId;
+      try {
+        ottyExec([
+          "pane",
+          "split",
+          "--direction",
+          "right",
+          "--pane",
+          agentId,
+          "--no-focus",
+          "--title",
+          name,
+        ]);
+        splitSucceeded = true;
+      } catch (e2) {
+        ottyLog(`[otty create] reset split failed: ${(e2 as Error).message}\n`);
+        return "";
+      }
+    }
+
+    if (!splitSucceeded) return "";
+    const newId = diffNewPane(before);
+    if (!newId) {
+      ottyLog(`[otty create] next split produced no new pane id\n`);
+      return "";
+    }
+    state.panes.push(newId);
+    state.pos++;
+    writeOttyState(state);
+    renameOttyTab(newId, name);
+    ottyLog(
+      `[otty create] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=${target} new=${newId} name=${JSON.stringify(name)}\n`,
+    );
+    return newId;
+  } finally {
+    releaseOttyLock();
+  }
+}
+
+// ── 对外 API：pane 操作 ──
+
+/**
+ * 给 pane 发送命令 + Enter。
+ *
+ * 关键限制：otty `pane send-keys` 默认 disabled（`ipc-allow-send-keys = true`）。
+ * 若该选项未启用，本函数 noop + log warn，调用方应提示用户启用。
+ *
+ * 实现：使用 `pane send-keys --pane <id> -- "<text>" key:Enter`。
+ * send-keys 接受任意数量 PARTS，可混合文本与 `key:Enter` 这种命名 key。
+ */
+export function sendOttyCommand(paneId: string, command: string): void {
+  if (!isOttySendKeysEnabled()) {
+    ottyLog(
+      `[otty send] pane=${paneId} cmd=${JSON.stringify(
+        command.slice(0, 80),
+      )} SKIPPED (send-keys disabled)\n`,
+    );
+    return;
+  }
+  try {
+    ottyExecSilent(["pane", "send-keys", "--pane", paneId, "--", command, "key:Enter"]);
+  } catch (e) {
+    ottyLog(`[otty send] pane=${paneId} cmd failed: ${(e as Error).message}\n`);
+  }
+}
+
+/**
+ * 给 pane 发送 Escape。
+ * send-keys 支持 `key:Escape` 这种命名 key。
+ */
+export function sendOttyEscape(paneId: string): void {
+  if (!isOttySendKeysEnabled()) {
+    ottyLog(`[otty escape] pane=${paneId} SKIPPED (send-keys disabled)\n`);
+    return;
+  }
+  try {
+    ottyExecSilent(["pane", "send-keys", "--pane", paneId, "--", "key:Escape"]);
+  } catch (e) {
+    ottyLog(`[otty escape] pane=${paneId} failed: ${(e as Error).message}\n`);
+  }
+}
+
+/**
+ * 读取 pane 屏幕内容。
+ * `otty pane capture --pane <id> --lines <N>` 直接打印文本（非 JSON）。
+ */
+export function readOttyScreen(paneId: string, lines = 50): string {
+  try {
+    return ottyExec(["pane", "capture", "--pane", paneId, "--lines", String(lines)]);
+  } catch (e) {
+    ottyLog(`[otty read] pane=${paneId} failed: ${(e as Error).message}\n`);
+    return "";
+  }
+}
+
+/**
+ * 关闭 pane。
+ *
+ * v1.0.4 已知：直接 `pane close --pane <id>` 可能不生效。最佳策略：
+ *   1. 先 `pane close --pane <id> --force`
+ *   2. 100ms 后检查 pane 是否还在 panes 列表
+ *   3. 若仍在，且 tab 里**只有这一个 pane**（孤立 tab），尝试 `tab close --tab <tab_id>`
+ *      —— 关 tab 不会误伤其他 pane。
+ *   4. 若 tab 里还有其他 pane（如 agent 自己的 pane），跳过 fallback，
+ *      仅 log warn。否则会把 agent 自己的 pane 一起带走（参见实际事故：
+ *      用户在测试时执行 `otty tab close t_xxx`，把同一个 tab 里的 pi 也关了）。
+ *   5. 若都失败，log warn，不 throw（避免 pollForExit 退出流程被 close 错误打断）。
+ *
+ * 与 cmux/muxy 不同：otty 没有"我自己的 pane"概念，close 总是针对显式 id。
+ */
+export function closeOttySurface(paneId: string): void {
+  const beforeIds = capturePaneIds();
+  let closed = false;
+
+  // 1. pane close --force
+  try {
+    ottyExecSilent(["pane", "close", "--pane", paneId, "--force"]);
+    closed = true;
+  } catch (e) {
+    ottyLog(`[otty close] pane close failed: ${(e as Error).message}\n`);
+  }
+
+  // 2. 验证
+  if (closed && beforeIds.has(paneId)) {
+    spawnSync("sleep", ["0.1"]);
+    const stillThere = capturePaneIds().has(paneId);
+    if (!stillThere) {
+      ottyLog(`[otty close] pane ${paneId} closed via pane close --force\n`);
+      cleanupOttyStateForPane(paneId);
+      return;
+    }
+  }
+
+  // 3. fallback: 仅当 pane 是 tab 的唯一成员时才关整个 tab。
+  // 否则关 tab 会把 agent pane 等其他 pane 也带走（实际事故）。
+  ottyLog(`[otty close] pane close ineffective, considering tab close fallback\n`);
+  const tabId = getTabIdForPane(paneId);
+  if (tabId) {
+    let panesInTab: OttyPaneSnapshot[] = [];
+    try {
+      panesInTab = readOttyPanes().filter((p) => p.tab_id === tabId);
+    } catch {
+      panesInTab = [];
+    }
+    const isLonelyTab = panesInTab.length <= 1;
+    if (isLonelyTab) {
+      try {
+        ottyExecSilent(["tab", "close", tabId]);
+        ottyLog(`[otty close] tab ${tabId} closed (lonely tab, safe)\n`);
+      } catch (e) {
+        ottyLog(`[otty close] tab close failed: ${(e as Error).message}\n`);
+      }
+    } else {
+      ottyLog(
+        `[otty close] pane=${paneId} tab=${tabId} has ${panesInTab.length} panes; ` +
+          `skipping tab close to avoid clobbering other panes (agent pane is likely in this tab)\n`,
+      );
+    }
+  }
+  cleanupOttyStateForPane(paneId);
+}
+
+/**
+ * 重命名 pane 对应的 tab。
+ * Otty 没有"pane -> tab id"的直接命令（pane id 包含 workspace:pane number 但
+ * 没法直接拿 tab number），所以用 `panes --json` 反查 tab_id。
+ */
+export function renameOttyTab(paneId: string, name: string): void {
+  const tabId = getTabIdForPane(paneId);
+  if (!tabId) {
+    ottyLog(`[otty rename] pane=${paneId} no tab id found\n`);
+    return;
+  }
+  try {
+    ottyExecSilent(["tab", "rename", "--tab", tabId, name]);
+  } catch (e) {
+    ottyLog(
+      `[otty rename] pane=${paneId} tab=${tabId} name=${JSON.stringify(name)} failed: ${
+        (e as Error).message
+      }\n`,
+    );
+  }
+}
+
+/**
+ * 从 mux state marker 中清理已关闭的 pane。
+ * 与 muxy / herdr 的 close 行为一致：避免僵尸 ID 累积导致后续 split 走错目标。
+ */
+function cleanupOttyStateForPane(paneId: string): void {
+  try {
+    const parsed = readOttyState();
+    const idx = parsed.panes.indexOf(paneId);
+    if (idx < 0) return;
+    const beforePanes = [...parsed.panes];
+    const beforePos = parsed.pos;
+    parsed.panes.splice(idx, 1);
+    if (typeof parsed.pos === "number" && idx < parsed.pos) {
+      parsed.pos = Math.max(0, parsed.pos - 1);
+    }
+    if (parsed.panes.length === 0) {
+      try {
+        rmSync(ottyStateFile());
+      } catch {
+        /* ignore */
+      }
+      ottyLog(
+        `[otty close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
+      );
+    } else {
+      writeOttyState(parsed);
+      ottyLog(
+        `[otty close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(
+          parsed.panes,
+        )} pos=${beforePos} -> ${parsed.pos}\n`,
+      );
+    }
+  } catch {
+    /* no marker or parse error, nothing to clean */
+  }
+}
+
+// ── Setup hint ──
+
+/**
+ * Otty setup hint —— 用户没在 Otty 终端内 / 没启用 send-keys 时提示。
+ *
+ * 注意：TERM_PROGRAM=otty 已经检查通过才会调用本函数。
+ * 这里只补充 send-keys 开关和 pane 创建失败的提示。
+ */
+export function ottySetupHint(): string {
+  if (!isOttySendKeysEnabled()) {
+    return i18n.t("setupHint.ottySendKeys");
+  }
+  return "";
+}

--- a/packages/pi-terminal-mux/tests/mux.test.ts
+++ b/packages/pi-terminal-mux/tests/mux.test.ts
@@ -1,0 +1,238 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  shellEscape,
+  isFishShell,
+  exitStatusVar,
+  isHeadlessSurface,
+  createHeadlessSurface,
+  isHeadlessMode,
+  getMuxBackend,
+  muxSetupHint,
+  parseCmuxJson,
+  parseCmuxFocusedSnapshot,
+  parseCmuxFocusedSnapshotFromJson,
+  parseCmuxPaneRefForSurface,
+  parseCmuxPaneRefForSurfaceFromJson,
+  predictZellijSplitDirection,
+  canSplitZellijPane,
+  selectZellijPlacement,
+  selectZellijStackPlacement,
+  getAgentPaneId,
+  type ZellijPaneSnapshot,
+} from "../src/index.ts";
+
+/** 保存并清理会干扰探测的环境变量 */
+const MUX_ENV_KEYS = [
+  "MUXY_SOCKET_PATH",
+  "CMUX_SOCKET_PATH",
+  "TMUX",
+  "ZELLIJ",
+  "ZELLIJ_SESSION_NAME",
+  "WEZTERM_UNIX_SOCKET",
+  "HERDR_ENV",
+  "HERDR_PANE_ID",
+  "TERM_PROGRAM",
+  "PI_TERMINAL_MUX",
+  "PI_SUBAGENT_MUX",
+  "PI_EXTENSIONS_LOCALE",
+];
+
+let savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedEnv = {};
+  for (const key of MUX_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of MUX_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe("shellEscape", () => {
+  test("普通字符串加单引号", () => {
+    assert.equal(shellEscape("abc"), "'abc'");
+  });
+  test("单引号转义", () => {
+    assert.equal(shellEscape("a'b"), "'a'\\''b'");
+  });
+  test("空字符串", () => {
+    assert.equal(shellEscape(""), "''");
+  });
+});
+
+describe("shell 检测", () => {
+  test("fish shell 用 $status", () => {
+    const saved = process.env.SHELL;
+    process.env.SHELL = "/opt/homebrew/bin/fish";
+    assert.equal(isFishShell(), true);
+    assert.equal(exitStatusVar(), "$status");
+    process.env.SHELL = saved;
+  });
+  test("bash 用 $?", () => {
+    const saved = process.env.SHELL;
+    process.env.SHELL = "/bin/bash";
+    assert.equal(isFishShell(), false);
+    assert.equal(exitStatusVar(), "$?");
+    process.env.SHELL = saved;
+  });
+});
+
+describe("headless surface", () => {
+  test("createHeadlessSurface 返回 headless: 前缀", () => {
+    const surface = createHeadlessSurface("t");
+    assert.ok(surface.startsWith("headless:"));
+    assert.equal(isHeadlessSurface(surface), true);
+  });
+  test("干净环境下无可用后端", () => {
+    assert.equal(getMuxBackend(), null);
+    assert.equal(isHeadlessMode(), true);
+  });
+});
+
+describe("后端偏好", () => {
+  test("PI_TERMINAL_MUX 指定但运行环境不满足时返回 null", () => {
+    process.env.PI_TERMINAL_MUX = "tmux";
+    assert.equal(getMuxBackend(), null);
+  });
+  test("PI_SUBAGENT_MUX 作为兼容别名生效", () => {
+    process.env.PI_SUBAGENT_MUX = "tmux";
+    process.env.TMUX = "/tmp/tmux-1000/default,1,0";
+    // tmux 命令不一定存在，只验证偏好解析不抛错
+    const backend = getMuxBackend();
+    assert.ok(backend === null || backend === "tmux");
+  });
+});
+
+describe("muxSetupHint i18n", () => {
+  test("中文提示", () => {
+    process.env.PI_EXTENSIONS_LOCALE = "zh-CN";
+    process.env.PI_TERMINAL_MUX = "tmux";
+    assert.match(muxSetupHint(), /请在 tmux 中启动 pi/);
+  });
+  test("英文提示", () => {
+    process.env.PI_EXTENSIONS_LOCALE = "en-US";
+    process.env.PI_TERMINAL_MUX = "tmux";
+    assert.match(muxSetupHint(), /Start pi inside tmux/);
+  });
+  test("无偏好时返回通用提示", () => {
+    process.env.PI_EXTENSIONS_LOCALE = "en-US";
+    assert.match(muxSetupHint(), /WezTerm/);
+  });
+});
+
+describe("cmux JSON 解析", () => {
+  test("parseCmuxJson 容错", () => {
+    assert.equal(parseCmuxJson("not json"), null);
+    assert.deepEqual(parseCmuxJson('{"a":1}'), { a: 1 });
+  });
+  test("parseCmuxFocusedSnapshot", () => {
+    assert.equal(parseCmuxFocusedSnapshot(null), null);
+    assert.equal(parseCmuxFocusedSnapshot({}), null);
+    assert.deepEqual(
+      parseCmuxFocusedSnapshot({ focused: { surface_ref: "surface:1", pane_ref: "pane:2" } }),
+      { surfaceRef: "surface:1", paneRef: "pane:2" },
+    );
+  });
+  test("parseCmuxFocusedSnapshotFromJson", () => {
+    assert.deepEqual(
+      parseCmuxFocusedSnapshotFromJson('{"focused":{"surface_ref":"surface:9"}}'),
+      { surfaceRef: "surface:9", paneRef: undefined },
+    );
+  });
+  test("parseCmuxPaneRefForSurface 匹配 surface_ref", () => {
+    assert.equal(
+      parseCmuxPaneRefForSurface({ surface_ref: "surface:3", pane_ref: "pane:7" }, "surface:3"),
+      "pane:7",
+    );
+    assert.equal(
+      parseCmuxPaneRefForSurface({ surface_ref: "surface:3", pane_ref: "pane:7" }, "surface:4"),
+      null,
+    );
+  });
+  test("parseCmuxPaneRefForSurface 匹配 caller", () => {
+    assert.equal(
+      parseCmuxPaneRefForSurfaceFromJson(
+        '{"caller":{"surface_ref":"surface:5","pane_ref":"pane:11"}}',
+        "surface:5",
+      ),
+      "pane:11",
+    );
+  });
+});
+
+describe("zellij 放置规划", () => {
+  const pane = (over: Partial<ZellijPaneSnapshot>): ZellijPaneSnapshot => ({
+    id: 1,
+    is_plugin: false,
+    is_floating: false,
+    is_selectable: true,
+    exited: false,
+    pane_rows: 24,
+    pane_columns: 80,
+    tab_id: 1,
+    ...over,
+  });
+
+  test("宽 pane 预测向右分", () => {
+    assert.equal(predictZellijSplitDirection(pane({ pane_columns: 100, pane_rows: 20 })), "right");
+  });
+  test("高 pane 预测向下分", () => {
+    assert.equal(predictZellijSplitDirection(pane({ pane_columns: 20, pane_rows: 30 })), "down");
+  });
+  test("太小不可分", () => {
+    assert.equal(predictZellijSplitDirection(pane({ pane_columns: 4, pane_rows: 4 })), null);
+    assert.equal(canSplitZellijPane(pane({ pane_columns: 4, pane_rows: 4 })), false);
+  });
+  test("无其他 pane 时 stack 返回 null", () => {
+    assert.equal(selectZellijStackPlacement([pane({ id: 1 })], 1), null);
+  });
+  test("有可分 pane 时选择 split", () => {
+    const panes = [pane({ id: 1, pane_columns: 200, pane_rows: 50 })];
+    const plan = selectZellijPlacement(panes, 1, 50, 10);
+    assert.equal(plan?.mode, "split");
+    if (plan?.mode === "split") {
+      assert.equal(plan.splitDirection, "right");
+      assert.equal(plan.anchorPaneId, 1);
+    }
+  });
+  test("pane 太小不满足最小尺寸时退化为 stack", () => {
+    // 两个 pane：zellij 自身最小尺寸可分，但分完小于 50x10，应选 stack 到面积最大的非 parent pane
+    const panes = [
+      pane({ id: 1, pane_columns: 40, pane_rows: 20 }),
+      pane({ id: 2, pane_columns: 60, pane_rows: 15 }),
+    ];
+    const plan = selectZellijPlacement(panes, 1, 50, 10);
+    assert.equal(plan?.mode, "stack");
+    if (plan?.mode === "stack") {
+      assert.equal(plan.anchorPaneId, 2);
+    }
+  });
+  test("plugin/floating/exited pane 不参与", () => {
+    const panes = [
+      pane({ id: 1, pane_columns: 200, pane_rows: 50 }),
+      pane({ id: 2, is_plugin: true, pane_columns: 200, pane_rows: 50 }),
+    ];
+    assert.equal(selectZellijStackPlacement(panes, 1), null);
+  });
+});
+
+describe("getAgentPaneId", () => {
+  test("无后端时返回 null", () => {
+    assert.equal(getAgentPaneId(), null);
+    assert.equal(getAgentPaneId(null), null);
+  });
+  test("tmux 后端读 TMUX_PANE", () => {
+    const saved = process.env.TMUX_PANE;
+    process.env.TMUX_PANE = "%42";
+    assert.equal(getAgentPaneId("tmux"), "%42");
+    if (saved === undefined) delete process.env.TMUX_PANE;
+    else process.env.TMUX_PANE = saved;
+  });
+});

--- a/packages/pi-terminal-mux/tsconfig.json
+++ b/packages/pi-terminal-mux/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
     "packages/pi-extensions-i18n": {},
     "packages/pi-distill": {},
     "packages/pi-tool-supervisor": {},
-    "packages/pi-extensions-tool-display": {}
+    "packages/pi-extensions-tool-display": {},
+    "packages/pi-terminal-mux": {}
   }
 }


### PR DESCRIPTION
## 背景

`pi-interactive-subagents` 的 `cmux.ts`/`herdr.ts`/`otty.ts`（约 3300 行）是完整的终端多路复用器实现，但只能被它自己用；`pi-workspace-tools` 里又重复造了一份只支持 muxy/herdr 的轮子。本 PR 把这套能力抽成独立公开包，后续所有涉及终端交互的插件统一复用。

## 内容

- 统一 surface API 跨 **muxy / cmux / tmux / zellij / wezterm / herdr / otty** 七后端，探测不到时 **headless 降级**（后台子进程 + 日志文件）
  - `createSurface` / `createSurfaceSplit` / `sendCommand` / `sendLongCommand` / `sendEscape` / `readScreen(Async)` / `closeSurface` / `renameSurface` / `pollForExit`
- 相对原始代码的增量：
  - `PI_TERMINAL_MUX` 后端偏好变量（`PI_SUBAGENT_MUX` 保留兼容别名）
  - **修复**：原 `createSurfaceSplit` 缺 herdr 分支，herdr 下会跌落 zellij 命令；新增 `splitHerdrPane` 补齐
  - 新增统一 `renameSurface()`、`getAgentPaneId()`、`backendAgentPaneEnvVar()`
  - setup hint 走 `pi-extensions-i18n` catalog（中英双语）
- 26 个单元测试（纯函数：zellij 放置规划 / cmux JSON 解析 / shellEscape / headless / 后端偏好 / i18n hint）
- 双语 README、release-please 注册、仓级 AGENTS.md 更新

## 验证

- [x] `npm run check`（typecheck + 26/26 测试 + 本机解耦门禁 + i18n key 对齐）全绿
- [x] 消费方 `pi-interactive-subagents`（npm link）116/116 单测通过
- [x] 消费方 `pi-workspace-tools`（npm link）typecheck 通过

## 合并顺序

**本仓先合并并发布 `pi-terminal-mux@0.1.0`**，以下两个仓才能从 registry 安装：
- maplezzk/PiExtensions（pi-workspace-tools 迁移）
- maplezzk/pi-interactive-subagents（删除 cmux/herdr/otty.ts 改为依赖本包）