### PR TITLE
ci: release.yml 发布矩阵加入 pi-terminal-mux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           - dir: packages/pi-distill
           - dir: packages/pi-tool-supervisor
           - dir: packages/pi-extensions-tool-display
+          - dir: packages/pi-terminal-mux
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
首发时 `pi-terminal-mux` 尚未在 npm 存在（trusted publisher 需包已存在才能配置），故 `pi-terminal-mux-v0.2.0` 由本地手动首发。

本 PR 把 `packages/pi-terminal-mux` 加入 release.yml 发布矩阵。合并 + npm 网页配置好 trusted publisher 后，后续版本发布全自动（OIDC，免 token）。

⚠️ 合并时机：建议在 npm 上完成首发 + trusted publisher 配置之后，避免下次 release 时 job 红掉。