### PR TITLE
fix(pi-terminal-mux): 导出 package.json subpath 并触发 0.2.1 发布

### DIFF
--- a/packages/pi-terminal-mux/package.json
+++ b/packages/pi-terminal-mux/package.json
@@ -6,6 +6,7 @@
   "main": "./index.ts",
   "exports": {
     ".": "./index.ts",
+    "./package.json": "./package.json",
     "./mux": "./src/mux.ts",
     "./herdr": "./src/herdr.ts",
     "./otty": "./src/otty.ts"


### PR DESCRIPTION
## 动机

#28 的 `refactor` 提交不被 release-please 视为 user-facing，npm 上仍是旧结构的 `0.2.0`。本机只能 `npm link` 才能吃到拆分后的源码。

## 改动

- `exports` 增加 `./package.json`，修复 `require('pi-terminal-mux/package.json')` 的 `ERR_PACKAGE_PATH_NOT_EXPORTED`
- 用 `fix:` 触发 release-please 发 `0.2.1`，把 #28 的 backends 拆分结构正式推到 registry

## 验证

- [x] `npm run check` 26/26 绿