### PR TITLE
fix(pi-distill): remove redundant file dumping, defer to Pi native output limiting

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -33,7 +33,7 @@ The distillation prompt strictly follows the current locale selected by `/pi-lan
 - Treats a prompt containing only `RAW` as an explicit request for the original output.
 - Uses the current session model by default, or a configured `provider/model` override.
 - Keeps diagnostic metadata such as status, character counts, compression ratio, duration, and anomalies in the tool result details.
-- Writes oversized distilled output or final output to a temporary file and returns its path instead of overflowing the tool result.
+- Oversized output is no longer written to a file or truncated by pi-distill; it is left to Pi's own output-limiting mechanism.
 - Adds a compact audit card when the active Pi display middleware is available, with a fallback renderer otherwise. The shared display protocol is provided by `pi-extensions-tool-display`.
 
 It does not register a second `bash`, `read`, `grep`, or `find` tool.
@@ -117,7 +117,7 @@ Agent consumes a result suited to the current decision, with auditable diagnosti
 | `outputRequest` | Behavior | Use it when |
 | --- | --- | --- |
 | Omitted | Invalid tool call; Pi rejects the call before the underlying tool runs | Never omit it; use `RAW` when no compression is explicitly requested |
-| Exactly `RAW` (case-insensitive) | Skip the distillation model and keep the complete original text; oversized text is returned through a file path | You need to inspect, copy, or verify exact output |
+| Exactly `RAW` (case-insensitive) | Skip the distillation model and keep the complete original text; oversized text is handled by Pi's own output-limiting mechanism | You need to inspect, copy, or verify exact output |
 | Any non-empty value other than `RAW` | Call the model once the output reaches the threshold; the prompt defines what to retain | “Keep errors, warnings, and final status” workflows |
 | Any non-text content such as images or audio | Preserve the result as-is; do not send it to the distillation model or apply text truncation | Image reads, binary results, and mixed text/media results |
 
@@ -138,7 +138,7 @@ The distillation prompt strictly follows the locale selected by `/pi-language`:
 - Registers no replacement tools, does not change tool execution semantics, and does not require a separately installed `pi-tool-display` host package.
 - Text distillation is lossy; use `RAW` when completeness matters.
 - Non-text results are a completeness boundary: images, audio, binary data, and mixed content bypass text distillation.
-- Oversized distilled or final text is written to a temporary file and represented by its path, preventing unbounded context growth.
+- Oversized distilled or final text is no longer written to a file or truncated by pi-distill; it is left to Pi's own output-limiting mechanism, preventing unbounded context growth.
 - If no model is available, distillation fails open: the original result is retained and Pi can continue running.
 
 ## Configuration
@@ -157,7 +157,6 @@ Start from [`config.example.json`](./config.example.json):
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
-  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
@@ -175,14 +174,13 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | --- | --- |
 | `model` | Optional `provider/model`; empty uses the current Pi session model. |
 | `minChars` | Minimum output size before a summary is requested. |
-| `maxChars` | Maximum size of the model's distilled result before it is written to a file. |
-| `maxOutputChars` | Maximum text size returned to the agent; larger results are written to a file. |
+| `maxChars` | Maximum output budget for the distillation model (about `maxChars / 2` tokens) and a diagnostic reference; no longer used to write files. |
 | `timeoutSeconds` | Maximum time allowed for the distillation model call. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
 | `summarizeErrors` | Whether error results should still be sent to the distillation model. |
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
-The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_MAX_OUTPUT_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`.
+The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`. The legacy `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` option is still parsed for backward compatibility but no longer has any effect.
 
 ## Requirements
 

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -33,7 +33,7 @@
 - 当提示词严格只有 `RAW` 时，视为明确要求返回原始输出。
 - 默认使用当前会话模型，也可以配置独立的 `provider/model`。
 - 在工具结果 details 中保留状态、字符数、压缩比、耗时和异常等诊断信息。
-- 提炼结果或最终返回结果过大时写入临时文件，只把文件路径返回给 Agent，避免工具结果失控膨胀。
+- 超长输出不再由 pi-distill 写文件或截断，统一交由 Pi 自身的输出限制机制处理。
 - 当前 Pi 展示中间件可用时显示紧凑审计卡片，否则使用自己的 fallback renderer。展示协议由公共运行库 `pi-extensions-tool-display` 提供。
 
 它不会注册第二个 `bash`、`read`、`grep` 或 `find` 工具。
@@ -103,7 +103,7 @@ Agent 提出处理目标
         ↓ 通过 outputRequest 传给工具
 工具执行真实操作，返回 stdout / stderr / 文件内容 / 多媒体结果
         ↓
-pi-distill 根据真实结果和配置决定：原样返回、调用模型提炼，或写入文件
+pi-distill 根据真实结果和配置决定：原样返回，或调用模型提炼
         ↓
 Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 ```
@@ -119,7 +119,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | `outputRequest` | 行为 | 适用场景 |
 | --- | --- | --- |
 | 未提供 | 工具调用无效；Pi 会在底层工具执行前拒绝该调用 | 不要省略；未明确要求压缩时使用 `RAW` |
-| 严格为 `RAW`（大小写不敏感） | 不调用提炼模型，保留完整原始文本；如超出返回上限则返回原文文件路径 | 逐字核对、复制内容、需要完整日志时 |
+| 严格为 `RAW`（大小写不敏感） | 不调用提炼模型，保留完整原始文本；超长时由 Pi 自身的输出限制机制处理 | 逐字核对、复制内容、需要完整日志时 |
 | 任意非空且非 `RAW` | 输出达到阈值后调用模型，具体保留内容由 prompt 决定 | “只保留错误、警告和最终状态”等场景 |
 | 包含图片、音频或其他非文本内容 | 原样保留，不发送给提炼模型，不做文本长度截断 | 图片读取、二进制结果、混合文本与图片结果 |
 
@@ -140,7 +140,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 - 不注册替代工具，不改变原工具的执行语义，也不要求额外安装独立的 `pi-tool-display` 宿主包。
 - 文本提炼是有损操作；完整性要求应使用 `RAW`。
 - 非文本结果是完整性边界：图片、音频、二进制和混合 content 不进入文本提炼链路。
-- 提炼结果或最终文本过大时写入临时文件并返回路径，避免上下文无限膨胀。
+- 超长输出不再由 pi-distill 写临时文件或截断，统一交由 Pi 自身的输出限制机制处理，避免上下文无限膨胀。
 - 当前会话没有模型时，提炼会失败并保留原始结果，不阻止 Pi 启动。
 
 ## 配置
@@ -159,7 +159,6 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
-  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
@@ -177,14 +176,13 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | --- | --- |
 | `model` | 可选的 `provider/model`；为空时使用当前 Pi 会话模型。 |
 | `minChars` | 达到此输出长度后才请求提炼。 |
-| `maxChars` | 模型提炼结果超过此长度时写入文件。 |
-| `maxOutputChars` | 返回给 Agent 的最大文本长度，超出后写入文件。 |
+| `maxChars` | 提炼模型的最大输出预算（约 `maxChars / 2` tokens），同时作为诊断参考；不再用于写文件。 |
 | `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
 | `summarizeErrors` | 工具返回错误时是否仍发送给提炼模型。 |
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
-主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_MAX_OUTPUT_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。
+主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。旧配置中的 `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` 仍会被解析以兼容旧文件，但不再生效。
 
 ## 要求
 

--- a/packages/pi-distill/config.example.json
+++ b/packages/pi-distill/config.example.json
@@ -3,7 +3,6 @@
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
-  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,

--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -63,10 +63,6 @@
     "zh-CN": "摘要上限：{value} 字符",
     "en-US": "Summary limit: {value} chars"
   },
-  "finalLimit": {
-    "zh-CN": "最终输出上限：{value} 字符",
-    "en-US": "Final output limit: {value} chars"
-  },
   "timeout": {
     "zh-CN": "超时：{value}s",
     "en-US": "Timeout: {value}s"
@@ -98,10 +94,6 @@
   "summaryLimitTitle": {
     "zh-CN": "摘要字符上限",
     "en-US": "Summary character limit"
-  },
-  "finalLimitTitle": {
-    "zh-CN": "最终输出字符上限",
-    "en-US": "Final output character limit"
   },
   "timeoutTitle": {
     "zh-CN": "提炼模型超时（秒）",

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -6,14 +6,13 @@
  *
  * 所有工具统一使用 outputRequest：严格传入 RAW 时返回原始输出；其他非空
  * outputRequest 表示调用提炼模型，具体保留内容由 outputRequest 决定。
- * 提炼结果超过 maxChars 时写入临时文件，只返回文件路径。
+ * 超长输出由 Pi 自身的 output-limit 机制处理，pi-distill 不再做文件转储或截断。
  *
  * 配置文件优先；旧环境变量继续兼容：
  * - ~/.pi/agent/extensions/pi-distill/config.json
  * - PI_DISTILL_MODEL=provider/model
  * - PI_DISTILL_MIN_CHARS=触发提炼的最小输出字符数，默认 200
- * - PI_DISTILL_MAX_CHARS=提炼结果超过此字符数时写入文件，默认 100000
- * - PI_DISTILL_MAX_OUTPUT_CHARS=最终返回内容超过此字符数时写入文件，默认 10000
+ * - PI_DISTILL_MAX_CHARS=提炼模型最大输出字符数，默认 100000
  * - PI_DISTILL_TIMEOUT_SECONDS=模型调用最长等待秒数，默认 10
  * - PI_DISTILL_MISSED_COMPRESSION_RATIO=长输出提醒倍数，默认 10
  * - 旧 PI_BASH_SUMMARY_* 变量作为兼容回退
@@ -36,10 +35,9 @@ import {
   isDistillToolDisplayMiddlewareActive,
   registerDistillToolDisplayMiddleware,
 } from "./tool-display-bridge.ts";
-import { getTextContent, hasNonTextContent, limitReturnedToolResult } from "./output-limit.ts";
+import { getTextContent, hasNonTextContent } from "./output-limit.ts";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import { createTranslator, loadCatalog } from "pi-extensions-i18n";
 import {
   buildSummaryPrompt,
@@ -91,7 +89,6 @@ const OUTPUT_REQUEST_SYSTEM_GUIDELINE = i18n.t("outputRequestSystemGuideline");
 type SummaryResult = {
   text: string;
   summaryChars: number;
-  summaryFilePath?: string;
   summaryModel: string;
 };
 
@@ -229,17 +226,6 @@ async function getCompleteOutput(result: ToolResult): Promise<string> {
   return getTextContent(result);
 }
 
-async function writeSummaryFile(summary: string): Promise<string> {
-  const directory = join(tmpdir(), "pi-distill");
-  await mkdir(directory, { recursive: true });
-  const filePath = join(
-    directory,
-    `summary-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
-  );
-  await writeFile(filePath, summary, "utf8");
-  return filePath;
-}
-
 async function summarizeOutput(
   prompt: string,
   output: string,
@@ -293,19 +279,9 @@ async function summarizeOutput(
     .trim();
 
   if (!summary) throw new Error("Summarizer returned no text");
-  if (summary.length <= config.maxChars) {
-    return {
-      text: summary,
-      summaryChars: summary.length,
-      summaryModel: `${model.provider}/${model.id}`,
-    };
-  }
-
-  const summaryFilePath = await writeSummaryFile(summary);
   return {
-    text: `Summary exceeded ${config.maxChars} chars and was written to: ${summaryFilePath}`,
+    text: summary,
     summaryChars: summary.length,
-    summaryFilePath,
     summaryModel: `${model.provider}/${model.id}`,
   };
 }
@@ -325,9 +301,6 @@ async function processToolResult(
   const loaded = loadDistillConfig();
   const config = loaded.config;
   const outputSummaryRender = { ...loaded.render };
-  const maxReturnedChars = config?.maxOutputChars ?? 10_000;
-  const finish = (candidate: ToolResult) =>
-    limitReturnedToolResult(candidate, maxReturnedChars);
   if (loaded.warnings.length > 0) {
     console.warn(`[pi-distill] ${loaded.warnings.join(" | ")}`);
   }
@@ -354,12 +327,12 @@ async function processToolResult(
           : "Distill is disabled by configuration.",
     };
     const agentDiagnostic = buildAgentDiagnosticText(diagnostics);
-    return finish({
+    return {
       ...attachDiagnostics(result, diagnostics),
       content: agentDiagnostic
         ? [...result.content, { type: "text", text: agentDiagnostic }]
         : result.content,
-    });
+    };
   }
 
   let output: string;
@@ -369,7 +342,7 @@ async function processToolResult(
     console.warn(
       `[tool-output-summary] ${context.toolName} could not read the full output; returning the original result: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return finish(attachDiagnostics(result, {
+    return attachDiagnostics(result, {
       toolExecutionMs,
       outputSummaryPrompt: prompt || undefined,
       outputSummaryRender,
@@ -378,7 +351,7 @@ async function processToolResult(
       summaryTriggerMaxChars: null,
       summaryResultMaxChars: config.maxChars,
       missedCompressionRatio: config.missedCompressionRatio,
-    }));
+    });
   }
 
   const decision = decideOutputSummary(prompt, output, config, result.isError === true);
@@ -404,7 +377,7 @@ async function processToolResult(
         ? [...result.content, { type: "text", text: agentDiagnostic }]
         : result.content,
     };
-    return finish(candidate);
+    return candidate;
   }
 
   const summaryStartedAt = performance.now();
@@ -451,7 +424,7 @@ async function processToolResult(
           ...(agentDiagnostic ? [{ type: "text", text: agentDiagnostic }] : []),
         ],
       };
-      return finish(candidate);
+      return candidate;
     }
     const compressionDiagnostics = getCompressionDiagnostics(
       decision.intent,
@@ -465,7 +438,7 @@ async function processToolResult(
     };
     const agentDiagnostic = buildAgentDiagnosticText(diagnostics);
 
-    return finish({
+    return {
       // 输出处理参数只影响结果上下文，不改变原工具的业务执行。
       // 异常诊断额外作为文本传给 Agent；普通成功总结不增加噪音。
       content: [
@@ -486,10 +459,9 @@ async function processToolResult(
         missedCompressionRatio: config.missedCompressionRatio,
         summaryModel: summarized.summaryModel,
         summaryText: summarized.text,
-        summaryFilePath: summarized.summaryFilePath,
         ...diagnostics,
       },
-    });
+    };
   } catch (error) {
     const summaryDurationMs = Math.round(performance.now() - summaryStartedAt);
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -520,7 +492,7 @@ async function processToolResult(
         ? [...result.content, { type: "text", text: agentDiagnostic }]
         : result.content,
     };
-    return finish(candidate);
+    return candidate;
   } finally {
     clearTimeout(timeout);
     context.signal?.removeEventListener("abort", abortFromParent);
@@ -575,7 +547,7 @@ function toToolResultEventResult(result: ToolResult): ToolResultEventPatch {
   };
 }
 
-type DistillUiConfig = Required<Pick<DistillConfigFile, "enabled" | "model" | "minChars" | "maxChars" | "maxOutputChars" | "timeoutSeconds" | "missedCompressionRatio" | "summarizeErrors">> & {
+type DistillUiConfig = Required<Pick<DistillConfigFile, "enabled" | "model" | "minChars" | "maxChars" | "timeoutSeconds" | "missedCompressionRatio" | "summarizeErrors">> & {
   render: DistillRenderConfig;
 };
 
@@ -589,7 +561,6 @@ function getDistillUiConfig(): DistillUiConfig {
       : "",
     minChars: config?.minChars ?? 200,
     maxChars: config?.maxChars ?? 100_000,
-    maxOutputChars: config?.maxOutputChars ?? 10_000,
     timeoutSeconds: config?.timeoutSeconds ?? 10,
     missedCompressionRatio: config?.missedCompressionRatio ?? 10,
     summarizeErrors: config?.summarizeErrors ?? true,
@@ -654,7 +625,6 @@ async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: stri
       i18n.t("model", { value: config.model || i18n.t("currentModel") }),
       i18n.t("minOutput", { value: config.minChars }),
       i18n.t("summaryLimit", { value: config.maxChars }),
-      i18n.t("finalLimit", { value: config.maxOutputChars }),
       i18n.t("timeout", { value: config.timeoutSeconds }),
       i18n.t("threshold", { value: config.missedCompressionRatio }),
       i18n.t("summarizeErrors", { value: config.summarizeErrors ? i18n.t("on") : i18n.t("off") }),
@@ -687,33 +657,27 @@ async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: stri
         await saveDistillConfigFile(ctx, config, configPath);
       }
     } else if (choice === choices[4]) {
-      const value = await editDistillNumber(ctx, i18n.t("finalLimitTitle"), config.maxOutputChars);
-      if (value !== undefined) {
-        config.maxOutputChars = value;
-        await saveDistillConfigFile(ctx, config, configPath);
-      }
-    } else if (choice === choices[5]) {
       const value = await editDistillNumber(ctx, i18n.t("timeoutTitle"), config.timeoutSeconds);
       if (value !== undefined) {
         config.timeoutSeconds = value;
         await saveDistillConfigFile(ctx, config, configPath);
       }
-    } else if (choice === choices[6]) {
+    } else if (choice === choices[5]) {
       const value = await editDistillNumber(ctx, i18n.t("thresholdTitle"), config.missedCompressionRatio);
       if (value !== undefined) {
         config.missedCompressionRatio = value;
         await saveDistillConfigFile(ctx, config, configPath);
       }
-    } else if (choice === choices[7]) {
+    } else if (choice === choices[6]) {
       config.summarizeErrors = !config.summarizeErrors;
       await saveDistillConfigFile(ctx, config, configPath);
-    } else if (choice === choices[8]) {
+    } else if (choice === choices[7]) {
       config.render.enabled = !config.render.enabled;
       await saveDistillConfigFile(ctx, config, configPath);
-    } else if (choice === choices[9]) {
+    } else if (choice === choices[8]) {
       config.render.showPrompt = !config.render.showPrompt;
       await saveDistillConfigFile(ctx, config, configPath);
-    } else if (choice === choices[10]) {
+    } else if (choice === choices[9]) {
       config.render.showResult = !config.render.showResult;
       await saveDistillConfigFile(ctx, config, configPath);
     }

--- a/packages/pi-distill/src/output-limit.ts
+++ b/packages/pi-distill/src/output-limit.ts
@@ -1,7 +1,3 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 export type OutputLimitToolResult = {
   content: Array<{ type?: string; text?: string }>;
   details?: {
@@ -18,53 +14,4 @@ export function getTextContent(result: OutputLimitToolResult): string {
 
 export function hasNonTextContent(result: OutputLimitToolResult): boolean {
   return result.content.some((content) => content.type !== "text" || typeof content.text !== "string");
-}
-
-async function writeSummaryFile(summary: string): Promise<string> {
-  const directory = join(tmpdir(), "pi-distill");
-  await mkdir(directory, { recursive: true });
-  const filePath = join(
-    directory,
-    `summary-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
-  );
-  await writeFile(filePath, summary, "utf8");
-  return filePath;
-}
-
-export async function limitReturnedToolResult(
-  result: OutputLimitToolResult,
-  maxChars: number,
-): Promise<OutputLimitToolResult> {
-  if (hasNonTextContent(result)) return result;
-
-  const text = getTextContent(result);
-  if (text.length <= maxChars) return result;
-
-  try {
-    const filePath = await writeSummaryFile(text);
-    const pointer = `Output exceeded ${maxChars} chars and was written to: ${filePath}`;
-    return {
-      ...result,
-      content: [{ type: "text", text: pointer.slice(0, maxChars) }],
-      details: {
-        ...(result.details ?? {}),
-        fullOutputPath: filePath,
-        outputTruncated: true,
-        outputLimitChars: maxChars,
-      },
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-distill] Failed to write oversized output to a temp file; returning a truncated result: ${message}`);
-    return {
-      ...result,
-      content: [{ type: "text", text: text.slice(0, maxChars) }],
-      details: {
-        ...(result.details ?? {}),
-        outputTruncated: true,
-        outputLimitChars: maxChars,
-        outputFileError: message,
-      },
-    };
-  }
 }

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hasNonTextContent, limitReturnedToolResult } from "../src/output-limit.ts";
+import { hasNonTextContent } from "../src/output-limit.ts";
 import {
   appendDistillFallbackAudit,
   buildDistillAuditLines,
@@ -288,44 +288,18 @@ test("提炼 prompt 完全跟随 pi-language，不被原始用户消息覆盖", 
   }
 });
 
-test("最终 content 未超限时不因原文长度写入临时文件", async () => {
-  const result = await limitReturnedToolResult(
-    {
-      content: [{ type: "text", text: "总结后的短结果" }],
-      details: { originalOutputChars: 50_000 },
-    },
-    10_000,
-  );
-
-  assert.equal(result.details?.outputTruncated, undefined);
-  assert.equal(result.details?.fullOutputPath, undefined);
-  assert.equal(result.content[0]?.text, "总结后的短结果");
-});
-
-test("包含图片等非文本内容时保留原结果，不做长度截断", async () => {
+test("包含图片等非文本内容时识别为非纯文本输出", () => {
   const result = {
     content: [
       { type: "image", data: "encoded-image" },
       { type: "text", text: "x".repeat(10_001) },
     ],
-  } as any;
+  } as unknown as Parameters<typeof hasNonTextContent>[0];
 
   assert.equal(hasNonTextContent(result), true);
-  assert.strictEqual(await limitReturnedToolResult(result, 10_000), result);
-});
-
-test("最终 content 超过限制时写入临时文件并返回路径", async () => {
-  const finalContent = "x".repeat(10_001);
-  const result = await limitReturnedToolResult(
-    { content: [{ type: "text", text: finalContent }] },
-    10_000,
-  );
-
-  assert.equal(result.details?.outputTruncated, true);
-  assert.match(result.content[0]?.text ?? "", /was written to/);
   assert.equal(
-    await readFile(result.details?.fullOutputPath as string, "utf8"),
-    finalContent,
+    hasNonTextContent({ content: [{ type: "text", text: "纯文本" }] }),
+    false,
   );
 });
 


### PR DESCRIPTION
## Problem

Pi already writes oversized tool output to a temporary file and returns a pointer to the agent. pi-distill was doing its own file dumping (and truncation) on top of that, which is redundant and produces a second, separate dump path.

## Observable behavior change

- pi-distill no longer writes oversized output or summaries to temp files, and no longer truncates them. Results are passed through unchanged and Pi's own output-limiting mechanism handles anything oversized.
- The `maxOutputChars` setting (and `PI_DISTILL_MAX_OUTPUT_CHARS`) no longer has any effect. It is still parsed so existing config files don't error, but it is removed from the config UI, `config.example.json`, and the docs.
- `maxChars` is retained: it still sets the distillation model's output token budget (`~maxChars/2`) and is used for diagnostics.

## Package and documentation impact

- `pi-distill` only.
  - `output-limit.ts`: removed `limitReturnedToolResult` and `writeSummaryFile`; kept `getTextContent` / `hasNonTextContent`.
  - `index.ts`: removed the `finish()` wrapper and the local `writeSummaryFile`; `summarizeOutput` returns the summary as-is; dropped `maxOutputChars` from the config UI and reindexed the menu.
  - `config.example.json`, both READMEs, and `locales/index.json`: removed `maxOutputChars` and the now-unused `finalLimit`/`finalLimitTitle` keys; updated docs to state oversized output is left to Pi.
- Backward compatible: legacy `maxOutputChars` values in existing configs are still accepted (parsed but ignored).

## Validation

- `npm run typecheck` — pass.
- `npm test` (pi-distill, 18 tests) — pass. Removed 3 tests that targeted the deleted `limitReturnedToolResult`; reworked the non-text test to assert `hasNonTextContent` only.
- `npm run check` (repo gate: typecheck, all package tests, packaging, local-binding policy, i18n key alignment) — pass.

## Notes

- Pre-existing lint findings in the test file (an `as any` and a 4-arg `shouldSummarizeOutput` call) are untouched; they predate this change and refactoring the function signature is out of scope here.