### PR TITLE
refactor(pi-terminal-mux): unify backend logging, file lock, and BFS split state into shared module

### DIFF
--- a/packages/pi-terminal-mux/src/backends/cmux.ts
+++ b/packages/pi-terminal-mux/src/backends/cmux.ts
@@ -8,7 +8,11 @@
 
 import { execSync, execFileSync, spawnSync } from "node:child_process";
 import { shellEscape } from "../shell.ts";
+import { createBackendLogger } from "./shared.ts";
 import type { BackendOps } from "./types.ts";
+
+/** Cmux 后端日志（统一格式，写入 /tmp/pi-mux-cmux.log） */
+const cmuxLog = createBackendLogger("cmux", "/tmp/pi-mux-cmux.log");
 
 // ── 内部辅助 ──
 
@@ -271,7 +275,11 @@ export const ops: BackendOps = {
       try {
         const tree = execSync(`cmux tree`, { encoding: "utf8" });
         if (tree.includes(cmuxSubagentPane)) {
-          return createSurfaceInPane(name, cmuxSubagentPane);
+          const surface = createSurfaceInPane(name, cmuxSubagentPane);
+          cmuxLog(
+            `[split] mode=tab-reuse pane=${cmuxSubagentPane} new=${surface} name=${JSON.stringify(name)}`,
+          );
+          return surface;
         }
       } catch {}
       // Pane 已消失 — fall through 创建新 split
@@ -280,11 +288,18 @@ export const ops: BackendOps = {
 
     const created = createCmuxSplitSurface(name, "right", process.env.CMUX_SURFACE_ID);
     cmuxSubagentPane = created.paneRef ?? null;
+    cmuxLog(
+      `[split] mode=first dir=right from=${process.env.CMUX_SURFACE_ID ?? "<unset>"} new=${created.surface} name=${JSON.stringify(name)}`,
+    );
     return created.surface;
   },
 
   createSplit(name: string, direction: "left" | "right" | "up" | "down", fromSurface?: string): string {
-    return createCmuxSplitSurface(name, direction, fromSurface).surface;
+    const surface = createCmuxSplitSurface(name, direction, fromSurface).surface;
+    cmuxLog(
+      `[split] mode=createSurfaceSplit dir=${direction} from=${fromSurface ?? "<unset>"} new=${surface} name=${JSON.stringify(name)}`,
+    );
+    return surface;
   },
 
   send(surface: string, command: string): void {
@@ -318,6 +333,7 @@ export const ops: BackendOps = {
     execSync(`cmux close-surface --surface ${shellEscape(surface)}`, {
       encoding: "utf8",
     });
+    cmuxLog(`[close] surface=${surface}`);
   },
 
   rename(surface: string, name: string): void {

--- a/packages/pi-terminal-mux/src/backends/herdr.ts
+++ b/packages/pi-terminal-mux/src/backends/herdr.ts
@@ -9,21 +9,16 @@
  *   HERDR_PANE_ID（公开 id，如 "1-1"）
  *
  * 所有 pane 操作通过 `herdr` CLI 完成，详见 SKILL.md。
+ * 日志、文件锁、BFS 分屏状态机、命令检测复用 backends/shared.ts。
  */
 
-import { execFileSync, execSync, spawnSync } from "node:child_process";
-import { appendFileSync, existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
 import { i18n } from "../i18n.ts";
+import { createBackendLogger, withFileLock, BfsSplitStateManager, hasCommand } from "./shared.ts";
 
-// ── 日志（herdr 独立文件，便于区分后端） ──
-const HERDR_SPLIT_LOG = "/tmp/pi-herdr-split.log";
-function herdrLog(msg: string): void {
-  try {
-    appendFileSync(HERDR_SPLIT_LOG, `[${new Date().toISOString()}] ${msg}`);
-  } catch {
-    /* 写日志失败不影响主流程 */
-  }
-}
+// ── 日志（统一格式，写入 /tmp/pi-mux-herdr.log） ──
+const herdrLog = createBackendLogger("herdr", "/tmp/pi-mux-herdr.log");
 
 /**
  * 捕获于模块加载时的 agent pane id。
@@ -33,27 +28,6 @@ function herdrLog(msg: string): void {
 export const AGENT_HERDR_PANE_ID = process.env.HERDR_PANE_ID;
 export const AGENT_HERDR_WORKSPACE_ID = process.env.HERDR_WORKSPACE_ID;
 export const AGENT_HERDR_TAB_ID = process.env.HERDR_TAB_ID;
-
-// ── 命令可用性缓存 ──
-
-const commandAvailability = new Map<string, boolean>();
-
-function hasCommand(command: string): boolean {
-  if (commandAvailability.has(command)) {
-    return commandAvailability.get(command)!;
-  }
-
-  let available = false;
-  try {
-    execFileSync("which", [command], { stdio: "ignore" });
-    available = true;
-  } catch {
-    available = false;
-  }
-
-  commandAvailability.set(command, available);
-  return available;
-}
 
 /**
  * 检测 herdr backend 是否可用：
@@ -77,12 +51,12 @@ export function isHerdrRuntimeAvailable(): boolean {
 
 /**
  * 调用 `herdr` 命令并返回 stdout。
- * 失败时 stderr 写入 log，原样抛错（调用方决定如何处理）。
+ * 失败时原样抛错（调用方决定如何处理）。
  */
 function herdrExec(args: string[]): string {
-  herdrLog(`[herdr exec] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}\n`);
+  herdrLog(`[exec] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`);
   const out = execFileSync("herdr", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-  herdrLog(`[herdr exec] -> ${JSON.stringify(out.trim().slice(0, 200))}\n`);
+  herdrLog(`[exec] -> ${JSON.stringify(out.trim().slice(0, 200))}`);
   return out;
 }
 
@@ -91,7 +65,7 @@ function herdrExec(args: string[]): string {
  * 无输出的命令，遵循 SKILL.md 中"pane send-text/send-keys/run print nothing on success"。
  */
 function herdrExecSilent(args: string[]): void {
-  herdrLog(`[herdr exec silent] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}\n`);
+  herdrLog(`[exec silent] herdr ${args.map((a) => (a.includes(" ") ? JSON.stringify(a) : a)).join(" ")}`);
   execFileSync("herdr", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 }
 
@@ -125,12 +99,12 @@ function extractPaneId(json: unknown): string | null {
   return null;
 }
 
-// ── mux state 缓存 ──
-//
-// herdr 没有 tmux `last_split_source` 之类的明确"上一个 split 的父 pane"语义。
-// 我们记录每个 surface 的"父 pane id"，用于 close 时清理（herdr 不需要这个，但保留
-// 以便将来扩展 — closePane 实际上只看 surface id）。
-const herdrPaneSources = new Map<string, string>();
+// ── BFS 分屏状态 marker 路径 ──
+
+/** herdr BFS 分屏状态 marker 文件路径（按 agent pane id 区分） */
+function herdrMarkerPath(): string {
+  return `/tmp/herdr-subagent-pane-${(AGENT_HERDR_PANE_ID ?? "default").replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
+}
 
 // ── 对外 API：createSurface 系列 ──
 
@@ -139,6 +113,7 @@ const herdrPaneSources = new Map<string, string>();
  *
  * 实现：split 当前 agent pane 右侧（--no-focus 保持 agent 焦点不变）。
  * 后续 subagent 按 breadth-first 模式轮转 right/down/right/down…（与 cmux/muxy 行为一致）。
+ * 锁与 BFS 状态机复用 shared.ts。
  */
 export function createHerdrSurface(name: string): string {
   if (!AGENT_HERDR_PANE_ID) {
@@ -148,142 +123,66 @@ export function createHerdrSurface(name: string): string {
     );
   }
 
-  // 与 muxy 同样的广度优先分屏策略：
-  //   第一轮：从 agent pane 向右分，pos=0, base=1
-  //   第二轮：从第一个 pane 向下分，pos=0, base=1
-  //   第三轮：从第一个 pane 向右、第二个 pane 向右，pos=0, base=2
-  //   ……
-  // 状态文件：/tmp/herdr-subagent-pane-<agent_pane_id>.json
-  const markerFile = `/tmp/herdr-subagent-pane-${AGENT_HERDR_PANE_ID.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
-  const lockFile = `${markerFile}.lock`;
+  const markerFile = herdrMarkerPath();
+  const lockPath = `${markerFile}.lock`;
 
-  // 全局锁：所有分屏操作串行化
-  const acquired = (() => {
-    for (let i = 0; i < 60; i++) {
-      if (!existsSync(lockFile)) {
-        try {
-          writeFileSync(lockFile, `${process.pid}`, { flag: "wx" });
-          return true;
-        } catch {
-          // 竞争失败，继续等待
-        }
-      }
-      spawnSync("sleep", ["0.05"]);
-    }
-    return false;
-  })();
-
-  if (!acquired) {
-    herdrLog(`[herdr split] failed to acquire lock ${lockFile}\n`);
-    return "";
-  }
-
-  try {
-    let state: { panes: string[]; pos: number; base: number; dir: "right" | "down" } = {
-      panes: [],
-      pos: 0,
-      base: 0,
-      dir: "right",
-    };
-    try {
-      state = JSON.parse(readFileSync(markerFile, "utf8"));
-    } catch {
-      /* 文件不存在或损坏，用初始状态 */
-    }
+  return withFileLock(lockPath, {}, () => {
+    const state = new BfsSplitStateManager(markerFile);
 
     // 首次 split
-    if (state.panes.length === 0) {
+    if (state.panes().length === 0) {
       const output = herdrExec([
         "pane",
         "split",
-        AGENT_HERDR_PANE_ID,
+        AGENT_HERDR_PANE_ID!,
         "--direction",
         "right",
         "--no-focus",
       ]);
-      const json = parseHerdrJson(output);
-      const newPaneId = extractPaneId(json);
+      const newPaneId = extractPaneId(parseHerdrJson(output));
       if (newPaneId) {
-        state.panes = [newPaneId];
-        state.pos = 0;
-        state.base = 1;
-        state.dir = "down";
-        writeFileSync(markerFile, JSON.stringify(state));
-        herdrPaneSources.set(newPaneId, AGENT_HERDR_PANE_ID);
+        state.add(newPaneId);
         renameHerdrPane(newPaneId, name);
         herdrLog(
-          `[herdr split] mode=first dir=right from=${AGENT_HERDR_PANE_ID} new=${newPaneId} name=${JSON.stringify(name)}\n`,
+          `[split] mode=first dir=right from=${AGENT_HERDR_PANE_ID} new=${newPaneId} name=${JSON.stringify(name)}`,
         );
         return newPaneId;
       }
-      herdrLog(`[herdr split] first split returned no pane id, output=${JSON.stringify(output)}\n`);
+      herdrLog(`[split] first split returned no pane id, output=${JSON.stringify(output)}`);
       return "";
     }
 
-    // 本轮结束？翻转方向
-    if (state.pos >= state.base) {
-      state.pos = 0;
-      state.base = state.panes.length;
-      state.dir = state.dir === "right" ? "down" : "right";
-    }
+    // 后续：BFS 分屏
+    const next = state.next();
+    if (!next) return "";
 
-    let targetPane = state.panes[state.pos];
-    if (!targetPane) {
-      herdrLog(`[herdr split] state.panes[${state.pos}] is undefined\n`);
-      return "";
-    }
+    let { source } = next;
+    const { direction } = next;
 
-    // 若 targetPane 过期（pane 被关闭 / session 重启），自动重置状态从 agent pane 重新分屏
+    // 若 source 过期（pane 被关闭 / session 重启），重置状态从 agent pane 重新分屏
     let output: string;
-    let sourcePane = targetPane;
     try {
-      output = herdrExec([
-        "pane",
-        "split",
-        targetPane,
-        "--direction",
-        state.dir,
-        "--no-focus",
-      ]);
+      output = herdrExec(["pane", "split", source, "--direction", direction, "--no-focus"]);
     } catch {
       try { rmSync(markerFile); } catch { /* ignore */ }
-      herdrLog(
-        `[herdr split] pane ${targetPane} gone, resetting from agent pane ${AGENT_HERDR_PANE_ID}\n`,
-      );
-      state = { panes: [], pos: 0, base: 0, dir: "right" };
-      targetPane = AGENT_HERDR_PANE_ID;
-      sourcePane = AGENT_HERDR_PANE_ID;
-      output = herdrExec([
-        "pane",
-        "split",
-        AGENT_HERDR_PANE_ID,
-        "--direction",
-        "right",
-        "--no-focus",
-      ]);
+      herdrLog(`[split] pane ${source} gone, resetting from agent pane ${AGENT_HERDR_PANE_ID}`);
+      source = AGENT_HERDR_PANE_ID!;
+      output = herdrExec(["pane", "split", source, "--direction", "right", "--no-focus"]);
     }
-    const json = parseHerdrJson(output);
-    const newPaneId = extractPaneId(json);
+
+    const newPaneId = extractPaneId(parseHerdrJson(output));
     if (newPaneId) {
-      state.panes.push(newPaneId);
-      state.pos++;
-      writeFileSync(markerFile, JSON.stringify(state));
-      herdrPaneSources.set(newPaneId, sourcePane);
+      state.advance();
+      state.add(newPaneId);
       renameHerdrPane(newPaneId, name);
       herdrLog(
-        `[herdr split] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=${targetPane} new=${newPaneId} name=${JSON.stringify(name)}\n`,
+        `[split] mode=next dir=${direction} from=${source} new=${newPaneId} name=${JSON.stringify(name)}`,
       );
       return newPaneId;
     }
-    herdrLog(`[herdr split] next split returned no pane id, output=${JSON.stringify(output)}\n`);
+    herdrLog(`[split] next split returned no pane id, output=${JSON.stringify(output)}`);
     return "";
-  } finally {
-    try {
-      rmSync(lockFile);
-    } catch {
-      /* ignore */
-    }
-  }
+  });
 }
 
 /**
@@ -302,11 +201,8 @@ export function splitHerdrPane(
   if (!newPaneId) {
     throw new Error(`Unexpected herdr pane split output: ${output.trim() || "(empty)"}`);
   }
-  herdrPaneSources.set(newPaneId, fromPane);
   if (name) renameHerdrPane(newPaneId, name);
-  herdrLog(
-    `[herdr split] mode=direct dir=${dir} from=${fromPane} new=${newPaneId} name=${JSON.stringify(name ?? "")}\n`,
-  );
+  herdrLog(`[split] mode=direct dir=${dir} from=${fromPane} new=${newPaneId} name=${JSON.stringify(name ?? "")}`);
   return newPaneId;
 }
 
@@ -320,7 +216,7 @@ export function renameHerdrPane(paneId: string, name: string): void {
     const paneLabel = wsLabel ? `${wsLabel}[${name}]` : name;
     herdrExecSilent(["pane", "rename", paneId, paneLabel]);
   } catch (e) {
-    herdrLog(`[herdr rename pane] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+    herdrLog(`[rename pane] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}`);
   }
 }
 
@@ -333,7 +229,7 @@ export function renameHerdrAgent(paneId: string, name: string): void {
   try {
     herdrExecSilent(["agent", "rename", paneId, name]);
   } catch (e) {
-    herdrLog(`[herdr rename agent] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+    herdrLog(`[rename agent] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}`);
   }
 }
 
@@ -376,7 +272,7 @@ export function renameHerdrTab(paneId: string, name: string): void {
       }
     }
   } catch (e) {
-    herdrLog(`[herdr rename tab] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}\n`);
+    herdrLog(`[rename tab] pane=${paneId} name=${JSON.stringify(name)} failed: ${(e as Error).message}`);
   }
 }
 
@@ -390,7 +286,7 @@ export function renameHerdrWorkspace(title: string): void {
   try {
     herdrExecSilent(["workspace", "rename", AGENT_HERDR_WORKSPACE_ID, title]);
   } catch (e) {
-    herdrLog(`[herdr rename workspace] title=${JSON.stringify(title)} failed: ${(e as Error).message}\n`);
+    herdrLog(`[rename workspace] title=${JSON.stringify(title)} failed: ${(e as Error).message}`);
   }
 }
 
@@ -435,38 +331,16 @@ export function readHerdrScreen(paneId: string, lines = 50, source: "visible" | 
 export function closeHerdrSurface(paneId: string): void {
   herdrExecSilent(["pane", "close", paneId]);
 
-  // 清理 mux state marker（与 muxy 的 close 逻辑一致）
-  const markerFile = `/tmp/herdr-subagent-pane-${(AGENT_HERDR_PANE_ID ?? "default").replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
-  try {
-    const parsed = JSON.parse(readFileSync(markerFile, "utf8"));
-    if (parsed && Array.isArray(parsed.panes)) {
-      const idx = parsed.panes.indexOf(paneId);
-      if (idx >= 0) {
-        const beforePanes = [...parsed.panes];
-        const beforePos = parsed.pos;
-        parsed.panes.splice(idx, 1);
-        if (typeof parsed.pos === "number" && idx < parsed.pos) {
-          parsed.pos = Math.max(0, parsed.pos - 1);
-        }
-        if (parsed.panes.length === 0) {
-          rmSync(markerFile);
-          herdrLog(
-            `[herdr close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
-          );
-        } else {
-          writeFileSync(markerFile, JSON.stringify(parsed));
-          herdrLog(
-            `[herdr close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(parsed.panes)} pos=${beforePos} -> ${parsed.pos}\n`,
-          );
-        }
-      } else {
-        herdrLog(`[herdr close] pane=${paneId} (not in marker state.panes)\n`);
-      }
-    }
-  } catch {
-    herdrLog(`[herdr close] pane=${paneId} (no marker, nothing to clean)\n`);
+  // 从 BFS 状态移除已关闭的 subagent，避免僵尸 ID 累积
+  const state = new BfsSplitStateManager(herdrMarkerPath());
+  const beforePanes = state.panes();
+  state.remove(paneId);
+  const afterPanes = state.panes();
+  if (beforePanes.length !== afterPanes.length) {
+    herdrLog(`[close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(afterPanes)}`);
+  } else {
+    herdrLog(`[close] pane=${paneId} (not in marker state.panes)`);
   }
-  herdrPaneSources.delete(paneId);
 }
 
 // ── 辅助：从 pane id 解析 workspace id ──

--- a/packages/pi-terminal-mux/src/backends/muxy.ts
+++ b/packages/pi-terminal-mux/src/backends/muxy.ts
@@ -2,23 +2,22 @@
  * backends/muxy.ts — Muxy 终端后端
  *
  * 包含 Muxy 特定的 surface 创建（广度优先分屏）、命令发送、屏幕读写、
- * 关闭与重命名。BFS 分屏状态通过 /tmp/muxy-subagent-pane-* marker 文件持久化。
+ * 关闭与重命名。BFS 分屏状态与文件锁使用 shared.ts 的统一实现。
  */
 
-import { execFileSync, execFile, spawnSync } from "node:child_process";
+import { execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
-import { muxLog, AGENT_MUXY_PANE_ID } from "../detection.ts";
+import { AGENT_MUXY_PANE_ID } from "../detection.ts";
+import { createBackendLogger, withFileLock, BfsSplitStateManager } from "./shared.ts";
 import type { BackendOps } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
 
-// ── 内部辅助 ──
+// ── 日志 ──
 
-/** Muxy 分屏锁重试次数上限 */
-const MUXY_LOCK_RETRY_COUNT = 60;
-/** Muxy 分屏锁重试间隔（秒） */
-const MUXY_LOCK_RETRY_INTERVAL_S = 0.05;
+const log = createBackendLogger("muxy", "/tmp/pi-mux-muxy.log");
+
+// ── 内部辅助 ──
 
 /**
  * 重命名 Muxy pane（best-effort，失败静默忽略）。
@@ -29,16 +28,6 @@ function renameMuxySurface(surface: string, name: string): void {
   } catch {}
 }
 
-// ── BFS 分屏状态管理 ──
-
-/** Muxy BFS 分屏持久化状态 */
-interface MuxySplitState {
-  panes: string[];
-  pos: number;
-  base: number;
-  dir: "right" | "down";
-}
-
 /**
  * 返回 Muxy BFS 分屏状态 marker 文件路径。
  * marker 文件记录当前所有 subagent pane ID 及分屏游标。
@@ -47,59 +36,18 @@ function muxyMarkerPath(): string {
   return `/tmp/muxy-subagent-pane-${AGENT_MUXY_PANE_ID || "default"}`;
 }
 
-/**
- * 从 marker 文件读取 BFS 分屏状态，文件不存在时返回空状态。
- */
-function readMuxyState(markerFile: string): MuxySplitState {
-  try {
-    return JSON.parse(readFileSync(markerFile, "utf8"));
-  } catch {
-    return { panes: [], pos: 0, base: 0, dir: "right" };
-  }
-}
-
-/**
- * 将 BFS 分屏状态写回 marker 文件。
- */
-function writeMuxyState(markerFile: string, state: MuxySplitState): void {
-  writeFileSync(markerFile, JSON.stringify(state));
-}
-
-/**
- * 通过创建 lock 文件尝试获取 Muxy 分屏全局锁。
- * 最多重试 MUXY_LOCK_RETRY_COUNT 次，每次间隔 MUXY_LOCK_RETRY_INTERVAL_S 秒。
- * 返回 true 表示获取成功，false 表示超时。
- */
-function acquireMuxyLock(lockFile: string): boolean {
-  for (let i = 0; i < MUXY_LOCK_RETRY_COUNT; i++) {
-    if (!existsSync(lockFile)) {
-      try {
-        writeFileSync(lockFile, `${process.pid}`, { flag: "wx" });
-        return true;
-      } catch {
-        // 竞争失败，继续等待
-      }
-    }
-    spawnSync("sleep", [String(MUXY_LOCK_RETRY_INTERVAL_S)]);
-  }
-  return false;
-}
-
 // ── BackendOps ──
 
 export const ops: BackendOps = {
   create(name: string): string {
     const markerFile = muxyMarkerPath();
-    const lockFile = `${markerFile}.lock`;
+    const lockPath = `${markerFile}.lock`;
 
-    const acquired = acquireMuxyLock(lockFile);
-    if (!acquired) return "";
-
-    try {
-      const state = readMuxyState(markerFile);
+    return withFileLock(lockPath, {}, () => {
+      const state = new BfsSplitStateManager(markerFile);
 
       // 首次：split-right from parent
-      if (state.panes.length === 0) {
+      if (state.panes().length === 0) {
         if (!AGENT_MUXY_PANE_ID) {
           throw new Error(
             "MUXY_PANE_ID not set; cannot determine parent pane for first subagent split. " +
@@ -107,55 +55,45 @@ export const ops: BackendOps = {
           );
         }
         const args = ["split-right", "--from", AGENT_MUXY_PANE_ID];
-        muxLog(
-          `[muxy split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=<pending> name=${JSON.stringify(name)}\n`,
+        log(
+          `[split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=<pending> name=${JSON.stringify(name)}`,
         );
         const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
         if (output) {
-          state.panes = [output];
-          state.pos = 0;
-          state.base = 1;
-          state.dir = "down";
-          writeMuxyState(markerFile, state);
+          state.add(output);
           renameMuxySurface(output, name);
-          muxLog(
-            `[muxy split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=${output} name=${JSON.stringify(name)}\n`,
+          log(
+            `[split] mode=first dir=right from=AGENT_MUXY_PANE_ID=${AGENT_MUXY_PANE_ID} new=${output} name=${JSON.stringify(name)}`,
           );
         }
         return output;
       }
 
-      // 本轮结束？翻转方向
-      if (state.pos >= state.base) {
-        state.pos = 0;
-        state.base = state.panes.length;
-        state.dir = state.dir === "right" ? "down" : "right";
-      }
+      // 后续：BFS 分屏
+      const next = state.next();
+      if (!next) return "";
 
-      const targetPane = state.panes[state.pos];
-      const muxyDir = state.dir === "right" ? "split-right" : "split-down";
+      const { source, direction } = next;
+      const muxyDir = direction === "right" ? "split-right" : "split-down";
       const args = [muxyDir];
-      if (targetPane) args.push("--from", targetPane);
+      if (source) args.push("--from", source);
 
-      muxLog(
-        `[muxy split] mode=next pos=${state.pos} base=${state.base} dir=${state.dir} from=state.panes[${state.pos}]=${targetPane} new=<pending> name=${JSON.stringify(name)}\n`,
+      log(
+        `[split] mode=next dir=${direction} from=${source} new=<pending> name=${JSON.stringify(name)}`,
       );
       const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
 
       if (output) {
-        state.panes.push(output);
-        state.pos++;
-        writeMuxyState(markerFile, state);
+        state.advance();
+        state.add(output);
         renameMuxySurface(output, name);
-        muxLog(
-          `[muxy split] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=state.panes[${state.pos - 1}]=${targetPane} new=${output} name=${JSON.stringify(name)}\n`,
+        log(
+          `[split] mode=next dir=${direction} from=${source} new=${output} name=${JSON.stringify(name)}`,
         );
       }
 
       return output;
-    } finally {
-      try { rmSync(lockFile); } catch {}
-    }
+    });
   },
 
   createSplit(name: string, direction: "left" | "right" | "up" | "down", fromSurface?: string): string {
@@ -171,14 +109,14 @@ export const ops: BackendOps = {
       );
     }
     const args = [`split-${dir}`, "--from", sourcePane];
-    muxLog(
-      `[muxy split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=<pending> name=${JSON.stringify(name)}\n`,
+    log(
+      `[split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=<pending> name=${JSON.stringify(name)}`,
     );
     const output = execFileSync("muxy", args, { encoding: "utf8" }).trim();
     if (output) {
       renameMuxySurface(output, name);
-      muxLog(
-        `[muxy split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=${output} name=${JSON.stringify(name)}\n`,
+      log(
+        `[split] mode=createSurfaceSplit dir=${dir} from=${sourcePane} (${sourceOrigin}) new=${output} name=${JSON.stringify(name)}`,
       );
     }
     return output;
@@ -212,40 +150,17 @@ export const ops: BackendOps = {
 
   close(surface: string): void {
     execFileSync("muxy", ["close-pane", "--pane", surface], { encoding: "utf8" });
-    // 从 state.panes 移除已关闭的 subagent，避免僵尸 ID 累积
-    const markerFile = muxyMarkerPath();
-    try {
-      const parsed = JSON.parse(readFileSync(markerFile, "utf8"));
-      if (parsed && Array.isArray(parsed.panes)) {
-        const idx = parsed.panes.indexOf(surface);
-        if (idx >= 0) {
-          const beforePanes = [...parsed.panes];
-          const beforePos = parsed.pos;
-          parsed.panes.splice(idx, 1);
-          if (typeof parsed.pos === "number" && idx < parsed.pos) {
-            parsed.pos = Math.max(0, parsed.pos - 1);
-          }
-          if (parsed.panes.length === 0) {
-            rmSync(markerFile);
-            muxLog(
-              `[muxy close] pane=${surface} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
-            );
-          } else {
-            writeFileSync(markerFile, JSON.stringify(parsed));
-            muxLog(
-              `[muxy close] pane=${surface} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(parsed.panes)} pos=${beforePos} -> ${parsed.pos}\n`,
-            );
-          }
-        } else {
-          muxLog(
-            `[muxy close] pane=${surface} (not in marker state.panes, marker unchanged)\n`,
-          );
-        }
-      }
-    } catch (e) {
-      muxLog(
-        `[muxy close] pane=${surface} (no marker found or parse error, nothing to clean)\n`,
+    // 从 BFS 状态移除已关闭的 subagent，避免僵尸 ID 累积
+    const state = new BfsSplitStateManager(muxyMarkerPath());
+    const beforePanes = state.panes();
+    state.remove(surface);
+    const afterPanes = state.panes();
+    if (beforePanes.length !== afterPanes.length) {
+      log(
+        `[close] pane=${surface} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(afterPanes)}`,
       );
+    } else {
+      log(`[close] pane=${surface} (not in marker state.panes, marker unchanged)`);
     }
   },
 
@@ -256,11 +171,10 @@ export const ops: BackendOps = {
 
 /**
  * 获取 Muxy BFS 分屏状态中当前要 split 的目标 pane（用于 surface.ts 设置 lastSplitSource）。
- * 首次调用返回 AGENT_MUXY_PANE_ID，后续返回 state.panes[pos] 或 null。
+ * 首次调用返回 AGENT_MUXY_PANE_ID，后续返回 next().source 或 null。
  */
 export function getMuxySplitSource(): string | null {
-  const markerFile = muxyMarkerPath();
-  const state = readMuxyState(markerFile);
-  if (state.panes.length === 0) return AGENT_MUXY_PANE_ID ?? null;
-  return state.panes[state.pos] ?? null;
+  const state = new BfsSplitStateManager(muxyMarkerPath());
+  if (state.panes().length === 0) return AGENT_MUXY_PANE_ID ?? null;
+  return state.next()?.source ?? null;
 }

--- a/packages/pi-terminal-mux/src/backends/otty.ts
+++ b/packages/pi-terminal-mux/src/backends/otty.ts
@@ -28,51 +28,18 @@
  *   - `otty tab list --json`                 列出所有 tab
  *   - `otty tab rename --tab <tab_id> <title>`
  *   - `otty tab close <tab_id>`
+ *
+ * 日志、文件锁、BFS 分屏状态机、命令检测复用 backends/shared.ts。
  */
 
-import {
-  execFileSync,
-  execSync,
-  spawnSync,
-} from "node:child_process";
-import {
-  appendFileSync,
-  existsSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { i18n } from "../i18n.ts";
+import { createBackendLogger, withFileLock, BfsSplitStateManager, hasCommand } from "./shared.ts";
 
-// ── 日志（otty 独立文件，便于区分后端） ──
-const OTTY_SPLIT_LOG = "/tmp/pi-otty-split.log";
-function ottyLog(msg: string): void {
-  try {
-    appendFileSync(OTTY_SPLIT_LOG, `[${new Date().toISOString()}] ${msg}`);
-  } catch {
-    /* 写日志失败不影响主流程 */
-  }
-}
-
-// ── 命令可用性缓存 ──
-
-const commandAvailability = new Map<string, boolean>();
-
-function hasCommand(command: string): boolean {
-  if (commandAvailability.has(command)) {
-    return commandAvailability.get(command)!;
-  }
-  let available = false;
-  try {
-    execFileSync("which", [command], { stdio: "ignore" });
-    available = true;
-  } catch {
-    available = false;
-  }
-  commandAvailability.set(command, available);
-  return available;
-}
+// ── 日志（统一格式，写入 /tmp/pi-mux-otty.log） ──
+const ottyLog = createBackendLogger("otty", "/tmp/pi-mux-otty.log");
 
 // ── Otty 检测 ──
 
@@ -90,7 +57,7 @@ export function isOttyRuntimeAvailable(): boolean {
   if (!hasCommand("otty")) return false;
 
   // 最后一道闸：otty 命令存在但 app 没启动时 `otty panes` 会失败。
-  // 提前 200ms 超时探一下，避免后续每次调用都等满 3s。
+  // 提前 500ms 超时探一下，避免后续每次调用都等满 3s。
   try {
     const result = spawnSync("otty", ["panes", "--json", "--timeout", "500"], {
       encoding: "utf8",
@@ -112,10 +79,7 @@ let sendKeysEnabledCache: boolean | null = null;
 export function isOttySendKeysEnabled(): boolean {
   if (sendKeysEnabledCache !== null) return sendKeysEnabledCache;
   try {
-    // 用一个无害的"noop"探针：给 agent 自己 pane 发一个不会执行的 key:End + Escape
-    // 序列的低成本命令，或者直接探测配置项。
-    // 优先用 ipc 命令问 otty 是否允许 send-keys，避免触发误判。
-    // 退路：直接试一次 `pane send-keys` 看错误信息。
+    // 用一个无害探针：给 agent 自己 pane 发 key:End，看 otty 是否允许 send-keys。
     const result = spawnSync(
       "otty",
       ["pane", "send-keys", "--pane", getOttyAgentPaneId(), "--", "key:End"],
@@ -125,15 +89,13 @@ export function isOttySendKeysEnabled(): boolean {
     sendKeysEnabledCache = enabled;
     if (!enabled) {
       ottyLog(
-        `[otty detect] send-keys DISABLED stderr=${JSON.stringify(
-          (result.stderr ?? "").trim().slice(0, 200),
-        )}\n`,
+        `[detect] send-keys DISABLED stderr=${JSON.stringify((result.stderr ?? "").trim().slice(0, 200))}`,
       );
     }
     return enabled;
   } catch (e) {
     sendKeysEnabledCache = false;
-    ottyLog(`[otty detect] send-keys probe failed: ${(e as Error).message}\n`);
+    ottyLog(`[detect] send-keys probe failed: ${(e as Error).message}`);
     return false;
   }
 }
@@ -143,8 +105,7 @@ export function isOttySendKeysEnabled(): boolean {
 /**
  * 捕获于模块加载时的 agent pane id。
  * Otty 不像 cmux 那样注入 surface id；需要在启动时通过 `otty panes --json`
- * 找 `active=true` 的 pane 并冻结到常量。模块加载后再查 env 可能反映
- * 用户切换焦点后的值（虽然这里走的是 IPC 而非 env，但为了一致性也冻结）。
+ * 找 `active=true` 的 pane 并冻结到常量。
  *
  * 如果暂时拿不到（Otty 刚启动、panes 还没列出来），返回 null，
  * 调用方在第一次 createSurface 时重试。
@@ -154,17 +115,13 @@ export const AGENT_OTTY_PANE_ID: string | null = (() => {
     const panes = readOttyPanes();
     // active=true 是当前 focus pane。但用户启动 pi 后焦点可能在 pi pane，
     // 也可能在另一个 pane —— 必须按 process 名称筛选。
-    const piPane = panes.find(
-      (p) =>
-        p.active &&
-        /(^|\s)(π|pi)($|\s|-)/i.test(p.process),
-    );
+    const piPane = panes.find((p) => p.active && /(^|\s)(π|pi)($|\s|-)/i.test(p.process));
     if (piPane) return piPane.id;
     // 退路：取 active=true 的 pane（不严谨，但能跑）
     const active = panes.find((p) => p.active);
     return active?.id ?? null;
   } catch (e) {
-    ottyLog(`[otty init] failed to capture agent pane id: ${(e as Error).message}\n`);
+    ottyLog(`[init] failed to capture agent pane id: ${(e as Error).message}`);
     return null;
   }
 })();
@@ -178,13 +135,12 @@ export function getOttyAgentPaneId(): string {
   if (AGENT_OTTY_PANE_ID && ottyPaneExists(AGENT_OTTY_PANE_ID)) {
     return AGENT_OTTY_PANE_ID;
   }
+
   // 重试一次
   const refreshed = (() => {
     try {
       const panes = readOttyPanes();
-      const piPane = panes.find(
-        (p) => p.active && /(^|\s)(π|pi)($|\s|-)/i.test(p.process),
-      );
+      const piPane = panes.find((p) => p.active && /(^|\s)(π|pi)($|\s|-)/i.test(p.process));
       if (piPane) return piPane.id;
       return panes.find((p) => p.active)?.id ?? null;
     } catch {
@@ -216,21 +172,21 @@ function ottyExec(args: string[]): string {
   const cmdline = `otty ${args
     .map((a) => (a.includes(" ") || a.includes('"') ? JSON.stringify(a) : a))
     .join(" ")}`;
-  ottyLog(`[otty exec] ${cmdline}\n`);
+  ottyLog(`[exec] ${cmdline}`);
   const result = spawnSync("otty", args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.error) {
-    ottyLog(`[otty exec] ERROR (spawn): ${result.error.message}\n`);
+    ottyLog(`[exec] ERROR (spawn): ${result.error.message}`);
     throw result.error;
   }
   if (result.status !== 0) {
     const stderr = (result.stderr ?? "").trim();
-    ottyLog(`[otty exec] ERROR status=${result.status} stderr=${JSON.stringify(stderr)}\n`);
+    ottyLog(`[exec] ERROR status=${result.status} stderr=${JSON.stringify(stderr)}`);
     throw new Error(`otty ${args[0]} failed (status=${result.status}): ${stderr}`);
   }
-  ottyLog(`[otty exec] -> ${JSON.stringify(result.stdout.trim().slice(0, 200))}\n`);
+  ottyLog(`[exec] -> ${JSON.stringify(result.stdout.trim().slice(0, 200))}`);
   return result.stdout;
 }
 
@@ -242,16 +198,16 @@ function ottyExecSilent(args: string[]): void {
   const cmdline = `otty ${args
     .map((a) => (a.includes(" ") || a.includes('"') ? JSON.stringify(a) : a))
     .join(" ")}`;
-  ottyLog(`[otty exec silent] ${cmdline}\n`);
+  ottyLog(`[exec silent] ${cmdline}`);
   const result = spawnSync("otty", args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.error || result.status !== 0) {
     ottyLog(
-      `[otty exec silent] ERROR status=${result.status} stderr=${JSON.stringify(
+      `[exec silent] ERROR status=${result.status} stderr=${JSON.stringify(
         (result.stderr ?? "").trim().slice(0, 200),
-      )}\n`,
+      )}`,
     );
   }
 }
@@ -282,7 +238,7 @@ export function parseOttyJson(output: string): unknown {
   try {
     return JSON.parse(trimmed);
   } catch (e) {
-    ottyLog(`[otty parse json] failed: ${(e as Error).message} raw=${JSON.stringify(trimmed.slice(0, 200))}\n`);
+    ottyLog(`[parse json] failed: ${(e as Error).message} raw=${JSON.stringify(trimmed.slice(0, 200))}`);
     return null;
   }
 }
@@ -297,13 +253,11 @@ export function readOttyPanes(): OttyPaneSnapshot[] {
 export function readOttyTabs(): Array<Record<string, unknown>> {
   try {
     const raw = ottyExec(["tab", "list", "--json"]);
-    const parsed = parseOttyJson(raw) as
-      | OttyListResponse<Array<Record<string, unknown>>>
-      | null;
+    const parsed = parseOttyJson(raw) as OttyListResponse<Array<Record<string, unknown>>> | null;
     if (!parsed?.ok || !Array.isArray(parsed.data)) return [];
     return parsed.data;
   } catch (e) {
-    ottyLog(`[otty tabs] list failed: ${(e as Error).message}\n`);
+    ottyLog(`[tabs] list failed: ${(e as Error).message}`);
     return [];
   }
 }
@@ -321,27 +275,10 @@ export function getTabIdForPane(paneId: string): string | null {
   }
 }
 
-// ── mux state 持久化 ──
+// ── BFS 分屏状态 marker 路径（复用 shared.ts 状态机） ──
 //
-// 与 muxy / herdr 同样的广度优先分屏策略：
-//   panes: 所有 subagent pane id 列表
-//   pos:   本轮下一个要 split 的索引
-//   base:  本轮开始时 pane 总数（本轮要分 base 个）
-//   dir:   当前方向（"right" | "down"）
-//
-// 第一轮：从 agent pane 向右分（pos=0, base=1）
-// 第二轮：从第一个 pane 向下分（pos=0, base=1）
-// 第三轮：第一个 pane 向右、第二个 pane 向右（pos=0, base=2）
-// ……
-// 每来一个 subagent：从 panes[pos] 拆 → 新 pane 追加到列表尾
-// pos 走完 base 个后 → 翻转方向，重置 pos，更新 base
-
-interface OttySplitState {
-  panes: string[];
-  pos: number;
-  base: number;
-  dir: "right" | "down";
-}
+// 与 muxy / herdr 同样的广度优先分屏策略。marker 文件落在 os.tmpdir()
+// （otty 历史路径，保持不动），锁与状态机逻辑由 shared.ts 提供。
 
 function ottyStateFile(): string {
   const agentId = AGENT_OTTY_PANE_ID ?? "default";
@@ -349,49 +286,8 @@ function ottyStateFile(): string {
   return `${tmpdir()}/otty-subagent-pane-${safe}.json`;
 }
 
-function ottyStateLockFile(): string {
-  return `${ottyStateFile()}.lock`;
-}
-
-function readOttyState(): OttySplitState {
-  try {
-    return JSON.parse(readFileSync(ottyStateFile(), "utf8"));
-  } catch {
-    return { panes: [], pos: 0, base: 0, dir: "right" };
-  }
-}
-
-function writeOttyState(state: OttySplitState): void {
-  writeFileSync(ottyStateFile(), JSON.stringify(state));
-}
-
-function acquireOttyLock(timeoutMs = 3000): boolean {
-  const lock = ottyStateLockFile();
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (!existsSync(lock)) {
-      try {
-        writeFileSync(lock, `${process.pid}`, { flag: "wx" });
-        return true;
-      } catch {
-        /* 竞争失败，继续等 */
-      }
-    }
-    spawnSync("sleep", ["0.05"]);
-  }
-  return false;
-}
-
-function releaseOttyLock(): void {
-  try {
-    rmSync(ottyStateLockFile());
-  } catch {
-    /* ignore */
-  }
-}
-
 /**
- * 找到 agent pane 之后的最新 pane id，用于 split 时作为父 pane。
+ * 找到 split 后的新 pane id。
  *
  * Otty 的 `pane split --pane <parent>` 把目标 pane 拆成两个，但返回的
  * stdout 在 v1.0.4 不会输出新 pane id —— 必须通过比较 split 前后的
@@ -411,14 +307,10 @@ function diffNewPane(before: Set<string>): string | null {
     if (newOnes.length === 0) return null;
     if (newOnes.length === 1) return newOnes[0]!.id;
     // 多于 1 个 → 取最后出现（split 后追加的通常在尾部）
-    ottyLog(
-      `[otty diff] multiple new panes after split: ${JSON.stringify(
-        newOnes.map((p) => p.id),
-      )}\n`,
-    );
+    ottyLog(`[diff] multiple new panes after split: ${JSON.stringify(newOnes.map((p) => p.id))}`);
     return newOnes[newOnes.length - 1]!.id;
   } catch (e) {
-    ottyLog(`[otty diff] failed: ${(e as Error).message}\n`);
+    ottyLog(`[diff] failed: ${(e as Error).message}`);
     return null;
   }
 }
@@ -428,9 +320,9 @@ function diffNewPane(before: Set<string>): string | null {
 /**
  * 创建一个新的 subagent pane。
  *
- * 实现：广度优先分屏（与 muxy / herdr 一致）。
+ * 实现：广度优先分屏（与 muxy / herdr 一致），锁与状态机复用 shared.ts。
  * 第一次 split：从 agent pane 向右拆（--no-focus 保持 agent 焦点不变）。
- * 后续 split：按 state 轮转 right/down，绕圈拆分已有 subagent pane。
+ * 后续 split：按状态机轮转 right/down，绕圈拆分已有 subagent pane。
  *
  * 已知问题：
  *   - `otty pane split` v1.0.4 不返回新 pane id，必须靠 panes --json 差集推断。
@@ -441,21 +333,18 @@ export function createOttySurface(name: string): string {
   const agentId = getOttyAgentPaneId();
 
   // send-keys 没开时无法在子 pane 里发送 Enter，必须改用 --command 注入启动命令。
-  // 见 sendOttyCommand 的注释。
   if (!isOttySendKeysEnabled()) {
-    ottyLog(`[otty create] send-keys disabled; createSurface will succeed but pane will be empty until otty config enables it\n`);
+    ottyLog(`[create] send-keys disabled; createSurface will succeed but pane will be empty until otty config enables it`);
   }
 
-  if (!acquireOttyLock()) {
-    ottyLog(`[otty create] failed to acquire lock\n`);
-    return "";
-  }
+  const markerFile = ottyStateFile();
+  const lockPath = `${markerFile}.lock`;
 
-  try {
-    const state = readOttyState();
+  return withFileLock(lockPath, { timeoutMs: 3000 }, () => {
+    let state = new BfsSplitStateManager(markerFile);
 
     // ── 首次 split ──
-    if (state.panes.length === 0) {
+    if (state.panes().length === 0) {
       const before = capturePaneIds();
       try {
         ottyExec([
@@ -470,48 +359,36 @@ export function createOttySurface(name: string): string {
           name,
         ]);
       } catch (e) {
-        ottyLog(`[otty create] first split failed: ${(e as Error).message}\n`);
+        ottyLog(`[create] first split failed: ${(e as Error).message}`);
         return "";
       }
       const newId = diffNewPane(before);
       if (!newId) {
-        ottyLog(`[otty create] first split produced no new pane id\n`);
+        ottyLog(`[create] first split produced no new pane id`);
         return "";
       }
-      state.panes = [newId];
-      state.pos = 0;
-      state.base = 1;
-      state.dir = "down";
-      writeOttyState(state);
-      // 改名 tab
+      state.add(newId);
       renameOttyTab(newId, name);
-      ottyLog(
-        `[otty create] mode=first dir=right from=${agentId} new=${newId} name=${JSON.stringify(name)}\n`,
-      );
+      ottyLog(`[create] mode=first dir=right from=${agentId} new=${newId} name=${JSON.stringify(name)}`);
       return newId;
     }
 
-    // ── 后续 split：先判断本轮是否结束 ──
-    if (state.pos >= state.base) {
-      state.pos = 0;
-      state.base = state.panes.length;
-      state.dir = state.dir === "right" ? "down" : "right";
-    }
+    // ── 后续 split ──
+    const next = state.next();
+    if (!next) return "";
 
-    let target = state.panes[state.pos];
-    if (!target) {
-      ottyLog(`[otty create] state.panes[${state.pos}] is undefined, fallback to agent\n`);
-      target = agentId;
-    }
+    let target = next.source;
+    const direction = next.direction;
 
     const before = capturePaneIds();
     let splitSucceeded = false;
+    let recovered = false;
     try {
       ottyExec([
         "pane",
         "split",
         "--direction",
-        state.dir,
+        direction,
         "--pane",
         target,
         "--no-focus",
@@ -521,14 +398,13 @@ export function createOttySurface(name: string): string {
       splitSucceeded = true;
     } catch (e) {
       // target 失效 → 重置 state，从 agent pane 重新拆
-      ottyLog(
-        `[otty create] pane ${target} gone (${(e as Error).message}), reset and retry from agent pane\n`,
-      );
+      ottyLog(`[create] pane ${target} gone (${(e as Error).message}), reset and retry from agent pane`);
       try {
-        rmSync(ottyStateFile());
+        rmSync(markerFile);
       } catch {
         /* ignore */
       }
+      state = new BfsSplitStateManager(markerFile); // marker 已删 → 空状态
       target = agentId;
       try {
         ottyExec([
@@ -543,8 +419,9 @@ export function createOttySurface(name: string): string {
           name,
         ]);
         splitSucceeded = true;
+        recovered = true;
       } catch (e2) {
-        ottyLog(`[otty create] reset split failed: ${(e2 as Error).message}\n`);
+        ottyLog(`[create] reset split failed: ${(e2 as Error).message}`);
         return "";
       }
     }
@@ -552,20 +429,17 @@ export function createOttySurface(name: string): string {
     if (!splitSucceeded) return "";
     const newId = diffNewPane(before);
     if (!newId) {
-      ottyLog(`[otty create] next split produced no new pane id\n`);
+      ottyLog(`[create] next split produced no new pane id`);
       return "";
     }
-    state.panes.push(newId);
-    state.pos++;
-    writeOttyState(state);
+    // 正常路径消费了状态机里的 source（advance）；recovery 路径用的是全新空状态，
+    // split 源是 agent pane（不在状态机里），只需 add。
+    if (!recovered) state.advance();
+    state.add(newId);
     renameOttyTab(newId, name);
-    ottyLog(
-      `[otty create] mode=next pos=${state.pos - 1} base=${state.base} dir=${state.dir} from=${target} new=${newId} name=${JSON.stringify(name)}\n`,
-    );
+    ottyLog(`[create] mode=next dir=${direction} from=${target} new=${newId} name=${JSON.stringify(name)}`);
     return newId;
-  } finally {
-    releaseOttyLock();
-  }
+  });
 }
 
 // ── 对外 API：pane 操作 ──
@@ -581,17 +455,13 @@ export function createOttySurface(name: string): string {
  */
 export function sendOttyCommand(paneId: string, command: string): void {
   if (!isOttySendKeysEnabled()) {
-    ottyLog(
-      `[otty send] pane=${paneId} cmd=${JSON.stringify(
-        command.slice(0, 80),
-      )} SKIPPED (send-keys disabled)\n`,
-    );
+    ottyLog(`[send] pane=${paneId} cmd=${JSON.stringify(command.slice(0, 80))} SKIPPED (send-keys disabled)`);
     return;
   }
   try {
     ottyExecSilent(["pane", "send-keys", "--pane", paneId, "--", command, "key:Enter"]);
   } catch (e) {
-    ottyLog(`[otty send] pane=${paneId} cmd failed: ${(e as Error).message}\n`);
+    ottyLog(`[send] pane=${paneId} cmd failed: ${(e as Error).message}`);
   }
 }
 
@@ -601,13 +471,13 @@ export function sendOttyCommand(paneId: string, command: string): void {
  */
 export function sendOttyEscape(paneId: string): void {
   if (!isOttySendKeysEnabled()) {
-    ottyLog(`[otty escape] pane=${paneId} SKIPPED (send-keys disabled)\n`);
+    ottyLog(`[escape] pane=${paneId} SKIPPED (send-keys disabled)`);
     return;
   }
   try {
     ottyExecSilent(["pane", "send-keys", "--pane", paneId, "--", "key:Escape"]);
   } catch (e) {
-    ottyLog(`[otty escape] pane=${paneId} failed: ${(e as Error).message}\n`);
+    ottyLog(`[escape] pane=${paneId} failed: ${(e as Error).message}`);
   }
 }
 
@@ -619,7 +489,7 @@ export function readOttyScreen(paneId: string, lines = 50): string {
   try {
     return ottyExec(["pane", "capture", "--pane", paneId, "--lines", String(lines)]);
   } catch (e) {
-    ottyLog(`[otty read] pane=${paneId} failed: ${(e as Error).message}\n`);
+    ottyLog(`[read] pane=${paneId} failed: ${(e as Error).message}`);
     return "";
   }
 }
@@ -648,7 +518,7 @@ export function closeOttySurface(paneId: string): void {
     ottyExecSilent(["pane", "close", "--pane", paneId, "--force"]);
     closed = true;
   } catch (e) {
-    ottyLog(`[otty close] pane close failed: ${(e as Error).message}\n`);
+    ottyLog(`[close] pane close failed: ${(e as Error).message}`);
   }
 
   // 2. 验证
@@ -656,7 +526,7 @@ export function closeOttySurface(paneId: string): void {
     spawnSync("sleep", ["0.1"]);
     const stillThere = capturePaneIds().has(paneId);
     if (!stillThere) {
-      ottyLog(`[otty close] pane ${paneId} closed via pane close --force\n`);
+      ottyLog(`[close] pane ${paneId} closed via pane close --force`);
       cleanupOttyStateForPane(paneId);
       return;
     }
@@ -664,7 +534,7 @@ export function closeOttySurface(paneId: string): void {
 
   // 3. fallback: 仅当 pane 是 tab 的唯一成员时才关整个 tab。
   // 否则关 tab 会把 agent pane 等其他 pane 也带走（实际事故）。
-  ottyLog(`[otty close] pane close ineffective, considering tab close fallback\n`);
+  ottyLog(`[close] pane close ineffective, considering tab close fallback`);
   const tabId = getTabIdForPane(paneId);
   if (tabId) {
     let panesInTab: OttyPaneSnapshot[] = [];
@@ -677,14 +547,14 @@ export function closeOttySurface(paneId: string): void {
     if (isLonelyTab) {
       try {
         ottyExecSilent(["tab", "close", tabId]);
-        ottyLog(`[otty close] tab ${tabId} closed (lonely tab, safe)\n`);
+        ottyLog(`[close] tab ${tabId} closed (lonely tab, safe)`);
       } catch (e) {
-        ottyLog(`[otty close] tab close failed: ${(e as Error).message}\n`);
+        ottyLog(`[close] tab close failed: ${(e as Error).message}`);
       }
     } else {
       ottyLog(
-        `[otty close] pane=${paneId} tab=${tabId} has ${panesInTab.length} panes; ` +
-          `skipping tab close to avoid clobbering other panes (agent pane is likely in this tab)\n`,
+        `[close] pane=${paneId} tab=${tabId} has ${panesInTab.length} panes; ` +
+          `skipping tab close to avoid clobbering other panes (agent pane is likely in this tab)`,
       );
     }
   }
@@ -693,56 +563,36 @@ export function closeOttySurface(paneId: string): void {
 
 /**
  * 重命名 pane 对应的 tab。
- * Otty 没有"pane -> tab id"的直接命令（pane id 包含 workspace:pane number 但
- * 没法直接拿 tab number），所以用 `panes --json` 反查 tab_id。
+ * Otty 没有"pane -> tab id"的直接命令，所以用 `panes --json` 反查 tab_id。
  */
 export function renameOttyTab(paneId: string, name: string): void {
   const tabId = getTabIdForPane(paneId);
   if (!tabId) {
-    ottyLog(`[otty rename] pane=${paneId} no tab id found\n`);
+    ottyLog(`[rename] pane=${paneId} no tab id found`);
     return;
   }
   try {
     ottyExecSilent(["tab", "rename", "--tab", tabId, name]);
   } catch (e) {
-    ottyLog(
-      `[otty rename] pane=${paneId} tab=${tabId} name=${JSON.stringify(name)} failed: ${
-        (e as Error).message
-      }\n`,
-    );
+    ottyLog(`[rename] pane=${paneId} tab=${tabId} name=${JSON.stringify(name)} failed: ${(e as Error).message}`);
   }
 }
 
 /**
- * 从 mux state marker 中清理已关闭的 pane。
+ * 从 BFS 状态 marker 中清理已关闭的 pane（复用 shared.ts 状态机）。
  * 与 muxy / herdr 的 close 行为一致：避免僵尸 ID 累积导致后续 split 走错目标。
  */
 function cleanupOttyStateForPane(paneId: string): void {
   try {
-    const parsed = readOttyState();
-    const idx = parsed.panes.indexOf(paneId);
-    if (idx < 0) return;
-    const beforePanes = [...parsed.panes];
-    const beforePos = parsed.pos;
-    parsed.panes.splice(idx, 1);
-    if (typeof parsed.pos === "number" && idx < parsed.pos) {
-      parsed.pos = Math.max(0, parsed.pos - 1);
-    }
-    if (parsed.panes.length === 0) {
-      try {
-        rmSync(ottyStateFile());
-      } catch {
-        /* ignore */
-      }
+    const state = new BfsSplitStateManager(ottyStateFile());
+    const beforePanes = state.panes();
+    state.remove(paneId);
+    const afterPanes = state.panes();
+    if (beforePanes.length !== afterPanes.length) {
       ottyLog(
-        `[otty close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> [] pos=${beforePos} -> <marker-removed>\n`,
-      );
-    } else {
-      writeOttyState(parsed);
-      ottyLog(
-        `[otty close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${JSON.stringify(
-          parsed.panes,
-        )} pos=${beforePos} -> ${parsed.pos}\n`,
+        `[close] pane=${paneId} panes=${JSON.stringify(beforePanes)} -> ${
+          afterPanes.length === 0 ? "<marker-removed>" : JSON.stringify(afterPanes)
+        }`,
       );
     }
   } catch {

--- a/packages/pi-terminal-mux/src/backends/shared.ts
+++ b/packages/pi-terminal-mux/src/backends/shared.ts
@@ -1,0 +1,250 @@
+/**
+ * backends/shared.ts — 后端共享基础设施
+ *
+ * 统一日志、文件锁、BFS 分屏状态机，消除各后端的重复实现。
+ */
+
+import { appendFileSync, mkdirSync, rmSync, statSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { execSync, execFileSync } from "node:child_process";
+
+/**
+ * 创建后端专属 logger。
+ *
+ * 日志写入 logPath（调用方传入），格式：`[ISO timestamp] [backend] msg\n`。
+ * 写失败静默忽略，不影响主流程。
+ */
+export function createBackendLogger(backend: string, logPath: string): (msg: string) => void {
+  return (msg: string): void => {
+    try {
+      appendFileSync(logPath, `[${new Date().toISOString()}] [${backend}] ${msg}\n`);
+    } catch {
+      // 写日志失败不影响主流程
+    }
+  };
+}
+
+// ── 文件锁 ──
+
+export interface FileLockOptions {
+  /** 获取锁的最大等待时间（毫秒），默认 10000 */
+  timeoutMs?: number;
+  /** 重试间隔（毫秒），默认 50 */
+  retryMs?: number;
+  /** 锁文件超过此时间视为 stale 并强制清理（毫秒），默认 30000 */
+  staleMs?: number;
+}
+
+const DEFAULT_LOCK_TIMEOUT_MS = 10_000;
+const DEFAULT_LOCK_RETRY_MS = 50;
+const DEFAULT_LOCK_STALE_MS = 30_000;
+
+/** 同步休眠（不阻塞事件循环外的线程，但阻塞当前线程） */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * 基于 mkdir 原子性的文件锁。
+ *
+ * - 用 `mkdirSync(lockPath)` 获取锁（目录创建是原子操作）
+ * - 锁目录内写入 owner 文件记录 PID
+ * - 支持 stale 检测：锁目录 mtime 超过 staleMs 时强制清理
+ * - 回调执行完毕（无论成功或抛错）后在 finally 中释放锁
+ */
+export function withFileLock<T>(lockPath: string, opts: FileLockOptions, fn: () => T): T {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const retryMs = opts.retryMs ?? DEFAULT_LOCK_RETRY_MS;
+  const staleMs = opts.staleMs ?? DEFAULT_LOCK_STALE_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      mkdirSync(lockPath);
+      writeFileSync(join(lockPath, "owner"), `${process.pid}\n`);
+      break;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw error;
+
+      // stale 检测
+      try {
+        if (Date.now() - statSync(lockPath).mtimeMs > staleMs) {
+          rmSync(lockPath, { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        // statSync 失败（锁刚好被释放），重试
+      }
+
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for file lock: ${lockPath}`);
+      }
+      sleepSync(retryMs);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
+// ── BFS 分屏状态机 ──
+
+/** BFS 分屏持久化状态 */
+interface BfsSplitState {
+  panes: string[];
+  pos: number;
+  base: number;
+  dir: "right" | "down";
+}
+
+/** next() 返回值：下一个要 split 的源 pane 及方向 */
+export interface BfsNext {
+  source: string;
+  direction: "right" | "down";
+}
+
+/**
+ * 广度优先分屏状态机，跨进程通过 marker 文件持久化。
+ *
+ * 分屏策略（与 muxy/herdr/otty 原有逻辑一致）：
+ *   第 1 轮：调用方在外部执行首次 split-right，然后 add(pane)
+ *   第 2 轮：从 p1 向下分
+ *   第 3 轮：从 p1、p2 分别向右分
+ *   第 4 轮：从 p1、p2、p3、p4 分别向下分
+ *   ……每轮结束翻转方向
+ *
+ * 用法：
+ *   const mgr = new BfsSplitStateManager(markerPath);
+ *   const next = mgr.next();       // 窥视下一个 split 源
+ *   // ... 执行 split ...
+ *   mgr.advance();                 // 消费当前 pos
+ *   mgr.add(newPaneId);            // 登记新 pane
+ */
+export class BfsSplitStateManager {
+  private readonly markerPath: string;
+  private state: BfsSplitState;
+
+  constructor(markerPath: string) {
+    this.markerPath = markerPath;
+    this.state = this.readState();
+  }
+
+  /** 从 marker 文件读取状态，文件不存在或损坏时返回初始状态 */
+  private readState(): BfsSplitState {
+    try {
+      return JSON.parse(readFileSync(this.markerPath, "utf8")) as BfsSplitState;
+    } catch {
+      return { panes: [], pos: 0, base: 0, dir: "right" };
+    }
+  }
+
+  /** 将当前状态写回 marker 文件 */
+  private writeState(): void {
+    writeFileSync(this.markerPath, JSON.stringify(this.state));
+  }
+
+  /** 窥视下一个 split 源和方向，不消费。无 pane 时返回 null */
+  next(): BfsNext | null {
+    if (this.state.panes.length === 0) return null;
+
+    let { pos, base, dir } = this.state;
+    // 本轮结束？翻转方向（窥视，不写入）
+    if (pos >= base) {
+      pos = 0;
+      base = this.state.panes.length;
+      dir = dir === "right" ? "down" : "right";
+    }
+
+    const source = this.state.panes[pos];
+    if (!source) return null;
+    return { source, direction: dir };
+  }
+
+  /** 消费当前 pos（调用方完成一次 split 后调用） */
+  advance(): void {
+    this.state.pos++;
+    this.writeState();
+  }
+
+  /** 登记新创建的 pane，必要时触发轮次翻转 */
+  add(pane: string): void {
+    this.state.panes.push(pane);
+
+    // 本轮结束？翻转方向
+    if (this.state.pos >= this.state.base) {
+      this.state.pos = 0;
+      this.state.base = this.state.panes.length;
+      this.state.dir = this.state.dir === "right" ? "down" : "right";
+    }
+
+    this.writeState();
+  }
+
+  /** 移除已关闭的 pane，修正 pos；全空时删除 marker 文件 */
+  remove(pane: string): void {
+    const idx = this.state.panes.indexOf(pane);
+    if (idx < 0) return;
+
+    this.state.panes.splice(idx, 1);
+    if (idx < this.state.pos) {
+      this.state.pos = Math.max(0, this.state.pos - 1);
+    }
+
+    if (this.state.panes.length === 0) {
+      try { rmSync(this.markerPath); } catch { /* 文件不存在也没关系 */ }
+      this.state = { panes: [], pos: 0, base: 0, dir: "right" };
+    } else {
+      this.writeState();
+    }
+  }
+
+  /** 返回当前所有 pane ID（副本） */
+  panes(): string[] {
+    return [...this.state.panes];
+  }
+}
+
+// ── 命令可用性检测 ──
+
+const commandAvailability = new Map<string, boolean>();
+
+/**
+ * 检测某命令是否在 PATH 中可用（带缓存）。
+ *
+ * 跨平台：Windows 用 where.exe，其他平台用 `command -v`。
+ * 各后端共用此实现，避免每个后端重复写 hasCommand。
+ */
+export function hasCommand(command: string): boolean {
+  if (commandAvailability.has(command)) {
+    return commandAvailability.get(command)!;
+  }
+
+  let available = false;
+  if (process.platform === "win32") {
+    try {
+      execFileSync("where.exe", [command], { stdio: "ignore" });
+      available = true;
+    } catch {
+      try {
+        execSync(`command -v ${command}`, { stdio: "ignore" });
+        available = true;
+      } catch {
+        available = false;
+      }
+    }
+  } else {
+    try {
+      execSync(`command -v ${command}`, { stdio: "ignore" });
+      available = true;
+    } catch {
+      available = false;
+    }
+  }
+
+  commandAvailability.set(command, available);
+  return available;
+}

--- a/packages/pi-terminal-mux/src/backends/tmux.ts
+++ b/packages/pi-terminal-mux/src/backends/tmux.ts
@@ -7,9 +7,13 @@
 
 import { execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { createBackendLogger } from "./shared.ts";
 import type { BackendOps } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
+
+/** Tmux 后端日志（统一格式，写入 /tmp/pi-mux-tmux.log） */
+const tmuxLog = createBackendLogger("tmux", "/tmp/pi-mux-tmux.log");
 
 export const ops: BackendOps = {
   create(_name: string): string {
@@ -40,6 +44,9 @@ export const ops: BackendOps = {
       throw new Error(`Unexpected tmux split-window output: ${pane}`);
     }
 
+    tmuxLog(
+      `[split] dir=${direction} from=${fromSurface ?? "<unset>"} new=${pane} name=${JSON.stringify(name)}`,
+    );
     return pane;
   },
 
@@ -71,6 +78,7 @@ export const ops: BackendOps = {
 
   close(surface: string): void {
     execFileSync("tmux", ["kill-pane", "-t", surface], { encoding: "utf8" });
+    tmuxLog(`[close] surface=${surface}`);
   },
 
   rename(surface: string, name: string): void {

--- a/packages/pi-terminal-mux/src/backends/wezterm.ts
+++ b/packages/pi-terminal-mux/src/backends/wezterm.ts
@@ -7,9 +7,13 @@
 import { execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { tailLines } from "../shell.ts";
+import { createBackendLogger } from "./shared.ts";
 import type { BackendOps } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
+
+/** WezTerm 后端日志（统一格式，写入 /tmp/pi-mux-wezterm.log） */
+const weztermLog = createBackendLogger("wezterm", "/tmp/pi-mux-wezterm.log");
 
 export const ops: BackendOps = {
   create(name: string): string {
@@ -41,6 +45,9 @@ export const ops: BackendOps = {
     } catch {
       // Optional — tab title is cosmetic.
     }
+    weztermLog(
+      `[split] dir=${direction} from=${fromSurface ?? "<unset>"} new=${paneId} name=${JSON.stringify(name)}`,
+    );
     return paneId;
   },
 
@@ -80,6 +87,7 @@ export const ops: BackendOps = {
     execFileSync("wezterm", ["cli", "kill-pane", "--pane-id", surface], {
       encoding: "utf8",
     });
+    weztermLog(`[close] surface=${surface}`);
   },
 
   rename(surface: string, name: string): void {

--- a/packages/pi-terminal-mux/src/backends/zellij.ts
+++ b/packages/pi-terminal-mux/src/backends/zellij.ts
@@ -7,10 +7,10 @@
 
 import { execFileSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { tailLines, sleepSync, envPositiveInteger } from "../shell.ts";
+import { withFileLock } from "./shared.ts";
 import type { BackendOps } from "./types.ts";
 
 const execFileAsync = promisify(execFile);
@@ -25,13 +25,6 @@ const ZELLIJ_CURSOR_HEIGHT_WIDTH_RATIO = 4;
 /** Pi subagent 可用空间最小值（可通过环境变量调优） */
 const DEFAULT_ZELLIJ_SUBAGENT_MIN_COLUMNS = 50;
 const DEFAULT_ZELLIJ_SUBAGENT_MIN_ROWS = 10;
-
-/** Zellij surface 锁超时（毫秒） */
-const ZELLIJ_LOCK_TIMEOUT_MS = 10000;
-/** Zellij surface 锁陈旧阈值（毫秒），超此时间视为死锁 */
-const ZELLIJ_LOCK_STALE_MS = 30000;
-/** Zellij 锁重试间隔（毫秒） */
-const ZELLIJ_LOCK_RETRY_MS = 50;
 
 // ── Zellij 公开类型 ──
 
@@ -340,37 +333,12 @@ function zellijSurfaceLockPath(): string {
 }
 
 function withZellijSurfaceLock<T>(callback: () => T): T {
-  const lockPath = zellijSurfaceLockPath();
-  const deadline = Date.now() + ZELLIJ_LOCK_TIMEOUT_MS;
-
-  while (true) {
-    try {
-      mkdirSync(lockPath);
-      writeFileSync(join(lockPath, "owner"), `${process.pid}\n`);
-      break;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "EEXIST") throw error;
-
-      try {
-        if (Date.now() - statSync(lockPath).mtimeMs > ZELLIJ_LOCK_STALE_MS) {
-          rmSync(lockPath, { recursive: true, force: true });
-          continue;
-        }
-      } catch {}
-
-      if (Date.now() > deadline) {
-        throw new Error(`Timed out waiting for zellij surface lock: ${lockPath}`);
-      }
-      sleepSync(ZELLIJ_LOCK_RETRY_MS);
-    }
-  }
-
-  try {
-    return callback();
-  } finally {
-    rmSync(lockPath, { recursive: true, force: true });
-  }
+  // 复用 shared.ts 的统一文件锁（mkdir 原子获取 + stale 检测 + finally 释放）
+  return withFileLock(
+    zellijSurfaceLockPath(),
+    { timeoutMs: 10000, retryMs: 50, staleMs: 30000 },
+    callback,
+  );
 }
 
 function createZellijSurfaceUnlocked(name: string): string {

--- a/packages/pi-terminal-mux/src/detection.ts
+++ b/packages/pi-terminal-mux/src/detection.ts
@@ -10,11 +10,11 @@
  * muxLog 被多模块使用，归此文件。
  */
 
-import { execSync, execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { i18n } from "./i18n.ts";
 import { isHerdrRuntimeAvailable } from "./herdr.ts";
 import { isOttyRuntimeAvailable, ottySetupHint } from "./otty.ts";
+import { hasCommand } from "./backends/shared.ts";
 
 // ── 分屏调试日志 ──
 
@@ -51,40 +51,7 @@ export const AGENT_MUXY_PANE_ID = process.env.MUXY_PANE_ID;
 
 export type MuxBackend = "cmux" | "muxy" | "tmux" | "zellij" | "wezterm" | "herdr" | "otty";
 
-// ── 命令可用性检测 ──
-
-const commandAvailability = new Map<string, boolean>();
-
-function hasCommand(command: string): boolean {
-  if (commandAvailability.has(command)) {
-    return commandAvailability.get(command)!;
-  }
-
-  let available = false;
-  if (process.platform === "win32") {
-    try {
-      execFileSync("where.exe", [command], { stdio: "ignore" });
-      available = true;
-    } catch {
-      try {
-        execSync(`command -v ${command}`, { stdio: "ignore" });
-        available = true;
-      } catch {
-        available = false;
-      }
-    }
-  } else {
-    try {
-      execSync(`command -v ${command}`, { stdio: "ignore" });
-      available = true;
-    } catch {
-      available = false;
-    }
-  }
-
-  commandAvailability.set(command, available);
-  return available;
-}
+// 命令可用性检测复用 backends/shared.ts 的 hasCommand（跨平台 + 缓存）。
 
 // ── 偏好解析 ──
 

--- a/packages/pi-terminal-mux/tests/shared.test.ts
+++ b/packages/pi-terminal-mux/tests/shared.test.ts
@@ -1,0 +1,260 @@
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, utimesSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createBackendLogger, withFileLock, BfsSplitStateManager, hasCommand } from "../src/backends/shared.ts";
+
+/** 每个测试用例的临时目录列表，afterEach 统一清理 */
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "pi-mux-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createBackendLogger", () => {
+  // 验证日志格式：[ISO] [backend] msg
+  test("writes timestamped message with backend tag to log file", () => {
+    const logDir = makeTempDir();
+    const logPath = join(logDir, "pi-mux-tmux.log");
+    const log = createBackendLogger("tmux", logPath);
+
+    log("split created");
+
+    const content = readFileSync(logPath, "utf8");
+    assert.match(content, /^\[\d{4}-\d{2}-\d{2}T[^\]]+\] \[tmux\] split created\n$/);
+  });
+
+  // 验证多次调用是追加而非覆盖
+  test("appends multiple messages", () => {
+    const logDir = makeTempDir();
+    const logPath = join(logDir, "pi-mux-muxy.log");
+    const log = createBackendLogger("muxy", logPath);
+
+    log("first");
+    log("second");
+
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /\[muxy\] first$/);
+    assert.match(lines[1], /\[muxy\] second$/);
+  });
+
+  // 验证写失败时静默不抛
+  test("does not throw when log path is not writable", () => {
+    const logDir = makeTempDir();
+    const logPath = join(logDir, "no-such-dir", "deep", "log.log");
+    const log = createBackendLogger("herdr", logPath);
+
+    log("this goes nowhere");
+  });
+});
+
+describe("withFileLock", () => {
+  // 验证锁内回调正常执行并返回结果
+  test("executes callback and returns its result", () => {
+    const lockDir = makeTempDir();
+    const lockPath = join(lockDir, "test.lock");
+
+    const result = withFileLock(lockPath, {}, () => "done");
+
+    assert.equal(result, "done");
+  });
+
+  // 验证回调执行后锁文件被清理
+  test("removes lock file after callback completes", () => {
+    const lockDir = makeTempDir();
+    const lockPath = join(lockDir, "test.lock");
+
+    withFileLock(lockPath, {}, () => {});
+
+    assert.equal(existsSync(lockPath), false);
+  });
+
+  // 验证回调抛错时锁仍然被释放
+  test("removes lock file even when callback throws", () => {
+    const lockDir = makeTempDir();
+    const lockPath = join(lockDir, "test.lock");
+
+    assert.throws(() => {
+      withFileLock(lockPath, {}, () => {
+        throw new Error("boom");
+      });
+    }, /boom/);
+
+    assert.equal(existsSync(lockPath), false);
+  });
+
+  // 验证 stale 锁被自动清理：手动创建一个 mtime 很旧的锁目录
+  test("acquires lock after stale lock expires", () => {
+    const lockDir = makeTempDir();
+    const lockPath = join(lockDir, "stale.lock");
+
+    // 手动创建 stale 锁（mkdir 方式，与实现一致）
+    mkdirSync(lockPath);
+    // 将 mtime 回拨 60 秒（超过默认 staleMs=30000）
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(lockPath, past, past);
+
+    const result = withFileLock(lockPath, {}, () => "recovered");
+
+    assert.equal(result, "recovered");
+    assert.equal(existsSync(lockPath), false);
+  });
+
+  // 验证活跃锁未被 stale 清理：回调内嵌套尝试获取同名锁应超时
+  test("does not acquire lock held by another active owner", () => {
+    const lockDir = makeTempDir();
+    const lockPath = join(lockDir, "active.lock");
+
+    const result = withFileLock(lockPath, { timeoutMs: 200, retryMs: 10, staleMs: 30_000 }, () => {
+      // 锁被当前回调持有，内部再获取应超时抛错
+      assert.throws(() => {
+        withFileLock(lockPath, { timeoutMs: 100, retryMs: 10, staleMs: 30_000 }, () => "inner");
+      }, /lock/i);
+      return "outer";
+    });
+
+    assert.equal(result, "outer");
+  });
+});
+
+describe("BfsSplitStateManager", () => {
+  // 初始状态：next() 返回 null（无 pane 可 split）
+  test("returns null source from empty state", () => {
+    const dir = makeTempDir();
+    const manager = new BfsSplitStateManager(join(dir, "state.json"));
+
+    assert.equal(manager.next(), null);
+  });
+
+  // 首次 add 后，next() 返回该 pane，方向为 down（首轮 right 已由调用方执行）
+  test("after first add, next returns that pane with direction flip", () => {
+    const dir = makeTempDir();
+    const manager = new BfsSplitStateManager(join(dir, "state.json"));
+
+    manager.add("pane-1");
+
+    const next = manager.next();
+    assert.deepEqual(next, { source: "pane-1", direction: "down" });
+  });
+
+  // 广度优先遍历：第一轮 right，第二轮 down，第三轮 right...
+  test("breadth-first direction alternates per round", () => {
+    const dir = makeTempDir();
+    const manager = new BfsSplitStateManager(join(dir, "state.json"));
+
+    // 模拟首次 split-right 后 add
+    manager.add("p1"); // round 1 done, base=1, dir flips to down
+
+    // round 2: split down from p1
+    const r2 = manager.next();
+    assert.deepEqual(r2, { source: "p1", direction: "down" });
+    manager.advance(); // consume p1 for this round
+    manager.add("p2"); // round 2 done, base=2 (p1,p2), dir flips to right
+
+    // round 3: split right from p1, then p2
+    const r3a = manager.next();
+    assert.deepEqual(r3a, { source: "p1", direction: "right" });
+    manager.advance();
+    const r3b = manager.next();
+    assert.deepEqual(r3b, { source: "p2", direction: "right" });
+  });
+
+  // remove 正确清理：移除 pane 后 pos 修正
+  test("remove adjusts position when removing before cursor", () => {
+    const dir = makeTempDir();
+    const manager = new BfsSplitStateManager(join(dir, "state.json"));
+
+    manager.add("p1");
+    manager.advance(); // pos=1
+    manager.add("p2"); // panes=[p1,p2], pos=1 (round complete triggers on next)
+
+    manager.remove("p1");
+
+    // p1 removed, p2 should still be accessible
+    const panes = manager.panes();
+    assert.deepEqual(panes, ["p2"]);
+  });
+
+  // 全部移除后 marker 文件被删除，next() 返回 null
+  test("removes marker file when all panes removed", () => {
+    const dir = makeTempDir();
+    const markerPath = join(dir, "state.json");
+    const manager = new BfsSplitStateManager(markerPath);
+
+    manager.add("p1");
+    assert.equal(existsSync(markerPath), true);
+
+    manager.remove("p1");
+
+    assert.equal(existsSync(markerPath), false);
+    assert.equal(manager.next(), null);
+  });
+
+  // 状态持久化：新实例从 marker 文件恢复
+  test("persists state across instances", () => {
+    const dir = makeTempDir();
+    const markerPath = join(dir, "state.json");
+
+    const m1 = new BfsSplitStateManager(markerPath);
+    m1.add("p1");
+    m1.advance();
+    m1.add("p2");
+
+    // 新实例应恢复状态
+    const m2 = new BfsSplitStateManager(markerPath);
+    assert.deepEqual(m2.panes(), ["p1", "p2"]);
+  });
+
+  // 文件损坏时回退到初始状态
+  test("recovers from corrupted marker file", () => {
+    const dir = makeTempDir();
+    const markerPath = join(dir, "state.json");
+    writeFileSync(markerPath, "not json {{{");
+
+    const manager = new BfsSplitStateManager(markerPath);
+
+    assert.equal(manager.next(), null);
+    assert.deepEqual(manager.panes(), []);
+  });
+
+  // remove 不存在的 pane 不改变状态
+  test("remove of unknown pane is a no-op", () => {
+    const dir = makeTempDir();
+    const manager = new BfsSplitStateManager(join(dir, "state.json"));
+
+    manager.add("p1");
+    manager.remove("nonexistent");
+
+    assert.deepEqual(manager.panes(), ["p1"]);
+  });
+});
+
+describe("hasCommand", () => {
+  // 真实存在的命令（node 必然在 PATH）
+  test("returns true for an existing command", () => {
+    assert.equal(hasCommand("node"), true);
+  });
+
+  // 不存在的命令
+  test("returns false for a missing command", () => {
+    assert.equal(hasCommand("definitely-not-a-real-cmd-xyz-123"), false);
+  });
+
+  // 缓存：重复调用同一命令返回一致结果
+  test("returns consistent result on repeated calls", () => {
+    const first = hasCommand("node");
+    const second = hasCommand("node");
+    assert.equal(first, second);
+  });
+});


### PR DESCRIPTION
## 问题（维护）

7 个终端后端各自实现了一套基础设施，导致实现散乱、不一致：

- **日志不统一**：muxy / herdr / otty 各有自己的 log 函数、写不同命名的文件；cmux / tmux / zellij / wezterm **完全没有日志**。
- **文件锁重复**：muxy 的 `acquireMuxyLock`、herdr 的内联 IIFE 锁、zellij 的 `withZellijSurfaceLock` 是三份近似实现。
- **BFS 分屏状态机复制粘贴三次**：muxy / herdr / otty 各有一份几乎相同的 `{ panes, pos, base, dir }` 状态机 + marker 文件读写。
- **`hasCommand` 重复**：detection.ts、backends/herdr.ts、backends/otty.ts 各有一份。

## 可观测行为变化

- 7 个后端现在都通过统一的 `createBackendLogger` 输出日志，格式 `[ISO] [backend] msg`，路径 `/tmp/pi-mux-<backend>.log`。cmux / tmux / wezterm 此前无日志，现在有了。
- **日志路径变更**（原本就有日志的三个后端）：
  - `/tmp/pi-muxy-split.log` → `/tmp/pi-mux-muxy.log`
  - `/tmp/pi-herdr-split.log` → `/tmp/pi-mux-herdr.log`
  - `/tmp/pi-otty-split.log` → `/tmp/pi-mux-otty.log`
  - 依赖旧路径 grep 排查的用户需要更新。
- 顺带修复 otty 的一个潜在 bug：stale-pane 恢复时删了 marker 文件却又把旧的内存状态写回（自己抵消了重置），现在与 herdr 一致正确重置。
- **统一 surface API（createSurface / sendCommand / readScreen 等）与 BackendOps 契约无变化**。

## 包与文档影响

- 新增内部模块 `backends/shared.ts`（`createBackendLogger` / `withFileLock` / `BfsSplitStateManager` / `hasCommand`），不属于公开导出；`index.ts` / `mux.ts` 导出面不变。
- `muxLog` 仍从 detection.ts / `./mux` subpath 导出，签名与写入路径不变。
- README 未引用这些日志路径，无需改动。
- 无依赖变化。

## 验证

- 新增 19 个测试 `tests/shared.test.ts`（logger / file lock / BFS 状态机 / hasCommand），按 TDD red→green 编写。
- pi-terminal-mux 包级 `npm run check` 通过（typecheck + 45 tests + pack dry-run），exit 0。
- 仓库级策略检查通过：`check-no-local-bindings` ✅、`check-package-config` ✅。
- **局限**：各后端对真实 multiplexer CLI 的调用（muxy / cmux / tmux / zellij / wezterm / herdr / otty 命令）不在测试覆盖内——需要安装对应 multiplexer。这些路径本次仅通过 typecheck 与不变的 BackendOps 契约保证，未在真实 multiplexer 上跑通。
