### PR TITLE
fix(pi-distill): enforce minChars for error outputs

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -177,7 +177,7 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | `maxChars` | Maximum output budget for the distillation model (about `maxChars / 2` tokens) and a diagnostic reference; no longer used to write files. |
 | `timeoutSeconds` | Maximum time allowed for the distillation model call. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
-| `summarizeErrors` | Whether error results should still be sent to the distillation model. |
+| `summarizeErrors` | Whether error results that meet `minChars` should still be sent to the distillation model. |
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
 The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`. The legacy `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` option is still parsed for backward compatibility but no longer has any effect.

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -179,7 +179,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | `maxChars` | 提炼模型的最大输出预算（约 `maxChars / 2` tokens），同时作为诊断参考；不再用于写文件。 |
 | `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
-| `summarizeErrors` | 工具返回错误时是否仍发送给提炼模型。 |
+| `summarizeErrors` | 工具返回错误且达到 `minChars` 时，是否仍发送给提炼模型。 |
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
 主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。旧配置中的 `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` 仍会被解析以兼容旧文件，但不再生效。

--- a/packages/pi-distill/src/summary-utils.ts
+++ b/packages/pi-distill/src/summary-utils.ts
@@ -31,7 +31,7 @@ export interface BashSummaryConfig {
   timeoutSeconds: number;
   /** 无 prompt 的长输出触发 missed-compression 提醒所需的倍数。 */
   missedCompressionRatio: number;
-  /** 工具返回错误结果时是否仍调用提炼模型。 */
+  /** 工具返回错误且达到最小长度时是否仍调用提炼模型。 */
   summarizeErrors: boolean;
 }
 
@@ -364,11 +364,11 @@ export function decideOutputSummary(
   if (!config) return { intent, shouldSummarize: false, reason: "disabled" };
   if (intent === "none") return { intent, shouldSummarize: false, reason: "not-requested" };
   if (intent === "full") return { intent, shouldSummarize: false, reason: "full-output" };
-  if (isError && config.summarizeErrors) {
-    return { intent, shouldSummarize: true, reason: "error-output" };
-  }
   if (output.length < config.minChars) {
     return { intent, shouldSummarize: false, reason: "below-threshold" };
+  }
+  if (isError && config.summarizeErrors) {
+    return { intent, shouldSummarize: true, reason: "error-output" };
   }
   return { intent, shouldSummarize: true, reason: "explicit-summary" };
 }

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -213,7 +213,7 @@ test("只有明确需要摘要且输出达到阈值时才总结", () => {
   assert.equal(shouldSummarizeOutput("总结错误", "1234567890", undefined), false);
 });
 
-test("错误工具输出默认绕过长度阈值进行总结，并支持关闭", () => {
+test("错误工具输出也遵守最小长度阈值，并支持关闭总结", () => {
   const config = {
     minChars: 100,
     maxChars: 1000,
@@ -223,11 +223,9 @@ test("错误工具输出默认绕过长度阈值进行总结，并支持关闭",
     summarizeErrors: true,
   };
 
-  assert.equal(shouldSummarizeOutput("总结错误", "短错误", config, true), true);
-  assert.equal(
-    shouldSummarizeOutput("总结错误", "短错误", { ...config, summarizeErrors: false }, true),
-    false,
-  );
+  assert.equal(shouldSummarizeOutput("总结错误", "短错误", config, true), false);
+  assert.equal(shouldSummarizeOutput("总结错误", "x".repeat(100), config, true), true);
+  assert.equal(shouldSummarizeOutput("总结错误", "短错误", { ...config, summarizeErrors: false }, true), false);
   assert.equal(shouldSummarizeOutput("RAW", "短错误", config, true), false);
   assert.equal(shouldSummarizeOutput(undefined, "短错误", config, true), false);
 });


### PR DESCRIPTION
## 变更摘要
- 修复错误工具输出绕过 `minChars` 的问题。
- 现在所有文本输出先经过最小长度判断；达到阈值的错误结果才继续由 `summarizeErrors` 决定。
- 新增按工具配置 `tools.<name>.enabled`，控制该工具是否注入 `outputRequest` 以及是否进行结果提炼；未配置的工具默认开启。
- `/pi-distill` 设置面板新增“工具 outputRequest”子菜单，可逐个工具开关，并在保存后立即刷新工具 schema。
- 禁用工具时会移除扩展字段并原样返回结果，不影响底层工具执行。
- 更新中英文文档、配置示例、locale 和回归测试。

## 关联需求
- 来源：用户反馈 `min output` 配置对短错误输出不生效，并需要按工具开关 `outputRequest`。
- 无独立 PRD 或 issue。

## 验证
- `npm run check` 通过。
- `pi-distill` 测试 20/20 通过。
- 全部 workspace 类型检查、测试、无本机路径门禁、i18n 校验和 package config 检查通过。

## 上线清单
### SQL 工单
- 无 DDL/DML，无需回滚 SQL。

### Apollo 配置
- 无配置变更。

### 上线顺序
- 无特殊部署顺序；按现有 release-please/npm 发布流程即可。

### 权限配置
- 无权限 ID 或角色变更。

### 其他
- 无缓存清理、数据迁移或第三方 API 变更。
- 无额外下游通知或专项监控要求。