### PR TITLE
feat(pi-distill): default disable edit and write distillation

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -106,7 +106,7 @@ pi-distill uses the actual result and configuration to keep it, distill it, or w
 Agent consumes a result suited to the current decision, with auditable diagnostics
 ```
 
-1. At session start, the extension adds required `outputRequest` to every enabled active tool whose parameter schema is an object. It does not hard-code `bash`, `read`, `grep`, or `find`.
+1. At session start, the extension adds required `outputRequest` to every enabled active tool whose parameter schema is an object. `edit` and `write` are disabled by default; other tools are enabled unless configured otherwise. It does not hard-code `bash`, `read`, `grep`, or `find`.
 2. The `tool_call` handler captures the parameter and removes it before forwarding the call, so the underlying tool never receives the extension-only field.
 3. The `tool_result` handler sees the actual output and decides what to do; it does not rely on the agent predicting the output size.
 4. Every tool call must include a non-empty `outputRequest`. A prompt containing only `RAW` explicitly requests the original. Any other non-empty prompt permits distillation once the configured threshold is reached.
@@ -178,7 +178,7 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | `timeoutSeconds` | Maximum time allowed for the distillation model call. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
 | `summarizeErrors` | Whether error results that meet `minChars` should still be sent to the distillation model. |
-| `tools.<name>.enabled` | Enables or disables `outputRequest` injection and result distillation for one tool. Unconfigured tools are enabled by default; it can also be changed from `/pi-distill`. |
+| `tools.<name>.enabled` | Enables or disables `outputRequest` injection and result distillation for one tool. `edit` and `write` default to disabled; other unconfigured tools default to enabled. It can also be changed from `/pi-distill`. |
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
 The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`. The legacy `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` option is still parsed for backward compatibility but no longer has any effect.

--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -106,7 +106,7 @@ pi-distill uses the actual result and configuration to keep it, distill it, or w
 Agent consumes a result suited to the current decision, with auditable diagnostics
 ```
 
-1. At session start, the extension adds required `outputRequest` to every active tool whose parameter schema is an object. It does not hard-code `bash`, `read`, `grep`, or `find`.
+1. At session start, the extension adds required `outputRequest` to every enabled active tool whose parameter schema is an object. It does not hard-code `bash`, `read`, `grep`, or `find`.
 2. The `tool_call` handler captures the parameter and removes it before forwarding the call, so the underlying tool never receives the extension-only field.
 3. The `tool_result` handler sees the actual output and decides what to do; it does not rely on the agent predicting the output size.
 4. Every tool call must include a non-empty `outputRequest`. A prompt containing only `RAW` explicitly requests the original. Any other non-empty prompt permits distillation once the configured threshold is reached.
@@ -134,7 +134,7 @@ The distillation prompt strictly follows the locale selected by `/pi-language`:
 
 ## Scope and boundaries
 
-- Handles every active tool with an object parameter schema; whether `outputRequest` can be injected is determined by the tool schema, not a fixed allowlist.
+- Handles every enabled active tool with an object parameter schema; whether `outputRequest` can be injected is determined by the tool schema, not a fixed allowlist.
 - Registers no replacement tools, does not change tool execution semantics, and does not require a separately installed `pi-tool-display` host package.
 - Text distillation is lossy; use `RAW` when completeness matters.
 - Non-text results are a completeness boundary: images, audio, binary data, and mixed content bypass text distillation.
@@ -178,6 +178,7 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | `timeoutSeconds` | Maximum time allowed for the distillation model call. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
 | `summarizeErrors` | Whether error results that meet `minChars` should still be sent to the distillation model. |
+| `tools.<name>.enabled` | Enables or disables `outputRequest` injection and result distillation for one tool. Unconfigured tools are enabled by default; it can also be changed from `/pi-distill`. |
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
 The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`. The legacy `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` option is still parsed for backward compatibility but no longer has any effect.

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -108,7 +108,7 @@ pi-distill 根据真实结果和配置决定：原样返回，或调用模型提
 Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 ```
 
-1. 扩展在会话启动时为所有已启用、参数 schema 为 object 的工具增加必填的 `outputRequest` 参数，不写死 `bash`、`read`、`grep` 或 `find`。
+1. 扩展在会话启动时为所有已启用、参数 schema 为 object 的工具增加必填的 `outputRequest` 参数；`edit` 和 `write` 默认关闭，其他未配置工具默认开启。不写死 `bash`、`read`、`grep` 或 `find`。
 2. `tool_call` 事件捕获这个参数，并在交给底层工具前移除它，因此原工具不会收到扩展专用字段。
 3. `tool_result` 事件拿到真实输出后再做判断，不依赖 Agent 对输出长度的预测。
 4. 每次工具调用都必须包含非空的 `outputRequest`；严格的 `RAW` 表示明确要求原文；其他非空 prompt 才允许进入提炼流程。
@@ -181,7 +181,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
 | `summarizeErrors` | 工具返回错误且达到 `minChars` 时，是否仍发送给提炼模型。 |
-| `tools.<name>.enabled` | 按工具开启或关闭 `outputRequest` 注入和结果提炼。未配置的工具默认开启，也可以通过 `/pi-distill` 修改。 |
+| `tools.<name>.enabled` | 按工具开启或关闭 `outputRequest` 注入和结果提炼。`edit` 和 `write` 默认关闭，其他未配置工具默认开启，也可以通过 `/pi-distill` 修改。 |
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
 主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。旧配置中的 `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` 仍会被解析以兼容旧文件，但不再生效。

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -162,6 +162,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
+  "tools": {},
   "render": {
     "enabled": true,
     "showPrompt": true,
@@ -180,6 +181,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
 | `summarizeErrors` | 工具返回错误且达到 `minChars` 时，是否仍发送给提炼模型。 |
+| `tools.<name>.enabled` | 按工具开启或关闭 `outputRequest` 注入和结果提炼。未配置的工具默认开启，也可以通过 `/pi-distill` 修改。 |
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
 主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。旧配置中的 `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` 仍会被解析以兼容旧文件，但不再生效。

--- a/packages/pi-distill/config.example.json
+++ b/packages/pi-distill/config.example.json
@@ -6,6 +6,7 @@
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
+  "tools": {},
   "render": {
     "enabled": true,
     "showPrompt": true,

--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -87,6 +87,22 @@
     "zh-CN": "显示摘要：{value}",
     "en-US": "Show summary: {value}"
   },
+  "toolOverrides": {
+    "zh-CN": "工具 outputRequest",
+    "en-US": "Tool outputRequest"
+  },
+  "toolSettingsTitle": {
+    "zh-CN": "工具 outputRequest 设置",
+    "en-US": "Tool outputRequest settings"
+  },
+  "toolStatus": {
+    "zh-CN": "{tool}：{value}",
+    "en-US": "{tool}: {value}"
+  },
+  "noConfigurableTools": {
+    "zh-CN": "当前没有可配置的工具。",
+    "en-US": "No configurable tools are currently available."
+  },
   "minOutputTitle": {
     "zh-CN": "最小输出字符数",
     "en-US": "Minimum output chars"

--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -63,6 +63,10 @@
     "zh-CN": "摘要上限：{value} 字符",
     "en-US": "Summary limit: {value} chars"
   },
+  "finalLimit": {
+    "zh-CN": "最终输出上限：{value} 字符",
+    "en-US": "Final output limit: {value} chars"
+  },
   "timeout": {
     "zh-CN": "超时：{value}s",
     "en-US": "Timeout: {value}s"
@@ -110,6 +114,10 @@
   "summaryLimitTitle": {
     "zh-CN": "摘要字符上限",
     "en-US": "Summary character limit"
+  },
+  "finalLimitTitle": {
+    "zh-CN": "最终输出字符上限",
+    "en-US": "Final output character limit"
   },
   "timeoutTitle": {
     "zh-CN": "提炼模型超时（秒）",

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -47,12 +47,15 @@ import {
   buildSummaryUserPrompt,
   decideOutputSummary,
   getDistillConfigPath,
+  isRawSummary,
+  isDistillToolEnabled,
   loadDistillConfig,
   MIN_EFFECTIVE_COMPRESSION_RATIO,
   shouldFallbackToOriginal,
   type BashSummaryConfig,
   type DistillConfigFile,
   type DistillRenderConfig,
+  type DistillToolConfig,
   type OutputSummaryDecision,
 } from "./summary-utils.ts";
 
@@ -77,10 +80,21 @@ type DistillExecutionContext = {
 };
 
 type PendingDistillCall = {
+  enabled: boolean;
   outputRequest: string;
   originalUserPrompt?: string;
   startedAt: number;
 };
+
+type OutputRequestSchemaState = {
+  hadProperties: boolean;
+  hadOutputRequest: boolean;
+  originalOutputRequest?: unknown;
+  hadRequired: boolean;
+  originalRequired?: unknown;
+};
+
+const outputRequestSchemaStates = new WeakMap<object, OutputRequestSchemaState>();
 
 type ToolResultEventPatch = {
   content?: ToolResultEvent["content"];
@@ -415,6 +429,8 @@ export async function processToolResult(
     console.warn(`[pi-distill] ${loaded.warnings.join(" | ")}`);
   }
 
+  if (config && loaded.enabled && !isDistillToolEnabled(config, context.toolName)) return result;
+
   if (hasNonTextContent(result)) {
     return attachDiagnostics(result, {
       toolExecutionMs,
@@ -639,24 +655,62 @@ export async function processToolResult(
   }
 }
 
-function extendOutputRequestParameter(tool: ToolInfo): boolean {
+function restoreOutputRequestParameter(parameters: Record<string, unknown>): boolean {
+  const state = outputRequestSchemaStates.get(parameters);
+  if (!state) return false;
+
+  const properties = parameters.properties;
+  if (state.hadOutputRequest) {
+    if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+      (properties as Record<string, unknown>).outputRequest = state.originalOutputRequest;
+    }
+  } else if (properties && typeof properties === "object" && !Array.isArray(properties)) {
+    delete (properties as Record<string, unknown>).outputRequest;
+    if (!state.hadProperties && Object.keys(properties).length === 0) {
+      delete parameters.properties;
+    }
+  }
+
+  if (state.hadRequired) parameters.required = state.originalRequired;
+  else delete parameters.required;
+  outputRequestSchemaStates.delete(parameters);
+  return true;
+}
+
+function extendOutputRequestParameter(tool: ToolInfo, enabled: boolean): boolean {
   const parameters = tool.parameters as unknown as Record<string, unknown> | undefined;
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
     console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
     return false;
   }
 
+  if (!enabled) return restoreOutputRequestParameter(parameters);
+
   if (parameters.type !== "object") {
     console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
     return false;
   }
 
+  const hadProperties = Object.prototype.hasOwnProperty.call(parameters, "properties");
   const properties = parameters.properties;
   if (properties === undefined) {
     parameters.properties = {};
   } else if (typeof properties !== "object" || properties === null || Array.isArray(properties)) {
     console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
     return false;
+  }
+
+  if (!outputRequestSchemaStates.has(parameters)) {
+    const currentProperties = parameters.properties as Record<string, unknown> | undefined;
+    outputRequestSchemaStates.set(parameters, {
+      hadProperties,
+      hadOutputRequest: Boolean(currentProperties && Object.prototype.hasOwnProperty.call(currentProperties, "outputRequest")),
+      originalOutputRequest: currentProperties?.outputRequest,
+      hadRequired: Object.prototype.hasOwnProperty.call(parameters, "required"),
+      originalRequired: Array.isArray(parameters.required)
+        ? [...parameters.required]
+        : parameters.required,
+    });
   }
 
   (parameters.properties as Record<string, unknown>).outputRequest = {
@@ -671,10 +725,14 @@ function extendOutputRequestParameter(tool: ToolInfo): boolean {
   return true;
 }
 
-export function extendDistillToolParameters(pi: Pick<ExtensionAPI, "getAllTools">): number {
+export function extendDistillToolParameters(
+  pi: Pick<ExtensionAPI, "getAllTools">,
+  loaded = loadDistillConfig(),
+): number {
   let extended = 0;
   for (const tool of pi.getAllTools()) {
-    if (extendOutputRequestParameter(tool)) extended += 1;
+    const enabled = loaded.enabled && Boolean(loaded.config) && isDistillToolEnabled(loaded.config, tool.name);
+    if (extendOutputRequestParameter(tool, enabled) && enabled) extended += 1;
   }
   return extended;
 }
@@ -688,6 +746,7 @@ function toToolResultEventResult(result: ToolResult): ToolResultEventPatch {
 }
 
 type DistillUiConfig = Required<Pick<DistillConfigFile, "enabled" | "model" | "minChars" | "maxChars" | "maxOutputChars" | "timeoutSeconds" | "missedCompressionRatio" | "summarizeErrors">> & {
+  tools: DistillToolConfig;
   render: DistillRenderConfig;
 };
 
@@ -705,6 +764,9 @@ function getDistillUiConfig(): DistillUiConfig {
     timeoutSeconds: config?.timeoutSeconds ?? 10,
     missedCompressionRatio: config?.missedCompressionRatio ?? 10,
     summarizeErrors: config?.summarizeErrors ?? true,
+    tools: Object.fromEntries(
+      Object.entries(config?.tools ?? {}).map(([toolName, override]) => [toolName, { ...override }]),
+    ),
     render: { ...loaded.render },
   };
 }
@@ -744,6 +806,7 @@ async function saveDistillConfigFile(
   ctx: ExtensionCommandContext,
   config: DistillUiConfig,
   configPath: string,
+  onSaved?: () => void,
 ): Promise<void> {
   await mkdir(dirname(configPath), { recursive: true });
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
@@ -751,9 +814,51 @@ async function saveDistillConfigFile(
   if (saved.warnings.length > 0) {
     ctx.ui.notify(i18n.t("savedWarnings", { warnings: saved.warnings.join(" ") }), "warning");
   }
+  onSaved?.();
 }
 
-async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: string): Promise<void> {
+function getConfigurableToolNames(pi: Pick<ExtensionAPI, "getAllTools">): string[] {
+  return [...new Set(
+    pi.getAllTools()
+      .map((tool) => tool.name)
+      .filter((name): name is string => typeof name === "string" && name.trim().length > 0),
+  )].sort();
+}
+
+async function runDistillToolConfigUi(
+  ctx: ExtensionCommandContext,
+  pi: Pick<ExtensionAPI, "getAllTools">,
+  config: DistillUiConfig,
+  configPath: string,
+  onSaved: () => void,
+): Promise<void> {
+  const toolNames = getConfigurableToolNames(pi);
+  if (toolNames.length === 0) {
+    ctx.ui.notify(i18n.t("noConfigurableTools"), "warning");
+    return;
+  }
+
+  while (true) {
+    const choices = toolNames.map((toolName) => i18n.t("toolStatus", {
+      tool: toolName,
+      value: isDistillToolEnabled(config, toolName) ? i18n.t("on") : i18n.t("off"),
+    }));
+    const choice = await ctx.ui.select(i18n.t("toolSettingsTitle"), choices);
+    if (choice === undefined) return;
+    const index = choices.indexOf(choice);
+    if (index < 0) return;
+    const toolName = toolNames[index];
+    config.tools[toolName] = { enabled: !isDistillToolEnabled(config, toolName) };
+    await saveDistillConfigFile(ctx, config, configPath, onSaved);
+  }
+}
+
+async function runDistillConfigUi(
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  configPath: string,
+  onSaved: () => void,
+): Promise<void> {
   const loaded = loadDistillConfig();
   if (loaded.warnings.length > 0) {
     ctx.ui.notify(i18n.t("configWarnings", { warnings: loaded.warnings.join(" ") }), "warning");
@@ -773,66 +878,69 @@ async function runDistillConfigUi(ctx: ExtensionCommandContext, configPath: stri
       i18n.t("auditRenderer", { value: config.render.enabled ? i18n.t("on") : i18n.t("off") }),
       i18n.t("showOutputRequest", { value: config.render.showPrompt ? i18n.t("on") : i18n.t("off") }),
       i18n.t("showSummary", { value: config.render.showResult ? i18n.t("on") : i18n.t("off") }),
+      i18n.t("toolOverrides"),
     ];
     const choice = await ctx.ui.select(i18n.t("settingsTitle"), choices);
     if (choice === undefined) return;
 
     if (choice === choices[0]) {
       config.enabled = !config.enabled;
-      await saveDistillConfigFile(ctx, config, configPath);
+      await saveDistillConfigFile(ctx, config, configPath, onSaved);
     } else if (choice === choices[1]) {
       const value = await editDistillModel(ctx, config.model);
       if (value !== undefined) {
         config.model = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[2]) {
       const value = await editDistillNumber(ctx, i18n.t("minOutputTitle"), config.minChars);
       if (value !== undefined) {
         config.minChars = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[3]) {
       const value = await editDistillNumber(ctx, i18n.t("summaryLimitTitle"), config.maxChars);
       if (value !== undefined) {
         config.maxChars = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[4]) {
       const value = await editDistillNumber(ctx, i18n.t("finalLimitTitle"), config.maxOutputChars);
       if (value !== undefined) {
         config.maxOutputChars = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[5]) {
       const value = await editDistillNumber(ctx, i18n.t("timeoutTitle"), config.timeoutSeconds);
       if (value !== undefined) {
         config.timeoutSeconds = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[6]) {
       const value = await editDistillNumber(ctx, i18n.t("thresholdTitle"), config.missedCompressionRatio);
       if (value !== undefined) {
         config.missedCompressionRatio = value;
-        await saveDistillConfigFile(ctx, config, configPath);
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[7]) {
       config.summarizeErrors = !config.summarizeErrors;
-      await saveDistillConfigFile(ctx, config, configPath);
+      await saveDistillConfigFile(ctx, config, configPath, onSaved);
     } else if (choice === choices[8]) {
       config.render.enabled = !config.render.enabled;
-      await saveDistillConfigFile(ctx, config, configPath);
+      await saveDistillConfigFile(ctx, config, configPath, onSaved);
     } else if (choice === choices[9]) {
       config.render.showPrompt = !config.render.showPrompt;
-      await saveDistillConfigFile(ctx, config, configPath);
+      await saveDistillConfigFile(ctx, config, configPath, onSaved);
     } else if (choice === choices[10]) {
       config.render.showResult = !config.render.showResult;
-      await saveDistillConfigFile(ctx, config, configPath);
+      await saveDistillConfigFile(ctx, config, configPath, onSaved);
+    } else if (choice === choices[11]) {
+      await runDistillToolConfigUi(ctx, pi, config, configPath, onSaved);
     }
   }
 }
 
-function registerDistillConfigCommand(pi: ExtensionAPI): void {
+function registerDistillConfigCommand(pi: ExtensionAPI, onSaved: () => void): void {
   pi.registerCommand("pi-distill", {
     description: i18n.t("commandDescription"),
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
@@ -840,7 +948,7 @@ function registerDistillConfigCommand(pi: ExtensionAPI): void {
         ctx.ui.notify(i18n.t("interactiveOnly"), "warning");
         return;
       }
-      await runDistillConfigUi(ctx, getDistillConfigPath());
+      await runDistillConfigUi(ctx, pi, getDistillConfigPath(), onSaved);
     },
   });
 }
@@ -852,7 +960,7 @@ export default function piDistillExtension(pi: ExtensionAPI) {
   registerDistillFallbackRenderer(pi);
   const extendParameters = () => {
     try {
-      extendDistillToolParameters(pi);
+      extendDistillToolParameters(pi, loadDistillConfig());
     } catch (error) {
       console.warn(`[pi-distill] Failed to extend the outputRequest parameter: ${error instanceof Error ? error.message : String(error)}`);
     }
@@ -870,8 +978,13 @@ export default function piDistillExtension(pi: ExtensionAPI) {
     };
   });
   pi.on("tool_call", (event) => {
+    const loaded = loadDistillConfig();
+    const enabled = loaded.enabled
+      && Boolean(loaded.config)
+      && isDistillToolEnabled(loaded.config, event.toolName);
     pendingCalls.set(event.toolCallId, {
-      outputRequest: getOutputRequest(event.input),
+      enabled,
+      outputRequest: enabled ? getOutputRequest(event.input) : "",
       originalUserPrompt,
       startedAt: performance.now(),
     });
@@ -881,6 +994,11 @@ export default function piDistillExtension(pi: ExtensionAPI) {
   pi.on("tool_result", async (event: ToolResultEvent, ctx) => {
     const pending = pendingCalls.get(event.toolCallId);
     pendingCalls.delete(event.toolCallId);
+    if (pending && !pending.enabled) return toToolResultEventResult({
+      content: event.content,
+      details: event.details as Record<string, unknown> | undefined,
+      isError: event.isError,
+    });
     const outputRequest = pending?.outputRequest ?? getOutputRequest(event.input);
     const result = await processToolResult(
       {
@@ -904,5 +1022,5 @@ export default function piDistillExtension(pi: ExtensionAPI) {
   });
   pi.on("agent_end", () => pendingCalls.clear());
   pi.on("session_shutdown", () => disposeToolDisplayMiddleware());
-  registerDistillConfigCommand(pi);
+  registerDistillConfigCommand(pi, extendParameters);
 }

--- a/packages/pi-distill/src/summary-utils.ts
+++ b/packages/pi-distill/src/summary-utils.ts
@@ -33,6 +33,8 @@ export interface BashSummaryConfig {
   missedCompressionRatio: number;
   /** 工具返回错误且达到最小长度时是否仍调用提炼模型。 */
   summarizeErrors: boolean;
+  /** 按工具覆盖是否注入 outputRequest；未配置的工具默认开启。 */
+  tools?: DistillToolConfig;
 }
 
 export type DistillConfig = BashSummaryConfig;
@@ -42,6 +44,12 @@ export interface DistillRenderConfig {
   showPrompt: boolean;
   showResult: boolean;
 }
+
+export interface DistillToolOverride {
+  enabled: boolean;
+}
+
+export type DistillToolConfig = Record<string, DistillToolOverride>;
 
 export interface DistillConfigFile {
   enabled?: boolean;
@@ -53,6 +61,7 @@ export interface DistillConfigFile {
   timeoutSeconds?: number;
   missedCompressionRatio?: number;
   summarizeErrors?: boolean;
+  tools?: DistillToolConfig;
   render?: Partial<DistillRenderConfig>;
 }
 
@@ -215,6 +224,27 @@ function parseRenderConfig(
   return render;
 }
 
+function parseToolConfig(
+  file: Record<string, unknown> | undefined,
+  warnings: string[],
+): DistillToolConfig | undefined {
+  if (!file || !("tools" in file)) return undefined;
+  if (!isRecord(file.tools)) {
+    warnings.push("Config field tools must be an object.");
+    return {};
+  }
+
+  const tools: DistillToolConfig = {};
+  for (const [toolName, value] of Object.entries(file.tools)) {
+    if (!isRecord(value) || typeof value.enabled !== "boolean") {
+      warnings.push(`Config field tools.${toolName}.enabled must be boolean.`);
+      continue;
+    }
+    tools[toolName] = { enabled: value.enabled };
+  }
+  return tools;
+}
+
 function appendFileValueToEnv(
   env: NodeJS.ProcessEnv,
   file: Record<string, unknown>,
@@ -309,6 +339,8 @@ export function loadDistillConfig(
   }
 
   const config = parseBashSummaryConfig(effectiveEnv);
+  const tools = parseToolConfig(file, warnings);
+  if (config && tools !== undefined) config.tools = tools;
   const render = parseRenderConfig(file, warnings);
   if (!config && warnings.length === 0) {
     warnings.push("Distill config is invalid; output distillation is disabled.");
@@ -326,6 +358,7 @@ export function defaultDistillConfigFile(): DistillConfigFile {
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
     missedCompressionRatio: DEFAULT_MISSED_COMPRESSION_RATIO,
     summarizeErrors: DEFAULT_SUMMARIZE_ERRORS,
+    tools: {},
     render: {
       enabled: DEFAULT_RENDER_ENABLED,
       showPrompt: DEFAULT_RENDER_PROMPT,
@@ -335,6 +368,13 @@ export function defaultDistillConfigFile(): DistillConfigFile {
 }
 
 export const MIN_EFFECTIVE_COMPRESSION_RATIO = 1.4;
+
+export function isDistillToolEnabled(
+  config: { tools?: DistillToolConfig } | undefined,
+  toolName: string,
+): boolean {
+  return config?.tools?.[toolName]?.enabled ?? true;
+}
 
 export type OutputSummaryIntent = "none" | "full" | "summary";
 

--- a/packages/pi-distill/src/summary-utils.ts
+++ b/packages/pi-distill/src/summary-utils.ts
@@ -14,6 +14,7 @@ const DEFAULT_SUMMARIZE_ERRORS = true;
 const DEFAULT_RENDER_ENABLED = true;
 const DEFAULT_RENDER_PROMPT = true;
 const DEFAULT_RENDER_RESULT = true;
+const DEFAULT_DISABLED_TOOL_NAMES = new Set(["edit", "write"]);
 const CONFIG_DIRECTORY = "pi-distill";
 const CONFIG_FILE_NAME = "config.json";
 
@@ -33,7 +34,7 @@ export interface BashSummaryConfig {
   missedCompressionRatio: number;
   /** 工具返回错误且达到最小长度时是否仍调用提炼模型。 */
   summarizeErrors: boolean;
-  /** 按工具覆盖是否注入 outputRequest；未配置的工具默认开启。 */
+  /** 按工具覆盖是否注入 outputRequest；edit/write 未配置时默认关闭，其他工具默认开启。 */
   tools?: DistillToolConfig;
 }
 
@@ -373,7 +374,7 @@ export function isDistillToolEnabled(
   config: { tools?: DistillToolConfig } | undefined,
   toolName: string,
 ): boolean {
-  return config?.tools?.[toolName]?.enabled ?? true;
+  return config?.tools?.[toolName]?.enabled ?? !DEFAULT_DISABLED_TOOL_NAMES.has(toolName);
 }
 
 export type OutputSummaryIntent = "none" | "full" | "summary";

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -275,6 +275,8 @@ test("配置文件支持按工具覆盖 outputRequest 开关", async () => {
   assert.equal(isDistillToolEnabled(loaded.config, "bash"), false);
   assert.equal(isDistillToolEnabled(loaded.config, "read"), true);
   assert.equal(isDistillToolEnabled(loaded.config, "grep"), true);
+  assert.equal(isDistillToolEnabled(loaded.config, "edit"), false);
+  assert.equal(isDistillToolEnabled(loaded.config, "write"), false);
   assert.deepEqual(loaded.warnings, []);
 });
 
@@ -649,7 +651,7 @@ test("包含图片等非文本内容时识别为非纯文本输出", () => {
 });
 
 test("按工具开关动态注入和移除 outputRequest", () => {
-  const tools = ["bash", "read"].map((name) => ({
+  const tools = ["bash", "read", "edit", "write"].map((name) => ({
     name,
     parameters: {
       type: "object",
@@ -666,7 +668,7 @@ test("按工具开关动态注入和移除 outputRequest", () => {
       timeoutSeconds: 10,
       missedCompressionRatio: 10,
       summarizeErrors: true,
-      tools: { bash: { enabled: false } },
+      tools: { bash: { enabled: false }, edit: { enabled: true } },
     },
     render: { enabled: true, showPrompt: true, showResult: true },
     configPath: "",
@@ -674,17 +676,19 @@ test("按工具开关动态注入和移除 outputRequest", () => {
   };
   const api = { getAllTools: () => tools } as any;
 
-  assert.equal(extendDistillToolParameters(api, loaded), 1);
+  assert.equal(extendDistillToolParameters(api, loaded), 2);
   assert.equal((tools[0].parameters as any).properties.outputRequest, undefined);
   assert.equal((tools[0].parameters as any).required.includes("outputRequest"), false);
   assert.equal(typeof (tools[1].parameters as any).properties.outputRequest, "object");
+  assert.equal(typeof (tools[2].parameters as any).properties.outputRequest, "object");
+  assert.equal((tools[3].parameters as any).properties.outputRequest, undefined);
 
   loaded.config.tools.bash.enabled = true;
-  assert.equal(extendDistillToolParameters(api, loaded), 2);
+  assert.equal(extendDistillToolParameters(api, loaded), 3);
   assert.equal(typeof (tools[0].parameters as any).properties.outputRequest, "object");
 
   loaded.config.tools.bash.enabled = false;
-  assert.equal(extendDistillToolParameters(api, loaded), 1);
+  assert.equal(extendDistillToolParameters(api, loaded), 2);
   assert.equal((tools[0].parameters as any).properties.outputRequest, undefined);
   assert.deepEqual((tools[0].parameters as any).required, ["value"]);
 });
@@ -878,12 +882,15 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
     assert.equal(registeredToolCount, 0);
     for (const tool of tools) {
       const schema = tool.parameters as any;
-      assert.equal(schema.required.filter((value: string) => value === "outputRequest").length, 1);
-      assert.equal(schema.properties.outputRequest.type, "string");
-      assert.equal(
-        schema.properties.outputRequest.description,
-        OUTPUT_REQUEST_DESCRIPTION,
-      );
+      const enabledByDefault = !["edit", "write"].includes(tool.name);
+      assert.equal(schema.required.filter((value: string) => value === "outputRequest").length, enabledByDefault ? 1 : 0);
+      assert.equal(schema.properties.outputRequest?.type, enabledByDefault ? "string" : undefined);
+      if (enabledByDefault) {
+        assert.equal(
+          schema.properties.outputRequest.description,
+          OUTPUT_REQUEST_DESCRIPTION,
+        );
+      }
     }
 
     const input: Record<string, unknown> = { value: "custom", outputRequest: "RAW" };
@@ -915,7 +922,7 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
     assert.equal(result.content[0].text, "ok");
     assert.equal(appendedEntries[0]?.type, DISTILL_AUDIT_ENTRY_TYPE);
 
-    const selections: Array<string | undefined> = ["Tool outputRequest", "custom-tool: On", undefined];
+    const selections: Array<string | undefined> = ["Tool outputRequest", "write: Off", "custom-tool: On", undefined];
     await commandHandler?.("", {
       hasUI: true,
       ui: {
@@ -928,7 +935,11 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
       join(process.env.PI_CODING_AGENT_DIR!, "extensions", "pi-distill", "config.json"),
       "utf8",
     )) as any;
-    assert.deepEqual(savedConfig.tools, { "custom-tool": { enabled: false } });
+    assert.deepEqual(savedConfig.tools, {
+      "custom-tool": { enabled: false },
+      write: { enabled: true },
+    });
+    assert.equal(typeof (tools.find((tool) => tool.name === "write")!.parameters as any).properties.outputRequest, "object");
     assert.equal((tools.find((tool) => tool.name === "custom-tool")!.parameters as any).properties.outputRequest, undefined);
 
     const disabledInput: Record<string, unknown> = { value: "custom", outputRequest: "RAW" };

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -16,10 +16,12 @@ import {
   registerDistillToolDisplayMiddleware,
 } from "../src/tool-display-bridge.ts";
 import { Text } from "@earendil-works/pi-tui";
+import { extendDistillToolParameters } from "../src/index.ts";
 import {
   buildDecisionEvaluationPrompt,
   buildSummaryEvaluationPrompt,
   buildSummaryPrompt,
+  isDistillToolEnabled,
   isRawSummary,
   loadDistillConfig,
   MIN_EFFECTIVE_COMPRESSION_RATIO,
@@ -252,6 +254,27 @@ test("配置文件优先于兼容环境变量", async () => {
     showPrompt: false,
     showResult: true,
   });
+  assert.deepEqual(loaded.warnings, []);
+});
+
+test("配置文件支持按工具覆盖 outputRequest 开关", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pi-distill-tool-config-"));
+  const configFile = join(directory, "config.json");
+  await writeFile(configFile, JSON.stringify({
+    tools: {
+      bash: { enabled: false },
+      read: { enabled: true },
+    },
+  }));
+
+  const loaded = loadDistillConfig({}, configFile);
+  assert.deepEqual(loaded.config?.tools, {
+    bash: { enabled: false },
+    read: { enabled: true },
+  });
+  assert.equal(isDistillToolEnabled(loaded.config, "bash"), false);
+  assert.equal(isDistillToolEnabled(loaded.config, "read"), true);
+  assert.equal(isDistillToolEnabled(loaded.config, "grep"), true);
   assert.deepEqual(loaded.warnings, []);
 });
 
@@ -610,6 +633,62 @@ test("提炼 prompt 完全跟随 pi-language，不被原始用户消息覆盖", 
   }
 });
 
+test("包含图片等非文本内容时识别为非纯文本输出", () => {
+  const result = {
+    content: [
+      { type: "image", data: "encoded-image" },
+      { type: "text", text: "x".repeat(10_001) },
+    ],
+  } as unknown as Parameters<typeof hasNonTextContent>[0];
+
+  assert.equal(hasNonTextContent(result), true);
+  assert.equal(
+    hasNonTextContent({ content: [{ type: "text", text: "纯文本" }] }),
+    false,
+  );
+});
+
+test("按工具开关动态注入和移除 outputRequest", () => {
+  const tools = ["bash", "read"].map((name) => ({
+    name,
+    parameters: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    },
+  }));
+  const loaded = {
+    enabled: true,
+    config: {
+      minChars: 200,
+      maxChars: 100000,
+      maxOutputChars: 10000,
+      timeoutSeconds: 10,
+      missedCompressionRatio: 10,
+      summarizeErrors: true,
+      tools: { bash: { enabled: false } },
+    },
+    render: { enabled: true, showPrompt: true, showResult: true },
+    configPath: "",
+    warnings: [],
+  };
+  const api = { getAllTools: () => tools } as any;
+
+  assert.equal(extendDistillToolParameters(api, loaded), 1);
+  assert.equal((tools[0].parameters as any).properties.outputRequest, undefined);
+  assert.equal((tools[0].parameters as any).required.includes("outputRequest"), false);
+  assert.equal(typeof (tools[1].parameters as any).properties.outputRequest, "object");
+
+  loaded.config.tools.bash.enabled = true;
+  assert.equal(extendDistillToolParameters(api, loaded), 2);
+  assert.equal(typeof (tools[0].parameters as any).properties.outputRequest, "object");
+
+  loaded.config.tools.bash.enabled = false;
+  assert.equal(extendDistillToolParameters(api, loaded), 1);
+  assert.equal((tools[0].parameters as any).properties.outputRequest, undefined);
+  assert.deepEqual((tools[0].parameters as any).required, ["value"]);
+});
+
 test("pi-distill 可以追加 UI-only 保底审计", () => {
   const entries: Array<{ type: string; data: unknown }> = [];
   const builtinPi = {
@@ -775,11 +854,12 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
       sourceInfo: { source: "pi-distill-test" },
     }));
     let registeredToolCount = 0;
+    let commandHandler: ((args: string, ctx: any) => Promise<void>) | undefined;
     const appendedEntries: Array<{ type: string; data: unknown }> = [];
     const pi = {
       getAllTools: () => tools,
       registerTool: () => { registeredToolCount += 1; },
-      registerCommand: () => undefined,
+      registerCommand: (_name: string, command: any) => { commandHandler = command.handler; },
       registerEntryRenderer: () => undefined,
       appendEntry: (type: string, data: unknown) => appendedEntries.push({ type, data }),
       on: (event: string, handler: (...args: any[]) => any) => handlers.set(event, handler),
@@ -834,6 +914,45 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
     assert.equal(result.details.outputSummaryStatus, "full-output");
     assert.equal(result.content[0].text, "ok");
     assert.equal(appendedEntries[0]?.type, DISTILL_AUDIT_ENTRY_TYPE);
+
+    const selections: Array<string | undefined> = ["Tool outputRequest", "custom-tool: On", undefined];
+    await commandHandler?.("", {
+      hasUI: true,
+      ui: {
+        select: async () => selections.shift(),
+        input: async () => undefined,
+        notify: () => undefined,
+      },
+    });
+    const savedConfig = JSON.parse(await readFile(
+      join(process.env.PI_CODING_AGENT_DIR!, "extensions", "pi-distill", "config.json"),
+      "utf8",
+    )) as any;
+    assert.deepEqual(savedConfig.tools, { "custom-tool": { enabled: false } });
+    assert.equal((tools.find((tool) => tool.name === "custom-tool")!.parameters as any).properties.outputRequest, undefined);
+
+    const disabledInput: Record<string, unknown> = { value: "custom", outputRequest: "RAW" };
+    await handlers.get("tool_call")?.({
+      type: "tool_call",
+      toolName: "custom-tool",
+      toolCallId: "call-disabled",
+      input: disabledInput,
+    }, {});
+    assert.equal(disabledInput.outputRequest, undefined);
+    const disabledResult = await handlers.get("tool_result")?.({
+      type: "tool_result",
+      toolName: "custom-tool",
+      toolCallId: "call-disabled",
+      input: disabledInput,
+      content: [{ type: "text", text: "disabled output" }],
+      details: {},
+      isError: false,
+    }, { cwd: process.cwd() });
+    assert.deepEqual(disabledResult, {
+      content: [{ type: "text", text: "disabled output" }],
+      details: {},
+      isError: false,
+    });
   } finally {
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = previousAgentDir;

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -922,11 +922,16 @@ test("pi-distill 独立扩展最终工具 schema，并通过 Pi 事件处理 out
     assert.equal(result.content[0].text, "ok");
     assert.equal(appendedEntries[0]?.type, DISTILL_AUDIT_ENTRY_TYPE);
 
-    const selections: Array<string | undefined> = ["Tool outputRequest", "write: Off", "custom-tool: On", undefined];
+    const selections: Array<string | undefined> = ["__last__", "write", "custom-tool", undefined, undefined];
     await commandHandler?.("", {
       hasUI: true,
       ui: {
-        select: async () => selections.shift(),
+        select: async (_title: string, choices: string[]) => {
+          const target = selections.shift();
+          if (!target) return undefined;
+          if (target === "__last__") return choices.at(-1);
+          return choices.find((choice) => choice.startsWith(target));
+        },
         input: async () => undefined,
         notify: () => undefined,
       },


### PR DESCRIPTION
## 变更摘要
- `edit` 和 `write` 工具默认关闭 `outputRequest` 注入与结果提炼。
- 其他工具仍默认开启。
- `tools.<name>.enabled` 显式配置优先，可通过 `/pi-distill` 打开 `edit` 或 `write`。
- 补充中英文文档和回归测试。

## 验证
- `npm run check` 通过。
- `pi-distill` 测试 20/20 通过。

## 上线清单
- 无 SQL、Apollo、权限、数据迁移、缓存清理或第三方 API 变更。
- 无特殊部署顺序，按现有 release-please/npm 发布流程即可。