### PR TITLE
feat: 引入 @maplezzk/pi-dynamic-workflows 与 @maplezzk/pi-interactive-subagents 两个 fork 包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
           - dir: packages/pi-terminal-mux
           - dir: packages/pi-metrics
           - dir: packages/pi-models-discovery
+          - dir: packages/pi-dynamic-workflows
+          - dir: packages/pi-interactive-subagents
     steps:
       - uses: actions/checkout@v4
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,7 @@
   "packages/pi-extensions-tool-display": "1.0.0",
   "packages/pi-terminal-mux": "0.2.1",
   "packages/pi-metrics": "0.2.1",
-  "packages/pi-models-discovery": "1.0.0"
+  "packages/pi-models-discovery": "1.0.0",
+  "packages/pi-dynamic-workflows": "1.0.0",
+  "packages/pi-interactive-subagents": "3.7.1"
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Each package is independently installable and keeps its detailed behavior, confi
 | [`pi-models-discovery`](./packages/pi-models-discovery) | Discovers models from `{baseUrl}/models` for providers marked with `discoverModels` in models.json, with a persistent startup cache and a manual refresh command. | [English](./packages/pi-models-discovery/README.md) · [中文](./packages/pi-models-discovery/README.zh-CN.md) |
 | [`pi-extensions-i18n`](./packages/pi-extensions-i18n) | Provides shared locale selection, catalog loading, interpolation, and the `/pi-language` command. | [English](./packages/pi-extensions-i18n/README.md) · [中文](./packages/pi-extensions-i18n/README.zh-CN.md) |
 | [`pi-extensions-tool-display`](./packages/pi-extensions-tool-display) | Provides the actual Pi tool-display host plus the shared result-rendering protocol and component helpers. | [English](./packages/pi-extensions-tool-display/README.md) · [中文](./packages/pi-extensions-tool-display/README.zh-CN.md) |
+| [`@maplezzk/pi-dynamic-workflows`](./packages/pi-dynamic-workflows) | Claude-Code-style dynamic workflow orchestration with `meta`/`phase()`/`agent()`/`parallel()`/`pipeline()` primitives, configurable via `/workflow-config`. Fork of michaelliv/pi-dynamic-workflows. | [English](./packages/pi-dynamic-workflows/README.md) · [中文](./packages/pi-dynamic-workflows/README.zh-CN.md) |
+| [`@maplezzk/pi-interactive-subagents`](./packages/pi-interactive-subagents) | Non-blocking interactive subagents in multiplexer panes with live status widget, `/plan` and `/iterate` workflows. Fork of HazAT/pi-interactive-subagents. | [English](./packages/pi-interactive-subagents/README.md) · [中文](./packages/pi-interactive-subagents/README.zh-CN.md) |
 
 ## Install everything
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,8 @@
 | [`pi-models-discovery`](./packages/pi-models-discovery) | 自动发现 models.json 中标记 `discoverModels` 的 provider 的模型列表，启动走持久化缓存，并提供手动刷新命令。 | [English](./packages/pi-models-discovery/README.md) · [中文](./packages/pi-models-discovery/README.zh-CN.md) |
 | [`pi-extensions-i18n`](./packages/pi-extensions-i18n) | 提供共享的语言选择、catalog 加载、插值和 `/pi-language` 命令。 | [English](./packages/pi-extensions-i18n/README.md) · [中文](./packages/pi-extensions-i18n/README.zh-CN.md) |
 | [`pi-extensions-tool-display`](./packages/pi-extensions-tool-display) | 提供实际的 Pi 工具展示宿主，以及共享的结果渲染协议和组件工具。 | [English](./packages/pi-extensions-tool-display/README.md) · [中文](./packages/pi-extensions-tool-display/README.zh-CN.md) |
+| [`@maplezzk/pi-dynamic-workflows`](./packages/pi-dynamic-workflows) | Claude-Code 风格的动态 workflow 编排，支持 `meta`/`phase()`/`agent()`/`parallel()`/`pipeline()` 原语，通过 `/workflow-config` 配置。Fork 自 michaelliv/pi-dynamic-workflows。 | [English](./packages/pi-dynamic-workflows/README.md) · [中文](./packages/pi-dynamic-workflows/README.zh-CN.md) |
+| [`@maplezzk/pi-interactive-subagents`](./packages/pi-interactive-subagents) | 终端复用器分屏中的非阻塞交互式子 agent，带实时状态 widget、`/plan` 与 `/iterate` 工作流。Fork 自 HazAT/pi-interactive-subagents。 | [English](./packages/pi-interactive-subagents/README.md) · [中文](./packages/pi-interactive-subagents/README.zh-CN.md) |
 
 ## 一键安装全部扩展
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,7 +2913,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.52",
-      "resolved": "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
       "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
@@ -3054,7 +3054,7 @@
     },
     "node_modules/acorn": {
       "version": "8.17.0",
-      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
@@ -3075,7 +3075,7 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
@@ -3215,13 +3215,13 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
@@ -3401,7 +3401,7 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
@@ -3581,7 +3581,7 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,7 +1014,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2808,6 +2808,14 @@
         }
       }
     },
+    "node_modules/@maplezzk/pi-dynamic-workflows": {
+      "resolved": "packages/pi-dynamic-workflows",
+      "link": true
+    },
+    "node_modules/@maplezzk/pi-interactive-subagents": {
+      "resolved": "packages/pi-interactive-subagents",
+      "link": true
+    },
     "node_modules/@mistralai/mistralai": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
@@ -2902,6 +2910,13 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@smithy/core": {
       "version": "3.29.5",
@@ -3037,6 +3052,18 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3044,6 +3071,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/base64-js": {
@@ -3169,6 +3212,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -3333,6 +3398,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -3508,6 +3579,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -3666,6 +3746,34 @@
         "pi-extensions-i18n": "^0.3.0"
       }
     },
+    "packages/pi-dynamic-workflows": {
+      "name": "@maplezzk/pi-dynamic-workflows",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-ai": "0.80.10",
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
+        "@types/node": "24.12.4",
+        "pi-extensions-i18n": "^0.3.0",
+        "tsx": "4.23.1",
+        "typebox": "latest",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": ">=0.80.0 <0.81.0",
+        "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+        "@earendil-works/pi-tui": ">=0.80.0 <0.81.0",
+        "pi-extensions-i18n": "^0.3.0",
+        "typebox": "*"
+      }
+    },
     "packages/pi-extensions-i18n": {
       "version": "0.3.0",
       "license": "MIT",
@@ -3720,6 +3828,32 @@
         "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
         "@earendil-works/pi-tui": ">=0.80.0 <0.81.0",
         "pi-extensions-i18n": "^0.3.0"
+      }
+    },
+    "packages/pi-interactive-subagents": {
+      "name": "@maplezzk/pi-interactive-subagents",
+      "version": "3.7.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.20.0",
+        "pi-extensions-i18n": "^0.3.0",
+        "pi-terminal-mux": "^0.2.1"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
+        "@sinclair/typebox": "^0.34.49",
+        "@types/node": "24.12.4",
+        "tsx": "4.23.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+        "@earendil-works/pi-tui": ">=0.80.0 <0.81.0",
+        "@sinclair/typebox": "*"
       }
     },
     "packages/pi-metrics": {

--- a/packages/pi-dynamic-workflows/README.md
+++ b/packages/pi-dynamic-workflows/README.md
@@ -1,0 +1,58 @@
+# pi-dynamic-workflows
+
+Claude-Code-style dynamic workflow orchestration for Pi.
+
+> **Fork notice:** This package is a fork of [michaelliv/pi-dynamic-workflows](https://github.com/Michaelliv/pi-dynamic-workflows) (MIT license). Full credit to the original author **michaelliv** for the design and implementation. Changes in this fork: monorepo integration, i18n support, and config migration from environment variables to a slash command.
+
+## Features
+
+- Define multi-agent workflows as plain JavaScript scripts with `meta`, `phase()`, `agent()`, `parallel()`, and `pipeline()` primitives
+- Static validation of workflow scripts via acorn AST parsing
+- Optional subagent backend via `pi-interactive-subagents` for real tool access per agent
+- Async background execution mode with live status widget
+- Configurable via `/workflow-config` slash command (persisted to JSON)
+
+## Installation
+
+```bash
+pi install @maplezzk/pi-dynamic-workflows
+```
+
+## Configuration
+
+Run `/workflow-config` to interactively configure:
+
+- **Execution backend**: `workflow` (built-in in-process agent) or `subagent` (requires `pi-interactive-subagents`)
+- **Async mode**: run workflows in the background with a live status widget
+
+Config is persisted to `~/.pi/agent/extensions/pi-dynamic-workflows/config.json`.
+
+Environment variables are supported as fallback only:
+
+| Variable | Values | Effect |
+|---|---|---|
+| `PI_WORKFLOW_BACKEND` | `subagent` | Use subagent backend (fallback) |
+| `PI_WORKFLOW_ASYNC` | `true` | Enable async mode (fallback) |
+
+JSON config takes priority over environment variables.
+
+## Usage
+
+```js
+// In a workflow script passed to the workflow tool:
+export const meta = {
+  name: 'my_workflow',
+  description: 'Does something useful',
+  phases: [{ title: 'Phase 1' }]
+};
+
+phase('Phase 1');
+const result = await agent('Analyze the codebase', {
+  label: 'code analysis',
+  schema: { type: 'object', properties: { summary: { type: 'string' } }, required: ['summary'] }
+});
+```
+
+## License
+
+MIT — see original repository for details.

--- a/packages/pi-dynamic-workflows/README.zh-CN.md
+++ b/packages/pi-dynamic-workflows/README.zh-CN.md
@@ -1,0 +1,58 @@
+# pi-dynamic-workflows
+
+为 Pi 提供 Claude-Code 风格的动态 workflow 编排能力。
+
+> **Fork 说明：** 本包 fork 自 [michaelliv/pi-dynamic-workflows](https://github.com/Michaelliv/pi-dynamic-workflows)（MIT 协议）。设计与实现的版权归原作者 **michaelliv** 所有。本 fork 的变更：monorepo 集成、i18n 支持、配置方式从环境变量迁移为斜杠命令。
+
+## 功能
+
+- 用纯 JavaScript 脚本定义多 agent 工作流，支持 `meta`、`phase()`、`agent()`、`parallel()`、`pipeline()` 原语
+- 通过 acorn AST 解析对 workflow 脚本进行静态校验
+- 可选 subagent 后端（依赖 `pi-interactive-subagents`），每个 agent 拥有真实工具访问
+- 异步后台执行模式，带实时状态 widget
+- 通过 `/workflow-config` 斜杠命令配置（持久化到 JSON）
+
+## 安装
+
+```bash
+pi install @maplezzk/pi-dynamic-workflows
+```
+
+## 配置
+
+运行 `/workflow-config` 进行交互式配置：
+
+- **执行后端**：`workflow`（内置进程内 agent）或 `subagent`（需安装 `pi-interactive-subagents`）
+- **异步模式**：后台运行 workflow，带实时状态 widget
+
+配置持久化到 `~/.pi/agent/extensions/pi-dynamic-workflows/config.json`。
+
+环境变量仅作兜底支持：
+
+| 变量 | 值 | 效果 |
+|---|---|---|
+| `PI_WORKFLOW_BACKEND` | `subagent` | 使用 subagent 后端（兜底） |
+| `PI_WORKFLOW_ASYNC` | `true` | 启用异步模式（兜底） |
+
+JSON 配置优先级高于环境变量。
+
+## 用法
+
+```js
+// 传给 workflow 工具的脚本：
+export const meta = {
+  name: 'my_workflow',
+  description: '完成某件有用的事',
+  phases: [{ title: '阶段 1' }]
+};
+
+phase('阶段 1');
+const result = await agent('分析代码库', {
+  label: '代码分析',
+  schema: { type: 'object', properties: { summary: { type: 'string' } }, required: ['summary'] }
+});
+```
+
+## 许可证
+
+MIT — 详见原始仓库。

--- a/packages/pi-dynamic-workflows/biome.json
+++ b/packages/pi-dynamic-workflows/biome.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "files": {
+    "includes": ["**", "!dist", "!node_modules", "!demos"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  }
+}

--- a/packages/pi-dynamic-workflows/index.ts
+++ b/packages/pi-dynamic-workflows/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./src/extension.ts";
+export * from "./src/index.ts";

--- a/packages/pi-dynamic-workflows/locales/index.json
+++ b/packages/pi-dynamic-workflows/locales/index.json
@@ -1,0 +1,78 @@
+{
+  "commandDescription": {
+    "zh-CN": "配置 workflow 执行后端与异步模式",
+    "en-US": "Configure workflow execution backend and async mode"
+  },
+  "configTitle": {
+    "zh-CN": "Workflow 配置",
+    "en-US": "Workflow Config"
+  },
+  "exit": {
+    "zh-CN": "退出",
+    "en-US": "Exit"
+  },
+  "on": {
+    "zh-CN": "开启",
+    "en-US": "on"
+  },
+  "off": {
+    "zh-CN": "关闭",
+    "en-US": "off"
+  },
+  "toggleBackend": {
+    "zh-CN": "切换执行后端（当前：{value}）",
+    "en-US": "Toggle execution backend (current: {value})"
+  },
+  "toggleAsync": {
+    "zh-CN": "切换异步模式（当前：{value}）",
+    "en-US": "Toggle async mode (current: {value})"
+  },
+  "savedBackend": {
+    "zh-CN": "执行后端已切换为：{value}",
+    "en-US": "Execution backend switched to: {value}"
+  },
+  "savedAsync": {
+    "zh-CN": "异步模式已切换为：{value}",
+    "en-US": "Async mode switched to: {value}"
+  },
+  "reloadHint": {
+    "zh-CN": "需 /reload 生效",
+    "en-US": "Requires /reload to take effect"
+  },
+  "cancelToolDescription": {
+    "zh-CN": "取消正在后台运行的 workflow",
+    "en-US": "Cancel a running background workflow"
+  },
+  "cancelSent": {
+    "zh-CN": "Workflow {name} 取消请求已发送",
+    "en-US": "Cancel request sent for Workflow {name}"
+  },
+  "noneRunning": {
+    "zh-CN": "当前没有正在运行的 workflow",
+    "en-US": "No workflow is currently running"
+  },
+  "alreadyRunning": {
+    "zh-CN": "已有 workflow 在运行: {name}",
+    "en-US": "A workflow is already running: {name}"
+  },
+  "resultWritten": {
+    "zh-CN": "Workflow {name} 已完成（{count} 个 agent，耗时 {ms}ms）。\n结果已写入: {path}",
+    "en-US": "Workflow {name} completed with {count} agent(s) in {ms}ms.\nResult written to: {path}"
+  },
+  "cancelled": {
+    "zh-CN": "Workflow {name} 已取消",
+    "en-US": "Workflow {name} cancelled"
+  },
+  "started": {
+    "zh-CN": "Workflow {name} 已启动，后台执行中...",
+    "en-US": "Workflow {name} started, running in background..."
+  },
+  "totalResult": {
+    "zh-CN": "📄 总结果：{path}",
+    "en-US": "📄 Result: {path}"
+  },
+  "subagentRequired": {
+    "zh-CN": "PI_WORKFLOW_BACKEND=subagent 需要 pi-interactive-subagents 扩展。\n安装: pi install pi-interactive-subagents",
+    "en-US": "PI_WORKFLOW_BACKEND=subagent requires the pi-interactive-subagents extension.\nInstall: pi install pi-interactive-subagents"
+  }
+}

--- a/packages/pi-dynamic-workflows/package.json
+++ b/packages/pi-dynamic-workflows/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@maplezzk/pi-dynamic-workflows",
+  "version": "1.0.0",
+  "description": "Claude-Code-style dynamic workflow orchestration for Pi. Fork of michaelliv/pi-dynamic-workflows.",
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "locales",
+    "types",
+    "README.md",
+    "README.zh-CN.md"
+  ],
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit --pretty false",
+    "build": "npm run typecheck",
+    "check": "npm run typecheck && npm test && npm pack --dry-run --json > /dev/null"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "author": "michaelliv",
+  "contributors": [
+    "maplezzk"
+  ],
+  "homepage": "https://github.com/maplezzk/pi-extensions/tree/main/packages/pi-dynamic-workflows",
+  "bugs": "https://github.com/maplezzk/pi-extensions/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maplezzk/pi-extensions.git",
+    "directory": "packages/pi-dynamic-workflows"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-extension",
+    "coding-agent",
+    "workflow",
+    "agents"
+  ],
+  "dependencies": {
+    "acorn": "^8.16.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": ">=0.80.0 <0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+    "@earendil-works/pi-tui": ">=0.80.0 <0.81.0",
+    "pi-extensions-i18n": "^0.3.0",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "0.80.10",
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
+    "@types/node": "24.12.4",
+    "pi-extensions-i18n": "^0.3.0",
+    "tsx": "4.23.1",
+    "typebox": "latest",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/pi-dynamic-workflows/src/agent.ts
+++ b/packages/pi-dynamic-workflows/src/agent.ts
@@ -1,0 +1,131 @@
+import type { AssistantMessage, TextContent } from "@earendil-works/pi-ai";
+import {
+  type CreateAgentSessionOptions,
+  createAgentSession,
+  createCodingTools,
+  getAgentDir,
+  SessionManager,
+  SettingsManager,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
+import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.ts";
+
+export interface WorkflowAgentOptions {
+  cwd?: string;
+  /** Extra tools available to the subagent in addition to the structured output tool. */
+  tools?: ToolDefinition[];
+  /** Override any createAgentSession option (model, authStorage, resourceLoader, etc.). */
+  session?: Partial<CreateAgentSessionOptions>;
+  /** Extra system guidance prepended to every subagent task. */
+  instructions?: string;
+}
+
+export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
+  label?: string;
+  schema?: TSchemaDef;
+  tools?: ToolDefinition[];
+  instructions?: string;
+  signal?: AbortSignal;
+}
+
+export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
+  ? Static<TSchemaDef>
+  : string;
+
+export class WorkflowAgent {
+  private readonly cwd: string;
+  private readonly baseTools: ToolDefinition[];
+  private readonly sessionOptions: Partial<CreateAgentSessionOptions>;
+  private readonly instructions?: string;
+
+  constructor(options: WorkflowAgentOptions = {}) {
+    this.cwd = options.cwd ?? process.cwd();
+    this.baseTools = options.tools ?? createCodingTools(this.cwd);
+    this.sessionOptions = options.session ?? {};
+    this.instructions = options.instructions;
+  }
+
+  async run<TSchemaDef extends TSchema | undefined = undefined>(
+    prompt: string,
+    options: AgentRunOptions<TSchemaDef> = {},
+  ): Promise<AgentRunResult<TSchemaDef>> {
+    const capture: StructuredOutputCapture<any> = { called: false, value: undefined };
+    const customTools: ToolDefinition[] = [...this.baseTools, ...(options.tools ?? [])];
+
+    if (options.schema) {
+      customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
+    }
+
+    const agentDir = getAgentDir();
+    const { session } = await createAgentSession({
+      cwd: this.cwd,
+      agentDir,
+      sessionManager: SessionManager.inMemory(this.cwd),
+      settingsManager: SettingsManager.create(this.cwd, agentDir),
+      customTools,
+      ...this.sessionOptions,
+    });
+
+    let removeAbortListener: (() => void) | undefined;
+    try {
+      if (options.signal?.aborted) throw new Error("Subagent was aborted");
+      if (options.signal) {
+        const onAbort = () => void session.abort();
+        options.signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
+      }
+
+      await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
+      if (options.signal?.aborted) throw new Error("Subagent was aborted");
+
+      if (options.schema) {
+        if (!capture.called) {
+          throw new Error("Subagent finished without calling structured_output");
+        }
+        return capture.value as AgentRunResult<TSchemaDef>;
+      }
+
+      return this.lastAssistantText(session.messages) as AgentRunResult<TSchemaDef>;
+    } finally {
+      removeAbortListener?.();
+      session.dispose();
+    }
+  }
+
+  private buildPrompt(prompt: string, options: AgentRunOptions<any>, structured: boolean): string {
+    const parts = [
+      this.instructions,
+      options.instructions,
+      options.label ? `Task label: ${options.label}` : undefined,
+      prompt,
+    ].filter(Boolean);
+
+    if (structured) {
+      parts.push(
+        [
+          "Final output contract:",
+          "- Your final action MUST be a structured_output tool call.",
+          "- The structured_output arguments are the return value of this subagent.",
+          "- Do not emit a prose final answer instead of structured_output.",
+          "- If you need to inspect files or run commands first, do so, then call structured_output exactly once.",
+        ].join("\n"),
+      );
+    }
+
+    return parts.join("\n\n");
+  }
+
+  private lastAssistantText(messages: unknown[]): string {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i] as Partial<AssistantMessage> | undefined;
+      if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+      const text = message.content
+        .filter((part): part is TextContent => part.type === "text")
+        .map((part) => part.text)
+        .join("");
+      if (text.trim()) return text;
+    }
+    return "";
+  }
+}

--- a/packages/pi-dynamic-workflows/src/config.ts
+++ b/packages/pi-dynamic-workflows/src/config.ts
@@ -1,0 +1,55 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Workflow 运行时配置。
+ *
+ * 优先级：JSON 配置文件（由 /workflow-config 斜杠命令写入）> 环境变量兜底 > 默认值。
+ * 环境变量仅作为兜底支持（PI_WORKFLOW_BACKEND / PI_WORKFLOW_ASYNC）。
+ */
+export type WorkflowBackend = "workflow" | "subagent";
+
+export interface WorkflowConfig {
+	/** 执行后端：内置 workflow agent 或 pi-interactive-subagents 子会话。 */
+	backend: WorkflowBackend;
+	/** 是否以后台异步模式运行 workflow（注册 workflow_cancel 工具）。 */
+	async: boolean;
+}
+
+const DEFAULTS: WorkflowConfig = { backend: "workflow", async: false };
+
+/** 配置文件路径：<agentDir>/extensions/pi-dynamic-workflows/config.json */
+export function configPath(): string {
+	return join(getAgentDir(), "extensions", "pi-dynamic-workflows", "config.json");
+}
+
+function fromEnv(): WorkflowConfig {
+	const config = { ...DEFAULTS };
+	if (process.env.PI_WORKFLOW_BACKEND === "subagent") config.backend = "subagent";
+	if (process.env.PI_WORKFLOW_ASYNC === "true") config.async = true;
+	return config;
+}
+
+/** 读取配置：JSON 文件覆盖环境变量兜底值。文件缺失或损坏时静默回退到环境变量/默认值。 */
+export function loadConfig(): WorkflowConfig {
+	const config = fromEnv();
+	try {
+		if (!existsSync(configPath())) return config;
+		const parsed = JSON.parse(readFileSync(configPath(), "utf-8")) as Partial<WorkflowConfig>;
+		if (parsed.backend === "workflow" || parsed.backend === "subagent") config.backend = parsed.backend;
+		if (typeof parsed.async === "boolean") config.async = parsed.async;
+	} catch {
+		// 配置损坏：保留环境变量兜底值，不抛出。
+	}
+	return config;
+}
+
+/** 合并写入配置，返回写入后的完整配置。 */
+export function saveConfig(partial: Partial<WorkflowConfig>): WorkflowConfig {
+	const merged: WorkflowConfig = { ...loadConfig(), ...partial };
+	const path = configPath();
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, "utf-8");
+	return merged;
+}

--- a/packages/pi-dynamic-workflows/src/display.ts
+++ b/packages/pi-dynamic-workflows/src/display.ts
@@ -1,0 +1,710 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import type { WorkflowMeta } from "./workflow.ts";
+
+const i18n = createTranslator(loadCatalog(new URL("../locales/index.json", import.meta.url)));
+
+export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
+
+export interface WorkflowAgentSnapshot {
+  id: number;
+  label: string;
+  phase?: string;
+  prompt: string;
+  status: WorkflowAgentStatus;
+  resultPreview?: string;
+  error?: string;
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+export interface WorkflowSnapshot {
+  name: string;
+  description?: string;
+  phases: string[];
+  currentPhase?: string;
+  logs: string[];
+  agents: WorkflowAgentSnapshot[];
+  agentCount: number;
+  runningCount: number;
+  doneCount: number;
+  errorCount: number;
+  durationMs?: number;
+  result?: unknown;
+  resultFile?: string;
+  startedAt?: number;
+}
+
+export interface WorkflowDisplay {
+  update(snapshot: WorkflowSnapshot): void;
+  complete(snapshot: WorkflowSnapshot): void;
+  clear(): void;
+}
+
+export interface WorkflowDisplayOptions {
+  key?: string;
+  placement?: "aboveEditor" | "belowEditor";
+  maxAgents?: number;
+  maxLogs?: number;
+  showStatus?: boolean;
+  showResultPreviews?: boolean;
+}
+
+export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
+  return {
+    name: meta.name,
+    description: meta.description,
+    phases: meta.phases.map((p) => p.title),
+    logs: [],
+    agents: [],
+    agentCount: 0,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 0,
+  };
+}
+
+export function recomputeWorkflowSnapshot(snapshot: WorkflowSnapshot): WorkflowSnapshot {
+  const runningCount = snapshot.agents.filter((agent) => agent.status === "running").length;
+  const doneCount = snapshot.agents.filter((agent) => agent.status === "done").length;
+  const errorCount = snapshot.agents.filter((agent) => agent.status === "error").length;
+  return { ...snapshot, agentCount: snapshot.agents.length, runningCount, doneCount, errorCount };
+}
+
+export function createWidgetWorkflowDisplay(
+  ctx: Pick<ExtensionContext, "ui" | "hasUI">,
+  options: WorkflowDisplayOptions = {},
+): WorkflowDisplay {
+  const key = options.key ?? "workflow";
+  const placement = options.placement ?? "belowEditor";
+  const showStatus = options.showStatus ?? false;
+
+  const render = (snapshot: WorkflowSnapshot, completed = false) => {
+    if (!ctx.hasUI) return;
+    if (showStatus) ctx.ui.setStatus(key, statusLine(snapshot, completed));
+    ctx.ui.setWidget(key, renderWorkflowLines(snapshot, options), { placement });
+  };
+
+  return {
+    update(snapshot) {
+      render(snapshot, false);
+    },
+    complete(snapshot) {
+      render(snapshot, true);
+    },
+    clear() {
+      if (!ctx.hasUI) return;
+      if (showStatus) ctx.ui.setStatus(key, undefined);
+      ctx.ui.setWidget(key, undefined);
+    },
+  };
+}
+
+export function createToolUpdateWorkflowDisplay(
+  onUpdate: ((result: { content: Array<{ type: "text"; text: string }>; details: unknown }) => void) | undefined,
+  ctx?: Pick<ExtensionContext, "ui" | "hasUI">,
+  options: WorkflowDisplayOptions & { streamToolUpdates?: boolean } = {},
+): WorkflowDisplay {
+  const widget = ctx ? createWidgetWorkflowDisplay(ctx, options) : undefined;
+  const streamToolUpdates = options.streamToolUpdates ?? !ctx?.hasUI;
+
+  const emit = (snapshot: WorkflowSnapshot, completed = false) => {
+    if (streamToolUpdates) {
+      onUpdate?.({
+        content: [{ type: "text", text: renderWorkflowText(snapshot, completed, options) }],
+        details: snapshot,
+      });
+    }
+    if (completed) widget?.complete(snapshot);
+    else widget?.update(snapshot);
+  };
+
+  return {
+    update(snapshot) {
+      emit(snapshot, false);
+    },
+    complete(snapshot) {
+      emit(snapshot, true);
+    },
+    clear() {
+      widget?.clear();
+    },
+  };
+}
+
+export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: WorkflowDisplayOptions = {}): string[] {
+  const maxAgents = options.maxAgents ?? 8;
+  const maxLogs = options.maxLogs ?? 2;
+  const showResultPreviews = options.showResultPreviews ?? false;
+  const state =
+    snapshot.errorCount > 0
+      ? `, ${snapshot.errorCount} errors`
+      : snapshot.runningCount > 0
+        ? `, ${snapshot.runningCount} running`
+        : "";
+  const lines = [`◆ Workflow: ${snapshot.name} (${snapshot.doneCount}/${snapshot.agentCount} done${state})`];
+
+  const agentPhaseNames = snapshot.agents
+    .map((agent) => agent.phase)
+    .filter((phase): phase is string => Boolean(phase));
+  const phaseNames = unique([
+    ...snapshot.phases,
+    ...(snapshot.currentPhase ? [snapshot.currentPhase] : []),
+    ...agentPhaseNames,
+  ]);
+  const rendered = new Set<WorkflowAgentSnapshot>();
+
+  for (const phase of phaseNames) {
+    const agents = snapshot.agents.filter((agent) => agent.phase === phase);
+    if (agents.length === 0 && snapshot.currentPhase !== phase) continue;
+    for (const agent of agents) rendered.add(agent);
+    const done = agents.filter((agent) => agent.status === "done").length;
+    const running = agents.filter((agent) => agent.status === "running").length;
+    const errors = agents.filter((agent) => agent.status === "error").length;
+    const skipped = agents.filter((agent) => agent.status === "skipped").length;
+    const complete = agents.length > 0 && done + errors + skipped === agents.length;
+    const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
+    lines.push(
+      `  ${marker} ${phase} ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
+    );
+
+    const visibleAgents = agents.slice(-maxAgents);
+    for (const agent of visibleAgents) {
+      const order = `#${agent.id}`;
+      const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+      const err = agent.status === "error" && agent.error ? ` [${shorten(agent.error, 80)}]` : "";
+      lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${result}${err}`);
+    }
+    if (agents.length > visibleAgents.length)
+      lines.push(`    … ${agents.length - visibleAgents.length} earlier agents`);
+  }
+
+  const unphased = snapshot.agents.filter((agent) => !rendered.has(agent));
+  if (unphased.length) {
+    lines.push("  Unphased");
+    for (const agent of unphased.slice(-maxAgents)) {
+      const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+      const err = agent.status === "error" && agent.error ? ` [${shorten(agent.error, 80)}]` : "";
+      lines.push(`    #${agent.id} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${result}${err}`);
+    }
+  }
+
+  const visibleLogs = snapshot.logs.slice(-maxLogs);
+  if (visibleLogs.length) {
+    if (lines.length > 1) lines.push("");
+    for (const log of visibleLogs) lines.push(`  log: ${log}`);
+  }
+
+  // 附加最终结果文件路径
+  if (snapshot.resultFile && snapshot.runningCount === 0) {
+    if (lines.length > 0) lines.push("");
+    lines.push(`  ${i18n.t("totalResult", { path: snapshot.resultFile })}`);
+  }
+
+  return lines;
+}
+
+export function renderWorkflowText(
+  snapshot: WorkflowSnapshot,
+  completed = false,
+  options: WorkflowDisplayOptions = {},
+): string {
+  const header = completed ? "Workflow completed" : "Workflow running";
+  return [header, ...renderWorkflowLines(snapshot, options)].join("\n");
+}
+
+// 仿 pi-interactive-subagents 的 formatStatusLine：
+// 每行一个 agent 状态，格式：`{label} {state detail} {elapsed}.`
+export function formatAgentStatusLine(agent: WorkflowAgentSnapshot, now = Date.now()): string {
+  const label = shorten(agent.label, 64);
+  const elapsed = agent.startedAt ? ((agent.finishedAt ?? now) - agent.startedAt) / 1000 : 0;
+  const elapsedText = `${elapsed.toFixed(1)}s`;
+  if (agent.status === "running") {
+    return `${label} running ${elapsedText}, active.`;
+  }
+  if (agent.status === "done") {
+    return `${label} finished in ${elapsedText}.`;
+  }
+  if (agent.status === "error") {
+    return `${label} failed after ${elapsedText}${agent.error ? ` (${shorten(agent.error, 60)})` : ""}.`;
+  }
+  if (agent.status === "skipped") {
+    return `${label} skipped.`;
+  }
+  return `${label} queued.`;
+}
+
+// 汇总所有 active agent（queued + running），其他只输出当前 phase 的进行中 agent
+export function formatWorkflowStatusAggregate(
+  snapshot: WorkflowSnapshot,
+  lineLimit = 4,
+  now = Date.now(),
+): { lines: string[]; overflow: number } {
+  const running = snapshot.agents.filter((a) => a.status === "running");
+  const queued = snapshot.agents.filter((a) => a.status === "queued");
+  const recent = [...running, ...queued].slice(0, lineLimit);
+  const lines = recent.map((a) => formatAgentStatusLine(a, now));
+  const overflow = Math.max(0, running.length + queued.length - recent.length);
+  return { lines, overflow };
+}
+
+function statusLine(snapshot: WorkflowSnapshot, completed: boolean): string {
+  if (completed) return `workflow ✓ ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount}`;
+  if (snapshot.runningCount > 0)
+    return `workflow ${snapshot.name}: ${snapshot.runningCount} running, ${snapshot.doneCount}/${snapshot.agentCount} done`;
+  return `workflow ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} done`;
+}
+
+function statusIcon(status: WorkflowAgentStatus): string {
+  switch (status) {
+    case "queued":
+      return "○";
+    case "running":
+      return "●";
+    case "done":
+      return "✓";
+    case "error":
+      return "✗";
+    case "skipped":
+      return "-";
+  }
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function shorten(value: string, max: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+/**
+ * CJK 双宽字符检测：返回字符的终端可见宽度（1 或 2）。
+ */
+function cjkCharWidth(code: number): number {
+  if (
+    (code >= 0x1100 && code <= 0x115f) ||
+    (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
+    (code >= 0xac00 && code <= 0xd7af) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe10 && code <= 0xfe6f) ||
+    (code >= 0xff01 && code <= 0xff60) ||
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0x20000 && code <= 0x2fffd) ||
+    (code >= 0x30000 && code <= 0x3fffd)
+  )
+    return 2;
+  return 1;
+}
+
+/**
+ * 计算字符串的终端可见宽度（考虑 CJK 双宽字符）。
+ */
+function visibleStrWidth(str: string): number {
+  let w = 0;
+  for (const ch of str) {
+    w += cjkCharWidth(ch.codePointAt(0) ?? 0);
+  }
+  return w;
+}
+
+/**
+ * 按可见宽度截断字符串，超出部分用省略号「…」替代。
+ * 用于 TUI widget 行内容截断，防止超出终端宽度导致 pi-tui 崩溃。
+ */
+function truncateVisible(str: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  const w = visibleStrWidth(str);
+  if (w <= maxWidth) return str;
+  const target = maxWidth - 1; // 留给「…」
+  let result = "";
+  let currentWidth = 0;
+  for (const ch of str) {
+    const cw = cjkCharWidth(ch.codePointAt(0) ?? 0);
+    if (currentWidth + cw > target) break;
+    result += ch;
+    currentWidth += cw;
+  }
+  return `${result}…`;
+}
+
+export function preview(value: unknown, max = 200): string {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (!text) return "";
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export function formatElapsed(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 1000) return "<1s";
+  if (ms < 60000) return `${Math.floor(ms / 1000)}s`;
+  if (ms < 3600000) {
+    const m = Math.floor(ms / 60000);
+    const s = Math.floor((ms % 60000) / 1000);
+    return `${m}m ${s}s`;
+  }
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return `${h}h ${m}m`;
+}
+
+export interface WorkflowTheme {
+  fg: (color: string, text: string) => string;
+  bold: (text: string) => string;
+}
+
+export function renderWorkflowThemed(
+  snapshot: WorkflowSnapshot,
+  theme: WorkflowTheme,
+  options: WorkflowDisplayOptions = {},
+): string {
+  const showResultPreviews = options.showResultPreviews ?? false;
+  const maxAgents = options.maxAgents ?? 8;
+
+  const elapsed = snapshot.durationMs ? formatElapsed(snapshot.durationMs) : "";
+  const agentSummary = `${snapshot.agentCount} agents`;
+  const durationPart = elapsed ? ` · ${elapsed}` : "";
+
+  const lines: string[] = [];
+
+  // Header: ▸ {name} — {agentCount} agents · {duration}
+  lines.push(
+    `${theme.fg("accent", "▸")} ${theme.fg("toolTitle", theme.bold(snapshot.name))} ${theme.fg("dim", `— ${agentSummary}${durationPart}`)}`,
+  );
+  lines.push("");
+
+  // Group agents by phase
+  const agentPhaseNames = snapshot.agents
+    .map((agent) => agent.phase)
+    .filter((phase): phase is string => Boolean(phase));
+  const phaseNames = unique([
+    ...snapshot.phases,
+    ...(snapshot.currentPhase ? [snapshot.currentPhase] : []),
+    ...agentPhaseNames,
+  ]);
+  const rendered = new Set<WorkflowAgentSnapshot>();
+
+  for (const phase of phaseNames) {
+    const agents = snapshot.agents.filter((agent) => agent.phase === phase);
+    if (agents.length === 0 && snapshot.currentPhase !== phase) continue;
+    for (const agent of agents) rendered.add(agent);
+
+    const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running").length;
+    const errors = agents.filter((a) => a.status === "error").length;
+    const skipped = agents.filter((a) => a.status === "skipped").length;
+    const complete = agents.length > 0 && done + errors + skipped === agents.length;
+
+    // Phase icon
+    let phaseIcon: string;
+    if (complete) {
+      phaseIcon = theme.fg("success", "✓");
+    } else if (running > 0 || snapshot.currentPhase === phase) {
+      phaseIcon = theme.fg("accent", "▶");
+    } else {
+      phaseIcon = theme.fg("dim", "○");
+    }
+
+    // Phase duration: first agent startedAt → last agent finishedAt
+    const phaseElapsed = computePhaseDuration(agents);
+    const phaseDurationText = phaseElapsed ? theme.fg("dim", formatElapsed(phaseElapsed)) : "";
+
+    lines.push(`  ${phaseIcon} ${phase}${phaseDurationText ? `  ${phaseDurationText}` : ""}`);
+
+    // Agents in this phase
+    const visibleAgents = agents.slice(-maxAgents);
+    for (const agent of visibleAgents) {
+      const order = `#${agent.id}`;
+      const icon = themedStatusIcon(agent.status, theme);
+      const label = theme.fg("toolOutput", shorten(agent.label, 48));
+      const agentElapsed = computeAgentDuration(agent);
+      const agentDurationText = agentElapsed ? `  ${theme.fg("dim", formatElapsed(agentElapsed))}` : "";
+      const err =
+        agent.status === "error" && agent.error ? ` ${theme.fg("error", `[${shorten(agent.error, 60)}]`)}` : "";
+      lines.push(`    ${order} ${icon} ${label}${agentDurationText}${err}`);
+
+      // Result preview (file path)
+      if (showResultPreviews && agent.resultPreview) {
+        lines.push(`         ${theme.fg("muted", agent.resultPreview)}`);
+      }
+    }
+    if (agents.length > visibleAgents.length) {
+      lines.push(`    ${theme.fg("dim", `… ${agents.length - visibleAgents.length} earlier agents`)}`);
+    }
+  }
+
+  // Unphased agents
+  const unphased = snapshot.agents.filter((agent) => !rendered.has(agent));
+  if (unphased.length) {
+    lines.push(`  ${theme.fg("dim", "Unphased")}`);
+    for (const agent of unphased.slice(-maxAgents)) {
+      const icon = themedStatusIcon(agent.status, theme);
+      const label = theme.fg("toolOutput", shorten(agent.label, 48));
+      const agentElapsed = computeAgentDuration(agent);
+      const agentDurationText = agentElapsed ? `  ${theme.fg("dim", formatElapsed(agentElapsed))}` : "";
+      const err =
+        agent.status === "error" && agent.error ? ` ${theme.fg("error", `[${shorten(agent.error, 60)}]`)}` : "";
+      lines.push(`    #${agent.id} ${icon} ${label}${agentDurationText}${err}`);
+      if (showResultPreviews && agent.resultPreview) {
+        lines.push(`         ${theme.fg("muted", agent.resultPreview)}`);
+      }
+    }
+  }
+
+  // Result file
+  if (snapshot.resultFile) {
+    lines.push("");
+    lines.push(`  ${theme.fg("muted", `📄 ${snapshot.resultFile}`)}`);
+  }
+
+  return lines.join("\n");
+}
+
+function themedStatusIcon(status: WorkflowAgentStatus, theme: WorkflowTheme): string {
+  switch (status) {
+    case "done":
+      return theme.fg("success", "✓");
+    case "error":
+      return theme.fg("error", "✗");
+    case "running":
+      return theme.fg("accent", "●");
+    case "queued":
+      return theme.fg("dim", "○");
+    case "skipped":
+      return theme.fg("dim", "-");
+  }
+}
+
+/**
+ * 渲染带边框的 Widget 状态栏行（用于 aboveEditor widget）。
+ * 使用 box-drawing 字符和硬编码 ANSI 色彩。
+ */
+export function renderWorkflowWidgetLines(snapshot: WorkflowSnapshot, width: number): string[] {
+  const ACCENT = "\x1b[38;2;77;163;255m";
+  const RST = "\x1b[0m";
+  const GREEN = "\x1b[32m";
+  const CYAN = "\x1b[36m";
+  const RED = "\x1b[31m";
+  const DIM = "\x1b[90m";
+
+  const MAX_VISIBLE_AGENTS = 6;
+  // boxWidth 必须严格不超过终端实际宽度，否则 pi-tui 会因行超出终端宽度而崩溃。
+  // 原先 Math.max(50, width) 在窄终端（如 43 列分屏）下强制设为 50，导致渲染行
+  // visible width=50 > 终端宽度 43，pi-tui 抛出 uncaughtException 退出。
+  // 修复：去掉 50 上限，让 widget 跟随终端实际宽度自适应填满。
+  // 最小 20 是为了保证极窄终端下 innerWidth=18 有足够空间显示基本内容。
+  const boxWidth = Math.max(20, width);
+  const innerWidth = boxWidth - 2; // exclude │ on each side
+
+  // 可见宽度辅助函数（考虑 CJK 双宽字符），已抽离为模块级 visibleStrWidth
+  const strWidth = visibleStrWidth;
+
+  // Helper: pad content line to fit inside box.
+  // 不变式：调用方保证 rawLen <= innerWidth，padLine 只补右侧空白到 innerWidth。
+  const padLine = (content: string, rawLen: number): string => {
+    const padding = Math.max(0, innerWidth - rawLen);
+    return `${ACCENT}│${RST}${content}${" ".repeat(padding)}${ACCENT}│${RST}`;
+  };
+
+  // Title line: ╭─ Workflow: {name} ──── {done}/{total} done ─╮
+  // 标题结构：╭ + ─ + titleText + ─*fill + statsText + ─ + ╮
+  // 总可见宽度 = 1(╭) + 1(─) + titleTextW + fillLen + statsTextW + 1(─) + 1(╮)
+  //           = 4 + titleTextW + fillLen + statsTextW
+  // fillLen 至少 1。极窄终端下逐步压缩 titlePrefix/statsText。
+  let titlePrefix = ` Workflow: `;
+  let statsText = ` ${snapshot.doneCount}/${snapshot.agentCount} done `;
+  // 判断在最小 fill(1) 下能否装下：4 + prefixW + 1(name至少1) + 1(fill) + statsW + 1(尾部空格) <= boxWidth
+  const tryFit = (prefix: string, stats: string): boolean =>
+    4 + strWidth(prefix) + 1 + 1 + strWidth(stats) + 1 <= boxWidth;
+  if (!tryFit(titlePrefix, statsText)) {
+    statsText = ` ${snapshot.doneCount}/${snapshot.agentCount} `;
+  }
+  if (!tryFit(titlePrefix, statsText)) {
+    titlePrefix = ` `;
+    statsText = `${snapshot.doneCount}/${snapshot.agentCount}`;
+  }
+  if (!tryFit(titlePrefix, statsText)) {
+    // 极窄：只显示 name + 边框
+    titlePrefix = ``;
+    statsText = ``;
+  }
+  // 固定占用 4（╭ ─ ─ ╮，不含 titleText/statsText/fill）
+  const fixedOverhead = 4;
+  // titleText = titlePrefix + name + " "（尾部空格）
+  const maxNameWidth = Math.max(1, boxWidth - fixedOverhead - strWidth(titlePrefix) - strWidth(statsText) - 2); // -1 尾空格 -1 fill
+  const truncatedName = truncateVisible(snapshot.name, maxNameWidth);
+  const titleText = `${titlePrefix}${truncatedName} `;
+  const fillLen = Math.max(1, boxWidth - fixedOverhead - strWidth(titleText) - strWidth(statsText));
+  const topLine = `${ACCENT}╭─${titleText}${"─".repeat(fillLen)}${statsText}─╮${RST}`;
+
+  // Bottom line: ╰ + ─*(boxWidth-2) + ╯
+  const bottomLine = `${ACCENT}╰${"─".repeat(boxWidth - 2)}╯${RST}`;
+
+  const lines: string[] = [topLine];
+
+  // Group agents by phase
+  const agentPhaseNames = snapshot.agents.map((a) => a.phase).filter((p): p is string => Boolean(p));
+  const phaseNames = unique([
+    ...snapshot.phases,
+    ...(snapshot.currentPhase ? [snapshot.currentPhase] : []),
+    ...agentPhaseNames,
+  ]);
+  const rendered = new Set<WorkflowAgentSnapshot>();
+
+  /** 渲染单个 agent 行。返回 padLine 后的字符串。 */
+  const renderAgentLine = (agent: WorkflowAgentSnapshot): string => {
+    const order = `#${agent.id}`;
+    const { icon } = widgetStatusIcon(agent.status);
+    const agentElapsed = computeAgentDuration(agent);
+    const elapsedText = agentElapsed ? formatElapsed(agentElapsed) : "";
+
+    const statusLabel =
+      agent.status === "done"
+        ? "done"
+        : agent.status === "running"
+          ? "running"
+          : agent.status === "error"
+            ? "error"
+            : "";
+    let rightText = elapsedText ? `${statusLabel} ${elapsedText}` : statusLabel;
+    let rightRawLen = rightText.length;
+    const statusColor =
+      agent.status === "done" ? GREEN : agent.status === "running" ? CYAN : agent.status === "error" ? RED : DIM;
+    let rightPart = rightText ? `${statusColor}${rightText}${RST}` : "";
+
+    // 布局："    " + order + " " + icon + " " + label + gap + rightText
+    // 左侧固定部分宽度（不含 label）：4(空格) + orderW + 1(空格) + 1(icon) + 1(空格)
+    const leftFixedWidth = 4 + order.length + 1 + 1 + 1;
+    // 如果有 rightText，需留至少 1 个 gap + rightRawLen
+    let minRightWidth = rightRawLen > 0 ? 1 + rightRawLen : 0;
+    // 极窄终端下 leftFixedWidth + minRightWidth 可能已超过 innerWidth。
+    // 此时逐步压缩：先去掉耗时，只留状态；再去掉状态，只留 label；最后连 label 也截断。
+    if (leftFixedWidth + minRightWidth > innerWidth) {
+      // 阶段 1：只留状态标签（去掉耗时）
+      rightText = statusLabel;
+      rightRawLen = rightText.length;
+      minRightWidth = rightRawLen > 0 ? 1 + rightRawLen : 0;
+    }
+    if (leftFixedWidth + minRightWidth > innerWidth) {
+      // 阶段 2：去掉右侧状态，只留左侧 label
+      rightText = "";
+      rightRawLen = 0;
+      rightPart = "";
+      minRightWidth = 0;
+    }
+    const labelMaxWidth = Math.max(1, innerWidth - leftFixedWidth - minRightWidth);
+    const label = truncateVisible(agent.label.replace(/\s+/g, " ").trim(), labelMaxWidth);
+
+    const leftPart = `    ${order} ${icon} ${label}`;
+    const leftRawLen = leftFixedWidth + strWidth(label);
+
+    // gap 填充剩余空间；如果没有 rightText，gap 可以是 0（label 占满）
+    const gapLen = Math.max(rightRawLen > 0 ? 1 : 0, innerWidth - leftRawLen - rightRawLen);
+    const agentLine = `${leftPart}${" ".repeat(gapLen)}${rightPart}`;
+    const agentRawLen = leftRawLen + gapLen + rightRawLen;
+    return padLine(agentLine, agentRawLen);
+  };
+
+  for (const phase of phaseNames) {
+    const agents = snapshot.agents.filter((a) => a.phase === phase);
+    for (const a of agents) rendered.add(a);
+
+    const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running").length;
+    const errors = agents.filter((a) => a.status === "error").length;
+    const skipped = agents.filter((a) => a.status === "skipped").length;
+    const complete = agents.length > 0 && done + errors + skipped === agents.length;
+
+    // Phase icon
+    let phaseIcon: string;
+    if (complete) {
+      phaseIcon = `${GREEN}✓${RST}`;
+    } else if (running > 0 || snapshot.currentPhase === phase) {
+      phaseIcon = `${CYAN}▶${RST}`;
+    } else {
+      phaseIcon = `${DIM}○${RST}`;
+    }
+
+    // Phase 行：按可见宽度截断 phase 名称，防止超出 innerWidth
+    // 布局："  " + icon(1) + " " + phaseName，总共占 2+1+1+nameW = 4+nameW
+    const phaseNameMaxWidth = Math.max(1, innerWidth - 4);
+    const truncatedPhase = truncateVisible(phase, phaseNameMaxWidth);
+    const phaseContent = `  ${phaseIcon} ${truncatedPhase}`;
+    const phaseRawLen = 2 + 1 + 1 + strWidth(truncatedPhase); // "  " + icon + " " + name
+    lines.push(padLine(phaseContent, phaseRawLen));
+
+    // Agents in this phase
+    const visibleAgents = agents.slice(-MAX_VISIBLE_AGENTS);
+    for (const agent of visibleAgents) {
+      lines.push(renderAgentLine(agent));
+    }
+    if (agents.length > visibleAgents.length) {
+      const moreText = `    … ${agents.length - visibleAgents.length} earlier`;
+      const moreRawLen = 2 + moreText.length;
+      // 极窄终端下 moreText 可能超过 innerWidth，截断保护
+      if (moreRawLen > innerWidth) {
+        const truncated = truncateVisible(`  ${moreText}`, innerWidth);
+        lines.push(padLine(`${DIM}${truncated}${RST}`, strWidth(truncated)));
+      } else {
+        lines.push(padLine(`  ${DIM}${moreText}${RST}`, moreRawLen));
+      }
+    }
+  }
+
+  // Unphased agents
+  const unphased = snapshot.agents.filter((a) => !rendered.has(a));
+  if (unphased.length) {
+    const visibleAgents = unphased.slice(-MAX_VISIBLE_AGENTS);
+    for (const agent of visibleAgents) {
+      lines.push(renderAgentLine(agent));
+    }
+    if (unphased.length > visibleAgents.length) {
+      const moreText = `    … ${unphased.length - visibleAgents.length} earlier`;
+      const moreRawLen = 2 + moreText.length;
+      if (moreRawLen > innerWidth) {
+        const truncated = truncateVisible(`  ${moreText}`, innerWidth);
+        lines.push(padLine(`${DIM}${truncated}${RST}`, strWidth(truncated)));
+      } else {
+        lines.push(padLine(`  ${DIM}${moreText}${RST}`, moreRawLen));
+      }
+    }
+  }
+
+  lines.push(bottomLine);
+  return lines;
+}
+
+function widgetStatusIcon(status: WorkflowAgentStatus): { icon: string; iconRaw: string } {
+  const GREEN = "\x1b[32m";
+  const CYAN = "\x1b[36m";
+  const RED = "\x1b[31m";
+  const DIM = "\x1b[90m";
+  const RST = "\x1b[0m";
+  switch (status) {
+    case "done":
+      return { icon: `${GREEN}✓${RST}`, iconRaw: "✓" };
+    case "running":
+      return { icon: `${CYAN}●${RST}`, iconRaw: "●" };
+    case "error":
+      return { icon: `${RED}✗${RST}`, iconRaw: "✗" };
+    case "queued":
+      return { icon: `${DIM}○${RST}`, iconRaw: "○" };
+    case "skipped":
+      return { icon: `${DIM}-${RST}`, iconRaw: "-" };
+  }
+}
+
+function computePhaseDuration(agents: WorkflowAgentSnapshot[]): number | undefined {
+  const starts = agents.map((a) => a.startedAt).filter((t): t is number => t != null);
+  const ends = agents.map((a) => a.finishedAt).filter((t): t is number => t != null);
+  if (starts.length === 0 || ends.length === 0) return undefined;
+  const duration = Math.max(...ends) - Math.min(...starts);
+  return duration > 0 ? duration : undefined;
+}
+
+function computeAgentDuration(agent: WorkflowAgentSnapshot): number | undefined {
+  if (!agent.startedAt) return undefined;
+  const end = agent.finishedAt ?? Date.now();
+  const duration = end - agent.startedAt;
+  return duration > 0 ? duration : undefined;
+}

--- a/packages/pi-dynamic-workflows/src/extension.ts
+++ b/packages/pi-dynamic-workflows/src/extension.ts
@@ -1,0 +1,136 @@
+import { defineTool, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import { Type } from "typebox";
+import { loadConfig, saveConfig } from "./config.ts";
+import { cancelRunningWorkflow, createWorkflowTool, renderWorkflowThemed } from "./index.ts";
+
+const i18n = createTranslator(loadCatalog(new URL("../locales/index.json", import.meta.url)));
+const LOG_PREFIX = "[pi-dynamic-workflows]";
+
+export default function extension(pi: ExtensionAPI) {
+  // Subagent session 不注册 workflow 工具：subagent 是 workflow 的执行节点，
+  // 不应再拥有启动 workflow 的能力（防止递归调用、误激活、误取消等）。
+  // pi-interactive-subagents 启动子 pi session 时会设置 PI_SUBAGENT_NAME。
+  if (process.env.PI_SUBAGENT_NAME) {
+    return;
+  }
+
+  const config = loadConfig();
+  const workflowTool = createWorkflowTool({ pi });
+  pi.registerTool(workflowTool);
+
+  // 异步模式：注册 workflow_cancel 工具
+  if (config.async) {
+    const cancelTool = defineTool({
+      name: "workflow_cancel",
+      label: "Cancel Workflow",
+      description: i18n.t("cancelToolDescription"),
+      promptSnippet: "Cancel a running background workflow.",
+      parameters: Type.Object({}),
+      async execute() {
+        const result = cancelRunningWorkflow();
+        if (result.cancelled) {
+          return {
+            content: [{ type: "text", text: i18n.t("cancelSent", { name: result.name }) }],
+            details: {},
+          };
+        }
+        return {
+          content: [{ type: "text", text: i18n.t("noneRunning") }],
+          details: {},
+        };
+      },
+      renderCall(_args, theme) {
+        return new Text(theme.fg("toolTitle", theme.bold("workflow_cancel")), 0, 0);
+      },
+    });
+    pi.registerTool(cancelTool);
+  }
+
+  // 注册异步模式的结果消息渲染器
+  pi.registerMessageRenderer("workflow_result", (message: any, _options: any, theme: any) => {
+    const snapshot = message.details;
+    if (!snapshot?.name) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const hasError = snapshot.errorCount > 0;
+        const bgFn = hasError
+          ? (text: string) => theme.bg("toolErrorBg", text)
+          : (text: string) => theme.bg("toolSuccessBg", text);
+        const icon = hasError ? theme.fg("error", "✗") : theme.fg("success", "✓");
+        const status = hasError ? "completed with errors" : "completed";
+        const elapsed = snapshot.durationMs ? `${Math.round(snapshot.durationMs / 1000)}s` : "?";
+
+        const header = `${icon} ${theme.fg("toolTitle", theme.bold(`Workflow: ${snapshot.name}`))} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;
+
+        const contentLines = [header, ""];
+        const themed = renderWorkflowThemed(snapshot, theme, {
+          key: "workflow",
+          maxAgents: 4,
+          maxLogs: 1,
+          showResultPreviews: true,
+        });
+        contentLines.push(...themed.split("\n"));
+
+        const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+      invalidate(): void {},
+    };
+  });
+
+  registerConfigCommand(pi);
+
+  pi.on("session_start", () => {
+    const active = pi.getActiveTools();
+    const toolNames = [workflowTool.name];
+    if (loadConfig().async) toolNames.push("workflow_cancel");
+    for (const name of toolNames) {
+      if (!active.includes(name)) {
+        pi.setActiveTools([...pi.getActiveTools(), name]);
+      }
+    }
+  });
+
+  // 会话关闭时取消运行中的异步 workflow
+  pi.on("session_shutdown", () => {
+    cancelRunningWorkflow();
+  });
+}
+
+/** /workflow-config 交互式配置命令：切换执行后端与异步模式，持久化到 JSON。 */
+function registerConfigCommand(pi: ExtensionAPI) {
+  pi.registerCommand("workflow-config", {
+    description: i18n.t("commandDescription"),
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) return;
+      while (true) {
+        const cfg = loadConfig();
+        const EXIT = i18n.t("exit");
+        const on = i18n.t("on");
+        const off = i18n.t("off");
+        const choices = [
+          i18n.t("toggleBackend", { value: cfg.backend }),
+          i18n.t("toggleAsync", { value: cfg.async ? on : off }),
+          EXIT,
+        ];
+        const choice = await ctx.ui.select(i18n.t("configTitle"), choices);
+        if (choice === undefined || choice === EXIT) return;
+
+        if (choice === choices[0]) {
+          const saved = saveConfig({ backend: cfg.backend === "subagent" ? "workflow" : "subagent" });
+          ctx.ui.notify(`${LOG_PREFIX} ${i18n.t("savedBackend", { value: saved.backend })}`, "info");
+        } else if (choice === choices[1]) {
+          const saved = saveConfig({ async: !cfg.async });
+          ctx.ui.notify(
+            `${LOG_PREFIX} ${i18n.t("savedAsync", { value: saved.async ? on : off })} ${i18n.t("reloadHint")}`,
+            "info",
+          );
+        }
+      }
+    },
+  });
+}

--- a/packages/pi-dynamic-workflows/src/index.ts
+++ b/packages/pi-dynamic-workflows/src/index.ts
@@ -1,0 +1,37 @@
+export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.ts";
+export { WorkflowAgent } from "./agent.ts";
+export type {
+  WorkflowAgentSnapshot,
+  WorkflowAgentStatus,
+  WorkflowDisplay,
+  WorkflowDisplayOptions,
+  WorkflowSnapshot,
+  WorkflowTheme,
+} from "./display.ts";
+export {
+  createToolUpdateWorkflowDisplay,
+  createWidgetWorkflowDisplay,
+  createWorkflowSnapshot,
+  preview,
+  recomputeWorkflowSnapshot,
+  renderWorkflowLines,
+  renderWorkflowText,
+  renderWorkflowThemed,
+  renderWorkflowWidgetLines,
+} from "./display.ts";
+export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.ts";
+export { createStructuredOutputTool } from "./structured-output.ts";
+export type { SubagentWorkflowAgentOptions } from "./subagent-agent.ts";
+export { SubagentWorkflowAgent } from "./subagent-agent.ts";
+export type {
+  AgentOptions,
+  WorkflowMeta,
+  WorkflowMetaPhase,
+  WorkflowRunOptions,
+  WorkflowRunResult,
+} from "./workflow.ts";
+export { parseWorkflowScript, runWorkflow } from "./workflow.ts";
+export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.ts";
+export { cancelRunningWorkflow, createWorkflowTool } from "./workflow-tool.ts";
+export type { WorkflowBackend, WorkflowConfig } from "./config.ts";
+export { configPath, loadConfig, saveConfig } from "./config.ts";

--- a/packages/pi-dynamic-workflows/src/structured-output.ts
+++ b/packages/pi-dynamic-workflows/src/structured-output.ts
@@ -1,0 +1,47 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
+
+export interface StructuredOutputCapture<T = unknown> {
+  value: T | undefined;
+  called: boolean;
+}
+
+export interface StructuredOutputToolOptions<TSchemaDef extends TSchema> {
+  schema: TSchemaDef;
+  capture: StructuredOutputCapture<Static<TSchemaDef>>;
+  name?: string;
+}
+
+/**
+ * Create a terminating tool that captures validated params as the subagent result.
+ *
+ * Pi validates `params` against `schema` before execute() is called. Returning
+ * `terminate: true` lets the subagent finish on this tool call without paying for
+ * an extra assistant follow-up turn.
+ */
+export function createStructuredOutputTool<TSchemaDef extends TSchema>({
+  schema,
+  capture,
+  name = "structured_output",
+}: StructuredOutputToolOptions<TSchemaDef>): ToolDefinition<TSchemaDef, Static<TSchemaDef>> {
+  return defineTool({
+    name,
+    label: "Structured Output",
+    description: "Return the final machine-readable result for this subagent task.",
+    promptSnippet: "Return final machine-readable output",
+    promptGuidelines: [
+      `${name} is the final answer channel for this task; call ${name} exactly once when done.`,
+      `Do not write a prose final answer after calling ${name}.`,
+    ],
+    parameters: schema,
+    async execute(_toolCallId, params) {
+      capture.value = params;
+      capture.called = true;
+      return {
+        content: [{ type: "text", text: "Structured output received." }],
+        details: params,
+        terminate: true,
+      };
+    },
+  });
+}

--- a/packages/pi-dynamic-workflows/src/subagent-agent.ts
+++ b/packages/pi-dynamic-workflows/src/subagent-agent.ts
@@ -1,0 +1,206 @@
+/**
+ * SubagentWorkflowAgent — workflow backend backed by pi-interactive-subagents.
+ *
+ * Activated when PI_WORKFLOW_BACKEND=subagent.  Uses launchSubagent / watchSubagent
+ * to run each agent() call as a separate tmux-pane subagent with real tool access.
+ * Structured output is enforced via the subagent's structured_output tool (ajv validation)
+ * rather than the in-memory session's structured_output mechanism.
+ */
+
+// ── defensive .jsonl validator ──
+// 拦截 pollForExit 误判（fast path 命中残留 .exit 或 slow path 读到 stale
+// sentinel）导致的"子 agent 根本没启动就被判定完成"。herdr-split.log 9:01 失败批次
+// 模式：pane run 6ms 后 close，subagentSessionFile.jsonl 永远不存在。
+import { existsSync, statSync } from "node:fs";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+
+const i18n = createTranslator(loadCatalog(new URL("../locales/index.json", import.meta.url)));
+
+/** 校验子 agent 的 .jsonl 会话文件是否真实存在且非空，防止 pollForExit 误判。 */
+function sessionFileLooksValid(jsonlPath: string): { ok: boolean; reason: string; size: number } {
+  if (!existsSync(jsonlPath)) return { ok: false, reason: "missing", size: 0 };
+  try {
+    const size = statSync(jsonlPath).size;
+    if (size === 0) return { ok: false, reason: "empty", size: 0 };
+    return { ok: true, reason: "ok", size };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, reason: `stat_failed:${msg}`, size: 0 };
+  }
+}
+
+// ── types lifted from pi-interactive-subagents ──
+interface SubagentCtx {
+  sessionManager: {
+    getSessionFile(): string | null;
+    getSessionId(): string;
+    getSessionDir(): string;
+  };
+  cwd: string;
+  model?: unknown;
+  modelRegistry?: unknown;
+  ui?: { notify?(message: string, level: "info" | "warning" | "error"): void };
+  [key: string]: unknown;
+}
+
+/** Mirror of pi-interactive-subagents' RunningSubagent (subset we care about). */
+interface RunningSubagent {
+  id: string;
+  name: string;
+  surface: string;
+  sessionFile: string;
+  startTime: number;
+}
+
+/** Mirror of pi-interactive-subagents' SubagentResult. */
+interface SubagentResult {
+  name: string;
+  task: string;
+  summary: string;
+  sessionFile?: string;
+  exitCode: number;
+  elapsed: number;
+  structuredOutput?: unknown;
+}
+
+// ── subagent API (lazily resolved from globalThis) ──
+interface SubagentApi {
+  launchSubagent(
+    params: Record<string, unknown>,
+    ctx: SubagentCtx,
+    options?: { surface?: string },
+  ): Promise<RunningSubagent>;
+  watchSubagent(running: RunningSubagent, signal: AbortSignal): Promise<SubagentResult>;
+}
+
+function getSubagentApi(): SubagentApi {
+  const api = (globalThis as any).__pi_subagents;
+  if (!api) {
+    throw new Error(i18n.t("subagentRequired"));
+  }
+  return api as SubagentApi;
+}
+
+// ── options ──
+export interface SubagentWorkflowAgentOptions {
+  cwd?: string;
+  /** Pi extension context (passed from workflow-tool execute callback). */
+  launchCtx: SubagentCtx;
+  /** Model override for subagent sessions (string id, not Model object). */
+  model?: string;
+  /** Extra instructions prepended to every agent() prompt. */
+  instructions?: string;
+}
+
+export interface AgentRunOptions {
+  label?: string;
+  schema?: unknown;
+  signal?: AbortSignal;
+  instructions?: string;
+  /** 覆盖 subagent 的模型，不传则走默认 fallback */
+  model?: string;
+}
+
+export type AgentRunResult = unknown;
+
+// ── agent ──
+export class SubagentWorkflowAgent {
+  private readonly cwd: string;
+  private readonly launchCtx: SubagentCtx;
+  private readonly model?: string;
+  private readonly instructions?: string;
+
+  constructor(options: SubagentWorkflowAgentOptions) {
+    this.cwd = options.cwd ?? process.cwd();
+    this.launchCtx = options.launchCtx;
+    this.model = options.model;
+    this.instructions = options.instructions;
+  }
+
+  async run(prompt: string, options: AgentRunOptions = {}): Promise<AgentRunResult> {
+    const api = getSubagentApi();
+
+    const taskParts = [
+      this.instructions,
+      options.instructions,
+      options.label ? `Task label: ${options.label}` : undefined,
+      prompt,
+    ].filter(Boolean);
+    const task = taskParts.join("\n\n");
+
+    const launchedAt = Date.now();
+    const running = await api.launchSubagent(
+      {
+        name: options.label ?? "workflow-agent",
+        task,
+        model: options.model ?? this.model,
+        cwd: this.cwd,
+        ...(options.schema ? { structuredOutputSchema: options.schema } : {}),
+      },
+      this.launchCtx,
+    );
+    this.launchCtx.ui?.notify?.(`[workflow] "${options.label ?? "workflow-agent"}" launched (${Date.now() - launchedAt}ms)`, "info");
+
+    // Create abort signal that combines caller's signal with module-level abort
+    const abortController = new AbortController();
+    let removeAbort: (() => void) | undefined;
+    if (options.signal) {
+      if (options.signal.aborted) {
+        throw new Error("Subagent was aborted");
+      }
+      const onAbort = () => abortController.abort();
+      options.signal.addEventListener("abort", onAbort, { once: true });
+      removeAbort = () => options.signal?.removeEventListener("abort", onAbort);
+    }
+
+    try {
+      const watchStartedAt = Date.now();
+      const result = await api.watchSubagent(running, abortController.signal);
+      const watchTookMs = Date.now() - watchStartedAt;
+      this.launchCtx.ui?.notify?.(
+        `[workflow] "${options.label ?? "workflow-agent"}" done (${watchTookMs}ms) → ` +
+          `exitCode=${result.exitCode} hasOutput=${result.structuredOutput !== undefined}`,
+        "info",
+      );
+
+      if (options.signal?.aborted) throw new Error("Subagent was aborted");
+
+      // 防御性校验：pollForExit 任何 reason (done / structured_output / ping / sentinel)
+      // 都要求 .jsonl 实际存在 + 非空。如果 .jsonl 不存在/为空，说明子 pi 根本没启动
+      // （典型场景：pane run 6ms 内 close、herdr 静默失败、stale .exit 残留命中 fast path）。
+      // 这种"假成功"比"明确失败"更危险——workflow 会把空数据当成结果继续往下走。
+      const jsonlCheck = sessionFileLooksValid(running.sessionFile);
+      if (!jsonlCheck.ok) {
+        this.launchCtx.ui?.notify?.(
+          `[workflow] "${options.label ?? "workflow-agent"}" SESSION FILE ${jsonlCheck.reason} ` +
+            `(${watchTookMs}ms, session ${running.sessionFile}) — ` +
+            `subagent never actually started, likely pollForExit false positive`,
+          "error",
+        );
+        throw new Error(
+          `Subagent pollForExit returned in ${watchTookMs}ms but session file is ` +
+            `${jsonlCheck.reason} (${running.sessionFile}). ` +
+            `This indicates the subagent never actually started — ` +
+            `likely a false positive from pollForExit (herdr workspace state issue). ` +
+            `Try restarting the herdr workspace or check for stale .exit sidecar files.`,
+        );
+      }
+
+      if (options.schema) {
+        if (result.structuredOutput === undefined) {
+          this.launchCtx.ui?.notify?.(
+            `[workflow] "${options.label ?? "workflow-agent"}" ${watchTookMs}ms exitCode=${result.exitCode} ` +
+              `— finished without calling structured_output`,
+            "warning",
+          );
+          throw new Error("Subagent finished without calling structured_output");
+        }
+        return result.structuredOutput as AgentRunResult;
+      }
+
+      return result.summary as AgentRunResult;
+    } finally {
+      removeAbort?.();
+    }
+  }
+}

--- a/packages/pi-dynamic-workflows/src/workflow-tool.ts
+++ b/packages/pi-dynamic-workflows/src/workflow-tool.ts
@@ -1,0 +1,513 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import { Type } from "typebox";
+import { loadConfig } from "./config.ts";
+import type { WorkflowTheme } from "./display.ts";
+import {
+  createToolUpdateWorkflowDisplay,
+  createWorkflowSnapshot,
+  recomputeWorkflowSnapshot,
+  renderWorkflowText,
+  renderWorkflowThemed,
+  renderWorkflowWidgetLines,
+  type WorkflowSnapshot,
+} from "./display.ts";
+import { parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.ts";
+
+const i18n = createTranslator(loadCatalog(new URL("../locales/index.json", import.meta.url)));
+
+const workflowToolSchema = Type.Object({
+  script: Type.Optional(
+    Type.String({
+      description: [
+        "Raw JavaScript workflow script with no Markdown fences.",
+        "First statement MUST be: export const meta = { name: 'short_snake_case', description: 'non-empty', whenToUse: 'optional', phases: [{ title: 'Phase 1' }, { title: 'Phase 2' }] }.",
+        "meta.phases is REQUIRED and must be a literal non-empty array of { title: string } objects — omitting it, passing `[]`, passing string arrays `['Phase 1']`, or passing `[{ name: 'Phase 1' }]` all raise parser errors.",
+        "meta must be plain literal values — no spread (`...base`), no computed keys (`['name']`), no function calls (`makeName()`), no backtick template strings with substitutions. The parser raises on these.",
+        "Runtime globals: phase(title), agent(prompt, { label, phase, schema, model, isolation, agentType }), parallel(thunks), pipeline(items, ...stages), log(msg), args, cwd, process.cwd(), budget.",
+        "Every agent() call REQUIRES opts.schema (a JSON Schema object) — without it the workflow fails at runtime.",
+        "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+      ].join(" "),
+    }),
+  ),
+  file: Type.Optional(
+    Type.String({
+      description:
+        "Absolute or relative path to a .js workflow file. Reads the file and executes it as the workflow script.",
+    }),
+  ),
+  args: Type.Optional(
+    Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
+  ),
+});
+
+export type WorkflowToolInput = {
+  script?: string;
+  file?: string;
+  args?: unknown;
+};
+
+const workflowDisplayOptions = {
+  key: "workflow",
+  streamToolUpdates: true,
+  maxAgents: 4,
+  maxLogs: 1,
+  showResultPreviews: true,
+} as const;
+
+export interface WorkflowToolOptions {
+  cwd?: string;
+  concurrency?: number;
+  pi?: { sendMessage: (message: any, options?: any) => void };
+}
+
+let runningWorkflow: { name: string; abortController: AbortController; cleanWidget?: () => void } | null = null;
+
+/**
+ * 取消正在运行的异步 workflow。
+ * 返回取消结果，供 workflow_cancel 工具和 session_shutdown 使用。
+ */
+export function cancelRunningWorkflow(): { cancelled: boolean; name?: string } {
+  if (!runningWorkflow) return { cancelled: false };
+  const { name, cleanWidget } = runningWorkflow;
+  runningWorkflow.abortController.abort();
+  // 立即清理 widget，不等 Promise 链 catch
+  if (cleanWidget) cleanWidget();
+  return { cancelled: true, name };
+}
+
+export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefinition<typeof workflowToolSchema, any> {
+  return defineTool({
+    name: "workflow",
+    label: "Workflow",
+    description: [
+      "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
+      "script is required raw JavaScript. It must start with `export const meta = { name: 'short_snake_case', description: '...', phases: [{ title: '...' }] }` (with optional `whenToUse`) and must call agent() at least once.",
+      "Every agent(prompt, opts) call REQUIRES opts.schema (a plain JSON Schema object) — without it the workflow throws at runtime. The subagent returns a validated object matching that schema, so spell out every field you want back.",
+      "meta.phases is REQUIRED: a literal non-empty array of `{ title: '...' }` objects that documents the static outline. Call `phase(title)` at runtime to drive the live progress UI alongside it.",
+    ].join(" "),
+    promptSnippet:
+      "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase 1' }, ...] }. Every agent() call requires opts.schema (JSON Schema). Use phase(title) at runtime to drive progress.",
+    promptGuidelines: [
+      "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
+      "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
+      "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase A' }, ...] }`. meta.name and meta.description must be non-empty strings; meta.phases must be a non-empty array of `{ title: string }` objects.",
+      "For workflow, meta.whenToUse is an optional string that describes when this workflow should be invoked; include it whenever the workflow has a non-obvious trigger condition.",
+      "For workflow, meta.phases is REQUIRED metadata that documents the static outline. It MUST be a literal non-empty array of plain objects: `phases: [{ title: 'Phase A' }, { title: 'Phase B' }]`. Each phase object MUST have a string `title` field (not `name`); `detail` and `model` are optional extras. Do NOT omit meta.phases, do NOT pass `phases: []` (empty array), do NOT write `phases: ['A', 'B']` (string array), do NOT write `phases: [{ name: 'A' }]` (wrong key) — all raise parser errors (`meta.phases must be a non-empty array of { title: string } objects` or `each meta phase must have a title string`). The meta.phases array must be a static literal; do not build it with loops, spreads, or function calls.",
+      "For workflow, the entire `meta` object must be plain literal values — no spread (`...base`), no computed keys (`['name']`), no function calls (`makeName()`), no backtick template strings with substitutions. Meta is statically parsed before the script runs, so any of these raise a parser error.",
+      "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
+      "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
+      "For workflow, call phase(title) at runtime to drive the live progress UI. Phase names may be conditional or built in a loop; do not predeclare speculative phases just in case. Note: meta.phases is the static outline; phase() at runtime drives the live UI.",
+      "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
+      "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
+      "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
+      "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
+      "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
+      "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
+      "For workflow, agent() REQUIRES opts.schema — a plain JSON Schema object (e.g. `{ type: 'object', properties: { ... }, required: [...] }`) that defines the structure of the validated object the subagent must return. The agent() call will throw `agent() requires a schema parameter` at runtime if `schema` is missing, so every agent() invocation in a workflow must pass it. Use JSON Schema syntax, not TypeScript or TypeBox constructors. The subagent's final action must be a structured_output call matching that schema; if you only need free-text output, use `schema: { type: 'string' }`.",
+      "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
+    ],
+    parameters: workflowToolSchema,
+    prepareArguments(args) {
+      return normalizeWorkflowToolArgs(args);
+    },
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
+      // 从 file 或 script 获取脚本内容
+      let rawScript: string;
+      if (params.file) {
+        const filePath = params.file.startsWith("/") ? params.file : join(ctx.cwd ?? "/", params.file);
+        rawScript = readFileSync(filePath, "utf8");
+      } else if (params.script) {
+        rawScript = params.script;
+      } else {
+        throw new Error(
+          "workflow requires either a `script` (JavaScript string) or `file` (path to .js file) argument",
+        );
+      }
+      const script = normalizeWorkflowScript(rawScript);
+      const parsed = parseWorkflowScript(script);
+
+      // === 异步模式 ===
+      const isAsync = loadConfig().async && options.pi;
+      if (isAsync) {
+        if (runningWorkflow) {
+          throw new Error(i18n.t("alreadyRunning", { name: runningWorkflow.name }));
+        }
+
+        let snapshot: WorkflowSnapshot = createWorkflowSnapshot(parsed.meta);
+        snapshot.startedAt = Date.now();
+        const bgAbortController = new AbortController();
+        const name = parsed.meta.name;
+        const workflowCwd = options.cwd ?? ctx.cwd;
+
+        // Widget 实时状态栏
+        const { updateWidget, clearWidget } = setupWidget(ctx, () => snapshot);
+
+        // 存储清理函数供 cancelRunningWorkflow() 立即清理
+        runningWorkflow = { name, abortController: bgAbortController, cleanWidget: clearWidget };
+
+        const update = () => {
+          snapshot = recomputeWorkflowSnapshot(snapshot);
+          // 异步模式下 tool 已返回，onUpdate 通道已失效，仅通过 widget 推送状态
+          updateWidget();
+        };
+
+        // 后台 Promise 链
+        runWorkflow(script, {
+          ...createWorkflowRunOptions({
+            cwd: workflowCwd,
+            args: params.args,
+            signal: bgAbortController.signal,
+            concurrency: options.concurrency,
+            ctx,
+          }),
+          ...createWorkflowCallbacks({
+            snapshot: () => snapshot,
+            setSnapshot: (s) => {
+              snapshot = s;
+            },
+            update,
+            signal: bgAbortController.signal,
+            cwd: workflowCwd,
+            metaName: parsed.meta.name,
+          }),
+        })
+          .then((result) => {
+            if (result.agentCount === 0) {
+              throw new Error(
+                "workflow scripts must call agent() at least once; this workflow declared phases but did not run any subagents",
+              );
+            }
+            snapshot.result = result.result;
+            snapshot.durationMs = result.durationMs;
+            snapshot = recomputeWorkflowSnapshot(snapshot);
+            clearWidget();
+
+            const outFile = writeResultFile(workflowCwd, result.meta.name, result.result);
+            snapshot.resultFile = outFile;
+
+            runningWorkflow = null;
+
+            options.pi?.sendMessage(
+              {
+                customType: "workflow_result",
+                content: i18n.t("resultWritten", { name, count: result.agentCount, ms: result.durationMs, path: outFile }),
+                display: true,
+                details: snapshot,
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          })
+          .catch((error) => {
+            clearWidget();
+            runningWorkflow = null;
+
+            const aborted = isAbortError(error);
+            const errMsg = error instanceof Error ? error.message : String(error);
+            for (const agent of snapshot.agents) {
+              if (agent.status === "running") {
+                agent.status = aborted ? "skipped" : "error";
+                agent.error = aborted ? "cancelled" : errMsg;
+              }
+            }
+            snapshot = recomputeWorkflowSnapshot(snapshot);
+
+            if (aborted) {
+              options.pi?.sendMessage(
+                {
+                  customType: "workflow_result",
+                  content: i18n.t("cancelled", { name }),
+                  display: true,
+                  details: { ...snapshot, cancelled: true },
+                },
+                { triggerTurn: true, deliverAs: "steer" },
+              );
+            } else {
+              options.pi?.sendMessage(
+                {
+                  customType: "workflow_result",
+                  content: `Workflow ${name} failed: ${errMsg}`,
+                  display: true,
+                  details: { ...snapshot, error: errMsg },
+                },
+                { triggerTurn: true, deliverAs: "steer" },
+              );
+            }
+          });
+
+        return {
+          content: [{ type: "text", text: i18n.t("started", { name }) }],
+          details: { name, status: "started" },
+        };
+      }
+
+      // === 同步模式（原逻辑）===
+      let snapshot: WorkflowSnapshot = createWorkflowSnapshot(parsed.meta);
+      const display = createToolUpdateWorkflowDisplay(onUpdate, undefined, workflowDisplayOptions);
+
+      snapshot.startedAt = Date.now();
+
+      const workflowCwd = options.cwd ?? ctx.cwd;
+      const { updateWidget, clearWidget } = setupWidget(ctx, () => snapshot);
+
+      const update = () => {
+        snapshot = recomputeWorkflowSnapshot(snapshot);
+        display.update(snapshot);
+        updateWidget();
+      };
+
+      let result: WorkflowRunResult;
+      try {
+        result = await runWorkflow(script, {
+          ...createWorkflowRunOptions({
+            cwd: workflowCwd,
+            args: params.args,
+            signal,
+            concurrency: options.concurrency,
+            ctx,
+          }),
+          ...createWorkflowCallbacks({
+            snapshot: () => snapshot,
+            setSnapshot: (s) => {
+              snapshot = s;
+            },
+            update,
+            signal,
+            cwd: workflowCwd,
+            metaName: parsed.meta.name,
+          }),
+        });
+      } catch (error) {
+        if (signal?.aborted || isAbortError(error)) {
+          for (const agent of snapshot.agents) {
+            if (agent.status === "running") {
+              agent.status = "skipped";
+              agent.error = "aborted";
+            }
+          }
+          snapshot = recomputeWorkflowSnapshot(snapshot);
+          display.complete(snapshot);
+          clearWidget();
+          throw new Error("Workflow was aborted");
+        }
+        clearWidget();
+        throw error;
+      }
+
+      if (result.agentCount === 0) {
+        throw new Error(
+          "workflow scripts must call agent() at least once; this workflow declared phases but did not run any subagents",
+        );
+      }
+
+      snapshot.result = result.result;
+      snapshot.durationMs = result.durationMs;
+      snapshot = recomputeWorkflowSnapshot(snapshot);
+      display.complete(snapshot);
+      clearWidget();
+
+      // 写入结果文件
+      const outFile = writeResultFile(workflowCwd, result.meta.name, result.result);
+      snapshot.resultFile = outFile;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: i18n.t("resultWritten", { name: result.meta.name, count: result.agentCount, ms: result.durationMs, path: outFile }),
+          },
+        ],
+        details: {
+          ...snapshot,
+          meta: result.meta,
+          phases: result.phases,
+          logs: result.logs,
+          result: result.result,
+          resultFile: outFile,
+          durationMs: result.durationMs,
+        },
+      };
+    },
+    renderCall(_args, theme) {
+      return new Text(theme.fg("toolTitle", theme.bold("workflow")), 0, 0);
+    },
+    renderResult(result, { isPartial }, theme) {
+      const snapshot = result.details as WorkflowSnapshot | undefined;
+      if (snapshot?.name) {
+        if (!isPartial) {
+          return new Text(
+            renderWorkflowThemed(snapshot, theme as unknown as WorkflowTheme, workflowDisplayOptions),
+            0,
+            0,
+          );
+        }
+        return new Text(renderWorkflowText(snapshot, false, workflowDisplayOptions), 0, 0);
+      }
+      const text = result.content?.[0];
+      return new Text(text?.type === "text" ? text.text : theme.fg("muted", "workflow"), 0, 0);
+    },
+  });
+}
+
+function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
+  if (!args || typeof args !== "object")
+    throw new Error("workflow requires an object argument with a script or file parameter");
+  const value = args as Record<string, unknown>;
+  if (typeof value.file !== "string" && typeof value.script !== "string")
+    throw new Error("workflow requires `script` (JavaScript string) or `file` (path to .js file)");
+  return value as WorkflowToolInput;
+}
+
+function normalizeWorkflowScript(script: string): string {
+  let text = script.trim();
+  const fence = text.match(/^```(?:js|javascript)?\s*\n([\s\S]*?)\n```$/i);
+  if (fence) text = fence[1].trim();
+  return text;
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /\babort(?:ed)?\b/i.test(error.message);
+}
+
+// --- 提取的共享辅助函数 ---
+
+/** 设置 Widget 实时状态栏，返回 updateWidget/clearWidget */
+function setupWidget(
+  ctx: any,
+  getSnapshot: () => WorkflowSnapshot,
+): { updateWidget: () => void; clearWidget: () => void } {
+  const WIDGET_KEY = Symbol.for("pi-workflow-widget-interval");
+  let widgetInterval: ReturnType<typeof setInterval> | null = null;
+
+  // 清除旧定时器（/reload 防护）
+  const prev = (globalThis as any)[WIDGET_KEY];
+  if (prev) clearInterval(prev);
+
+  const updateWidget = () => {
+    if (!ctx.hasUI) return;
+    ctx.ui.setWidget(
+      "workflow-status",
+      (_tui: any, _theme: any) => ({
+        invalidate() {},
+        render(w: number) {
+          return renderWorkflowWidgetLines(getSnapshot(), w);
+        },
+      }),
+      { placement: "aboveEditor" },
+    );
+  };
+
+  updateWidget();
+  widgetInterval = setInterval(updateWidget, 1000);
+  (globalThis as any)[WIDGET_KEY] = widgetInterval;
+
+  const clearWidget = () => {
+    if (widgetInterval) {
+      clearInterval(widgetInterval);
+      widgetInterval = null;
+    }
+    (globalThis as any)[WIDGET_KEY] = null;
+    if (ctx.hasUI) ctx.ui.setWidget("workflow-status", undefined);
+  };
+
+  return { updateWidget, clearWidget };
+}
+
+/** 创建 runWorkflow 的基础选项（不含回调） */
+function createWorkflowRunOptions(opts: {
+  cwd: string;
+  args?: unknown;
+  signal?: AbortSignal;
+  concurrency?: number;
+  ctx: any;
+}) {
+  return {
+    cwd: opts.cwd,
+    args: opts.args,
+    signal: opts.signal,
+    concurrency: opts.concurrency,
+    session: {
+      modelRegistry: opts.ctx.modelRegistry,
+      model: opts.ctx.model,
+    },
+    subagent: {
+      launchCtx: opts.ctx as any,
+      cwd: opts.cwd,
+    },
+  };
+}
+
+/** 创建 runWorkflow 的回调选项 */
+function createWorkflowCallbacks(opts: {
+  snapshot: () => WorkflowSnapshot;
+  setSnapshot: (s: WorkflowSnapshot) => void;
+  update: () => void;
+  signal?: AbortSignal;
+  cwd: string;
+  metaName: string;
+}) {
+  const recordPhase = (title: string | undefined) => {
+    if (!title) return;
+    const snap = opts.snapshot();
+    if (!snap.phases.includes(title)) snap.phases.push(title);
+  };
+
+  return {
+    onLog(message: string) {
+      opts.snapshot().logs.push(message);
+      opts.update();
+    },
+    onPhase(title: string) {
+      const snap = opts.snapshot();
+      snap.currentPhase = title;
+      recordPhase(title);
+      opts.update();
+    },
+    onAgentStart(event: { label: string; phase?: string; prompt: string }) {
+      if (opts.signal?.aborted) throw new Error("Workflow was aborted");
+      recordPhase(event.phase);
+      const snap = opts.snapshot();
+      snap.agents.push({
+        id: snap.agents.length + 1,
+        label: event.label,
+        phase: event.phase,
+        prompt: event.prompt,
+        status: "running",
+        startedAt: Date.now(),
+      });
+      opts.update();
+    },
+    onAgentEnd(event: { label: string; phase?: string; result: unknown; error?: string }) {
+      const snap = opts.snapshot();
+      const agent = [...snap.agents].reverse().find((item) => item.label === event.label && item.status === "running");
+      if (agent) {
+        agent.status = event.result === null ? "error" : "done";
+        agent.finishedAt = Date.now();
+        if (event.error) agent.error = event.error;
+        if (event.result != null) {
+          const agentsDir = join(opts.cwd, ".pi", "workflows", opts.metaName, "agents");
+          mkdirSync(agentsDir, { recursive: true });
+          const safeLabel = agent.label.replace(/[/\\:*?"<>|\s]+/g, "_").slice(0, 32);
+          const agentFile = join(agentsDir, `${String(agent.id).padStart(2, "0")}-${safeLabel}.json`);
+          writeFileSync(agentFile, JSON.stringify(event.result, null, 2), "utf8");
+          agent.resultPreview = `📄 ${agentFile}`;
+        }
+      }
+      opts.update();
+    },
+  };
+}
+
+/** 写入 workflow 结果文件，返回文件路径 */
+function writeResultFile(cwd: string, metaName: string, result: unknown): string {
+  const outDir = join(cwd, ".pi", "workflows");
+  mkdirSync(outDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outFile = join(outDir, `${metaName}-${ts}.json`);
+  writeFileSync(outFile, JSON.stringify(result ?? null, null, 2), "utf8");
+  return outFile;
+}

--- a/packages/pi-dynamic-workflows/src/workflow.ts
+++ b/packages/pi-dynamic-workflows/src/workflow.ts
@@ -1,0 +1,474 @@
+import vm from "node:vm";
+import type { Node } from "acorn";
+import { parse } from "acorn";
+import type { TSchema } from "typebox";
+import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.ts";
+import { SubagentWorkflowAgent, type SubagentWorkflowAgentOptions } from "./subagent-agent.ts";
+import { loadConfig } from "./config.ts";
+
+export interface WorkflowMetaPhase {
+  title: string;
+  detail?: string;
+  model?: string;
+}
+
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+  whenToUse?: string;
+  phases: WorkflowMetaPhase[];
+}
+
+export interface WorkflowRunOptions extends WorkflowAgentOptions {
+  args?: unknown;
+  agent?: { run(prompt: string, options: Record<string, unknown>): Promise<unknown> };
+  concurrency?: number;
+  tokenBudget?: number | null;
+  signal?: AbortSignal;
+  onLog?: (message: string) => void;
+  onPhase?: (title: string) => void;
+  onAgentStart?: (event: { label: string; phase?: string; prompt: string }) => void;
+  onAgentEnd?: (event: { label: string; phase?: string; result: unknown; error?: string }) => void;
+  /** When using subagent backend, the pi extension context from tool execute. */
+  subagent?: SubagentWorkflowAgentOptions;
+}
+
+export interface WorkflowRunResult<T = unknown> {
+  meta: WorkflowMeta;
+  result: T;
+  logs: string[];
+  phases: string[];
+  agentCount: number;
+  durationMs: number;
+}
+
+export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema | undefined> {
+  label?: string;
+  phase?: string;
+  schema?: TSchemaDef;
+  model?: string;
+  isolation?: "worktree";
+  agentType?: string;
+}
+
+interface RuntimeState {
+  currentPhase?: string;
+  logs: string[];
+  phases: string[];
+  agentCount: number;
+  spent: number;
+}
+
+type AnyNode = Node & { [key: string]: any; start: number; end: number };
+
+const NONDETERMINISM_ERROR =
+  "Workflow scripts must be deterministic: Date.now()/Math.random()/new Date() are unavailable";
+
+export async function runWorkflow<T = unknown>(
+  script: string,
+  options: WorkflowRunOptions = {},
+): Promise<WorkflowRunResult<T>> {
+  const started = Date.now();
+  const { meta, body } = parseWorkflowScript(script);
+  const state: RuntimeState = { logs: [], phases: [], agentCount: 0, spent: 0 };
+  const agentRunner =
+    options.agent ??
+    (loadConfig().backend === "subagent" && options.subagent
+      ? new SubagentWorkflowAgent(options.subagent)
+      : new WorkflowAgent(options));
+  const concurrency = Math.max(
+    1,
+    Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), 16),
+  );
+  const limiter = createLimiter(concurrency);
+  const pendingAgentRuns = new Set<Promise<unknown>>();
+
+  const log = (message: string) => {
+    const text = String(message);
+    state.logs.push(text);
+    options.onLog?.(text);
+  };
+
+  const phase = (title: unknown) => {
+    const text = requireString(title, "phase title");
+    state.currentPhase = text;
+    if (!state.phases.includes(text)) state.phases.push(text);
+    options.onPhase?.(text);
+  };
+
+  const budget = Object.freeze({
+    total: options.tokenBudget ?? null,
+    spent: () => state.spent,
+    remaining: () => (options.tokenBudget == null ? Infinity : Math.max(0, options.tokenBudget - state.spent)),
+  });
+
+  const throwIfAborted = () => {
+    if (options.signal?.aborted) throw new Error("workflow aborted");
+  };
+
+  const agent = async (prompt: unknown, agentOptions: unknown = {}) => {
+    throwIfAborted();
+    if (budget.total !== null && budget.remaining() <= 0) throw new Error("workflow token budget exhausted");
+    const taskPrompt = requireString(prompt, "agent prompt");
+    const normalizedOptions = normalizeAgentOptions(agentOptions);
+    if (!normalizedOptions.schema) {
+      throw new TypeError(
+        "agent() requires a `schema` parameter. Pass a JSON Schema via `agent(prompt, { schema: ... })`.",
+      );
+    }
+    const assignedPhase = normalizedOptions.phase ?? state.currentPhase;
+    const requestedLabel = normalizedOptions.label?.trim();
+    const run = limiter(async () => {
+      state.agentCount++;
+      const label = requestedLabel || defaultAgentLabel(assignedPhase, state.agentCount);
+      options.onAgentStart?.({ label, phase: assignedPhase, prompt: taskPrompt });
+      try {
+        throwIfAborted();
+        const result = await agentRunner.run(taskPrompt, {
+          label,
+          schema: normalizedOptions.schema,
+          signal: options.signal,
+          model: normalizedOptions.model,
+          instructions: buildAgentInstructions(assignedPhase, normalizedOptions),
+        } as any);
+        throwIfAborted();
+        state.spent += estimateTokens(result);
+        options.onAgentEnd?.({ label, phase: assignedPhase, result });
+        return result;
+      } catch (error) {
+        if (options.signal?.aborted) throw error;
+        log(`agent ${label} failed: ${error instanceof Error ? error.message : String(error)}`);
+        options.onAgentEnd?.({
+          label,
+          phase: assignedPhase,
+          result: null,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    });
+    pendingAgentRuns.add(run);
+    run.then(
+      () => pendingAgentRuns.delete(run),
+      () => pendingAgentRuns.delete(run),
+    );
+    return run;
+  };
+
+  const parallel = async (thunks: Array<() => Promise<unknown>>) => {
+    throwIfAborted();
+    if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
+    if (thunks.some((thunk) => typeof thunk !== "function")) {
+      throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
+    }
+    return Promise.all(
+      thunks.map(async (thunk, index) => {
+        try {
+          return await thunk();
+        } catch (error) {
+          if (options.signal?.aborted) throw error;
+          log(`parallel[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
+          return null;
+        }
+      }),
+    );
+  };
+
+  const pipeline = async (
+    items: unknown[],
+    ...stages: Array<(prev: unknown, original: unknown, index: number) => unknown>
+  ) => {
+    throwIfAborted();
+    if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
+    if (stages.some((stage) => typeof stage !== "function")) {
+      throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
+    }
+    return Promise.all(
+      items.map(async (item, index) => {
+        let value: unknown = item;
+        for (const stage of stages) {
+          try {
+            throwIfAborted();
+            value = await stage(value, item, index);
+            throwIfAborted();
+          } catch (error) {
+            if (options.signal?.aborted) throw error;
+            log(`pipeline[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
+            return null;
+          }
+        }
+        return value;
+      }),
+    );
+  };
+
+  const context = vm.createContext({
+    agent,
+    parallel,
+    pipeline,
+    log,
+    phase,
+    args: options.args,
+    cwd: options.cwd ?? process.cwd(),
+    process: Object.freeze({ cwd: () => options.cwd ?? process.cwd() }),
+    budget,
+    console: {
+      log,
+      info: log,
+      warn: (m: unknown) => log(`[warn] ${String(m)}`),
+      error: (m: unknown) => log(`[error] ${String(m)}`),
+    },
+    JSON,
+    Math,
+    Array,
+    Object,
+    String,
+    Number,
+    Boolean,
+    Set,
+    Map,
+    Promise,
+  });
+
+  const wrapped = `(async () => {\n${body}\n})()`;
+  const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+  await Promise.allSettled([...pendingAgentRuns]);
+  assertStructuredCloneable(result, "workflow result");
+  return {
+    meta,
+    result: result as T,
+    logs: state.logs,
+    phases: state.phases,
+    agentCount: state.agentCount,
+    durationMs: Date.now() - started,
+  };
+}
+
+export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
+  const ast = parse(script, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    ranges: false,
+  }) as AnyNode;
+
+  assertDeterministicAst(ast);
+
+  const first = ast.body?.[0] as AnyNode | undefined;
+  if (first?.type !== "ExportNamedDeclaration") {
+    throw new Error("`export const meta = { name, description }` must be the first statement in the script");
+  }
+
+  const declaration = first.declaration as AnyNode | null;
+  if (declaration?.type !== "VariableDeclaration" || declaration.kind !== "const") {
+    throw new Error("meta export must be `export const meta = ...`");
+  }
+  if (declaration.declarations.length !== 1) {
+    throw new Error("meta export must declare only `meta`");
+  }
+
+  const declarator = declaration.declarations[0] as AnyNode;
+  if (declarator.id?.type !== "Identifier" || declarator.id.name !== "meta") {
+    throw new Error("meta export must declare `meta`");
+  }
+  if (!declarator.init) throw new Error("meta must have a literal value");
+
+  const meta = evaluateLiteral(declarator.init, "meta");
+  validateMeta(meta);
+
+  return {
+    meta,
+    body: script.slice(0, first.start) + script.slice(first.end),
+  };
+}
+
+function evaluateLiteral(node: AnyNode, path: string): unknown {
+  switch (node.type) {
+    case "ObjectExpression": {
+      const out: Record<string, unknown> = {};
+      for (const prop of node.properties as AnyNode[]) {
+        if (prop.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+        if (prop.type !== "Property") throw new Error(`only plain properties allowed in ${path}`);
+        if (prop.computed) throw new Error(`computed keys not allowed in ${path}`);
+        if (prop.kind !== "init" || prop.method) throw new Error(`methods/accessors not allowed in ${path}`);
+        const key = propertyKey(prop.key as AnyNode, path);
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+          throw new Error(`reserved key name not allowed in ${path}: ${key}`);
+        }
+        out[key] = evaluateLiteral(prop.value as AnyNode, `${path}.${key}`);
+      }
+      return out;
+    }
+    case "ArrayExpression":
+      return (node.elements as Array<AnyNode | null>).map((element, index) => {
+        if (!element) throw new Error(`sparse arrays not allowed in ${path}`);
+        if (element.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+        return evaluateLiteral(element, `${path}[${index}]`);
+      });
+    case "Literal":
+      return node.value;
+    case "TemplateLiteral":
+      if (node.expressions.length > 0) throw new Error(`template interpolation not allowed in ${path}`);
+      return node.quasis.map((quasi: AnyNode) => quasi.value.cooked ?? quasi.value.raw).join("");
+    case "UnaryExpression":
+      if (node.operator === "-" && node.argument?.type === "Literal" && typeof node.argument.value === "number") {
+        return -node.argument.value;
+      }
+      throw new Error(`only negative-number unary allowed in ${path}`);
+    default:
+      throw new Error(`non-literal node type in ${path}: ${node.type}`);
+  }
+}
+
+function propertyKey(node: AnyNode, path: string): string {
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "Literal" && (typeof node.value === "string" || typeof node.value === "number"))
+    return String(node.value);
+  throw new Error(`unsupported key type in ${path}: ${node.type}`);
+}
+
+function assertDeterministicAst(node: AnyNode): void {
+  if (isDateNowCall(node) || isMathRandomCall(node) || isNewDateExpression(node)) {
+    throw new Error(NONDETERMINISM_ERROR);
+  }
+
+  for (const child of astChildren(node)) assertDeterministicAst(child);
+}
+
+function astChildren(node: AnyNode): AnyNode[] {
+  const children: AnyNode[] = [];
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) children.push(...value.filter(isAstNode));
+    else if (isAstNode(value)) children.push(value);
+  }
+  return children;
+}
+
+function isAstNode(value: unknown): value is AnyNode {
+  return !!value && typeof value === "object" && typeof (value as AnyNode).type === "string";
+}
+
+function isDateNowCall(node: AnyNode): boolean {
+  return node.type === "CallExpression" && isMemberExpression(node.callee, "Date", "now");
+}
+
+function isMathRandomCall(node: AnyNode): boolean {
+  return node.type === "CallExpression" && isMemberExpression(node.callee, "Math", "random");
+}
+
+function isNewDateExpression(node: AnyNode): boolean {
+  return node.type === "NewExpression" && node.callee?.type === "Identifier" && node.callee.name === "Date";
+}
+
+function isMemberExpression(node: AnyNode | undefined, objectName: string, propertyName: string): boolean {
+  if (node?.type !== "MemberExpression" || node.object?.type !== "Identifier" || node.object.name !== objectName) {
+    return false;
+  }
+  return propertyNameOf(node) === propertyName;
+}
+
+function propertyNameOf(node: AnyNode): string | undefined {
+  if (!node.computed && node.property?.type === "Identifier") return node.property.name;
+  return staticStringOf(node.property);
+}
+
+function staticStringOf(node: AnyNode | undefined): string | undefined {
+  if (node?.type === "Literal" && typeof node.value === "string") return node.value;
+  if (node?.type === "TemplateLiteral" && node.expressions.length === 0) {
+    return node.quasis.map((quasi: AnyNode) => quasi.value.cooked ?? quasi.value.raw).join("");
+  }
+  if (node?.type === "BinaryExpression" && node.operator === "+") {
+    const left = staticStringOf(node.left);
+    const right = staticStringOf(node.right);
+    if (left !== undefined && right !== undefined) return left + right;
+  }
+  return undefined;
+}
+
+function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
+  if (!meta || typeof meta !== "object") throw new Error("meta must be an object");
+  const value = meta as WorkflowMeta;
+  if (typeof value.name !== "string" || !value.name.trim()) throw new Error("meta.name must be a non-empty string");
+  if (typeof value.description !== "string" || !value.description.trim())
+    throw new Error("meta.description must be a non-empty string");
+  if (value.whenToUse !== undefined && typeof value.whenToUse !== "string")
+    throw new Error("meta.whenToUse must be a string");
+  if (!Array.isArray(value.phases) || value.phases.length === 0) {
+    throw new Error("meta.phases must be a non-empty array of { title: string } objects");
+  }
+  for (const phase of value.phases) {
+    if (!phase || typeof phase !== "object" || typeof (phase as WorkflowMetaPhase).title !== "string") {
+      throw new Error("each meta phase must have a title string");
+    }
+  }
+}
+
+function createLimiter(limit: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const next = () => {
+    active--;
+    queue.shift()?.();
+  };
+  return async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
+    active++;
+    try {
+      return await fn();
+    } finally {
+      next();
+    }
+  };
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== "string") throw new TypeError(`${name} must be a string`);
+  return value;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, name);
+}
+
+function normalizeAgentOptions(value: unknown): AgentOptions {
+  if (!value || typeof value !== "object") throw new TypeError("agent options must be an object");
+  const options = value as AgentOptions;
+  return {
+    ...options,
+    label: optionalString(options.label, "agent label"),
+    phase: optionalString(options.phase, "agent phase"),
+    model: optionalString(options.model, "agent model"),
+    isolation: options.isolation,
+    agentType: optionalString(options.agentType, "agent type"),
+  };
+}
+
+function assertStructuredCloneable(value: unknown, name: string): void {
+  try {
+    structuredClone(value);
+  } catch (error) {
+    const detail = error instanceof Error ? ` ${error.message}` : "";
+    throw new Error(
+      `${name} must be structured-cloneable; did you forget to await agent(), parallel(), or pipeline()?${detail}`,
+    );
+  }
+}
+
+function defaultAgentLabel(phase: string | undefined, index: number): string {
+  return phase ? `${phase} agent ${index}` : `agent ${index}`;
+}
+
+function buildAgentInstructions(phase: string | undefined, options: AgentOptions): string | undefined {
+  const lines = [];
+  if (phase) lines.push(`Workflow phase: ${phase}`);
+  if (options.agentType) lines.push(`Act as workflow subagent type: ${options.agentType}`);
+  if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
+  if (options.model) lines.push(`Requested model: ${options.model}`);
+  return lines.length ? lines.join("\n") : undefined;
+}
+
+function estimateTokens(value: unknown): number {
+  return Math.ceil(JSON.stringify(value ?? "").length / 4);
+}

--- a/packages/pi-dynamic-workflows/tests/catalog.test.ts
+++ b/packages/pi-dynamic-workflows/tests/catalog.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const catalog = JSON.parse(
+  readFileSync(new URL("../locales/index.json", import.meta.url), "utf-8"),
+);
+
+test("locales/index.json has zh-CN and en-US for every key", () => {
+  for (const [key, translations] of Object.entries(catalog)) {
+    const t = translations as Record<string, string>;
+    assert.ok(t["zh-CN"]?.length > 0, `key "${key}" missing zh-CN`);
+    assert.ok(t["en-US"]?.length > 0, `key "${key}" missing en-US`);
+  }
+});
+
+test("default export is a function", async () => {
+  const mod = await import("../index.ts");
+  assert.equal(typeof mod.default, "function");
+});

--- a/packages/pi-dynamic-workflows/tests/workflow-display.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-display.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createWorkflowSnapshot,
+  recomputeWorkflowSnapshot,
+  renderWorkflowLines,
+  renderWorkflowText,
+  renderWorkflowWidgetLines,
+  type WorkflowAgentSnapshot,
+  type WorkflowSnapshot,
+} from "../src/display.ts";
+
+function snapshot(overrides: Partial<WorkflowSnapshot> = {}): WorkflowSnapshot {
+  return recomputeWorkflowSnapshot({
+    name: "demo_workflow",
+    phases: [],
+    logs: [],
+    agents: [],
+    agentCount: 0,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 0,
+    ...overrides,
+  });
+}
+
+function agent(overrides: Partial<WorkflowAgentSnapshot> = {}): WorkflowAgentSnapshot {
+  return {
+    id: 1,
+    label: "scan repo",
+    phase: "Scan",
+    prompt: "Scan the repo",
+    status: "done",
+    ...overrides,
+  };
+}
+
+test("createWorkflowSnapshot does not pre-render declared phases", () => {
+  const value = createWorkflowSnapshot({
+    name: "demo_workflow",
+    description: "A useful workflow",
+    phases: [{ title: "Scan" }, { title: "Review" }],
+  });
+
+  assert.deepEqual(value.phases, ["Scan", "Review"]);
+});
+
+test("renderWorkflowLines hides empty phase rows", () => {
+  const lines = renderWorkflowLines(
+    snapshot({
+      phases: ["Scan", "Review"],
+      agents: [agent()],
+    }),
+  );
+
+  assert.ok(lines.some((line) => line.includes("Scan 1/1")));
+  assert.ok(!lines.some((line) => line.includes("Review 0/0")));
+});
+
+test("renderWorkflowLines keeps the current empty phase visible", () => {
+  const lines = renderWorkflowLines(
+    snapshot({
+      phases: ["Scan"],
+      currentPhase: "Scan",
+    }),
+  );
+
+  assert.ok(lines.some((line) => line.includes("▶ Scan 0/0")));
+});
+
+test("renderWorkflowLines groups agents by phase even when the phase was not pre-recorded", () => {
+  const lines = renderWorkflowLines(
+    snapshot({
+      phases: ["Scan"],
+      agents: [agent({ id: 2, label: "review diff", phase: "Review" })],
+    }),
+  );
+
+  assert.ok(lines.some((line) => line.includes("Review 1/1")));
+  assert.ok(!lines.some((line) => line.trim() === "Unphased"));
+});
+
+test("renderWorkflowLines renders runtime-created phases from the phase list", () => {
+  const lines = renderWorkflowLines(
+    snapshot({
+      phases: ["Inspect API"],
+      agents: [agent({ label: "inspect api", phase: "Inspect API" })],
+    }),
+  );
+
+  assert.ok(lines.some((line) => line.includes("Inspect API 1/1")));
+});
+
+test("renderWorkflowText respects log limits", () => {
+  const text = renderWorkflowText(
+    snapshot({
+      logs: ["first", "second", "third"],
+    }),
+    true,
+    { maxLogs: 1 },
+  );
+
+  assert.doesNotMatch(text, /log: first/);
+  assert.doesNotMatch(text, /log: second/);
+  assert.match(text, /log: third/);
+});
+
+test("renderWorkflowLines separates logs from progress", () => {
+  const lines = renderWorkflowLines(
+    snapshot({
+      agents: [agent()],
+      logs: ["finished scan"],
+    }),
+  );
+
+  const logIndex = lines.findIndex((line) => line.includes("log: finished scan"));
+  assert.ok(logIndex > 0);
+  assert.equal(lines[logIndex - 1], "");
+});
+
+// ===== 窄终端渲染安全性测试 =====
+// 回归：pi-crash 当终端分屏宽度变窄时，renderWorkflowWidgetLines 渲染的行
+// 可见宽度超过终端宽度，导致 pi-tui 抛出 uncaughtException 崩溃。
+
+/**
+ * 计算字符串的终端可见宽度，忽略 ANSI 转义序列，考虑 CJK 双宽字符。
+ * 仿 pi-tui visibleWidth 的关键行为，用于测试断言。
+ */
+function visibleWidth(str: string): number {
+  // 去除 ANSI 转义序列
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: 测试需要匹配 ANSI 转义序列
+  const stripped = str.replace(/\x1b\[[0-9;]*m/g, "");
+  let w = 0;
+  for (const ch of stripped) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (
+      (code >= 0x1100 && code <= 0x115f) ||
+      (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
+      (code >= 0xac00 && code <= 0xd7af) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xfe10 && code <= 0xfe6f) ||
+      (code >= 0xff01 && code <= 0xff60) ||
+      (code >= 0xffe0 && code <= 0xffe6) ||
+      (code >= 0x20000 && code <= 0x2fffd) ||
+      (code >= 0x30000 && code <= 0x3fffd)
+    ) {
+      w += 2;
+    } else {
+      w += 1;
+    }
+  }
+  return w;
+}
+
+test("renderWorkflowWidgetLines: 窄终端宽度 43 时所有行可见宽度不超过 43", () => {
+  // 模拟崩溃日志中的场景：长 phase 名 + 多 agent
+  const snap = snapshot({
+    name: "hscode_v3_backend_impl",
+    phases: [
+      "Batch 2：调拨包裹聚合 + 波次聚合（并行）",
+      "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）",
+    ],
+    agents: [
+      agent({ id: 1, label: "U2 调拨包裹聚合", phase: "Batch 2：调拨包裹聚合 + 波次聚合（并行）", status: "done" }),
+      agent({ id: 2, label: "U3 波次聚合", phase: "Batch 2：调拨包裹聚合 + 波次聚合（并行）", status: "done" }),
+      agent({
+        id: 3,
+        label: "U4 分波算法",
+        phase: "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）",
+        status: "done",
+      }),
+      agent({
+        id: 4,
+        label: "U5 波次内分箱",
+        phase: "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）",
+        status: "done",
+      }),
+      agent({
+        id: 5,
+        label: "U6 调拨包裹映射",
+        phase: "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）",
+        status: "running",
+      }),
+    ],
+  });
+
+  const lines = renderWorkflowWidgetLines(snap, 43);
+  for (const line of lines) {
+    const w = visibleWidth(line);
+    assert.ok(w <= 43, `行可见宽度 ${w} 超过终端宽度 43：${line}`);
+  }
+});
+
+test("renderWorkflowWidgetLines: 极窄终端宽度 20 时所有行可见宽度不超过 20", () => {
+  const snap = snapshot({
+    name: "very_long_workflow_name_that_exceeds_width",
+    phases: ["PhaseWithLongName"],
+    agents: [agent({ id: 1, label: "some agent with a long label", phase: "PhaseWithLongName", status: "running" })],
+  });
+
+  const lines = renderWorkflowWidgetLines(snap, 20);
+  for (const line of lines) {
+    const w = visibleWidth(line);
+    assert.ok(w <= 20, `行可见宽度 ${w} 超过终端宽度 20：${line}`);
+  }
+});
+
+test("renderWorkflowWidgetLines: boxWidth 不超过终端实际宽度", () => {
+  // 原先 Math.max(50, width) 会把 boxWidth 强制设为 50，
+  // 当终端宽度 < 50 时会导致渲染行超出终端宽度而崩溃。
+  const snap = snapshot({
+    name: "test",
+    phases: [],
+    agents: [],
+  });
+
+  // 终端宽度 43（崩溃日志中的值）— boxWidth 必须跟随为 43，不能是 50
+  const lines43 = renderWorkflowWidgetLines(snap, 43);
+  const topLine43 = lines43[0];
+  assert.ok(visibleWidth(topLine43) <= 43, `boxWidth 应不超过 43，但顶行可见宽度为 ${visibleWidth(topLine43)}`);
+
+  // 终端宽度 30 — boxWidth 跟随为 30
+  const lines30 = renderWorkflowWidgetLines(snap, 30);
+  const topLine30 = lines30[0];
+  assert.ok(visibleWidth(topLine30) <= 30, `boxWidth 应不超过 30，但顶行可见宽度为 ${visibleWidth(topLine30)}`);
+
+  // 终端宽度 120 — boxWidth 跟随为 120（修复后不再被上限 50 限制）
+  const lines120 = renderWorkflowWidgetLines(snap, 120);
+  const topLine120 = lines120[0];
+  assert.equal(
+    visibleWidth(topLine120),
+    120,
+    `boxWidth 应跟随终端宽度 120，但顶行可见宽度为 ${visibleWidth(topLine120)}`,
+  );
+});
+
+test("renderWorkflowWidgetLines: 长 phase 名被截断不溢出", () => {
+  const longPhaseName = "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）";
+  const snap = snapshot({
+    name: "test",
+    phases: [longPhaseName],
+    agents: [agent({ id: 1, label: "U4", phase: longPhaseName, status: "running" })],
+  });
+
+  // 在宽度 43 的终端下，长 phase 名必须被截断
+  const lines = renderWorkflowWidgetLines(snap, 43);
+  const phaseLine = lines.find((l) => l.includes("Batch 3"));
+  assert.ok(phaseLine, "应包含 phase 行");
+  assert.ok(visibleWidth(phaseLine) <= 43, `phase 行可见宽度 ${visibleWidth(phaseLine)} 超过 43`);
+  // 截断后应包含省略号
+  assert.ok(phaseLine.includes("…"), "长 phase 名应被截断并显示省略号");
+});
+
+test("renderWorkflowWidgetLines: 多种终端宽度下所有行均不溢出（fuzz）", () => {
+  // 模拟崩溃日志场景：超长 phase 名 + 多 agent + 超长 workflow 名
+  const longPhase = "Batch 3：分波 → 波次内分箱 → 调拨包裹映射（串行，共改 AllocationVoucherApplicationService）";
+  const snap = snapshot({
+    name: "hscode_v3_backend_impl_with_very_long_name_that_exceeds_normal_width",
+    phases: ["短Phase", longPhase],
+    agents: [
+      agent({ id: 1, label: "短标签", phase: "短Phase", status: "done" }),
+      agent({ id: 2, label: "一个比较长的 agent 标签用于测试截断", phase: longPhase, status: "running" }),
+      agent({ id: 3, label: "another long label for testing truncation behavior", phase: longPhase, status: "queued" }),
+      agent({
+        id: 4,
+        label: "U4",
+        phase: longPhase,
+        status: "error",
+        error: "编译失败：找不到符号 AllocationVoucherApplicationService",
+      }),
+      agent({ id: 5, label: "U5", phase: longPhase, status: "done" }),
+      agent({ id: 6, label: "U6", phase: longPhase, status: "done" }),
+      agent({ id: 7, label: "U7", phase: longPhase, status: "done" }),
+      agent({ id: 8, label: "U8", phase: longPhase, status: "skipped" }),
+      agent({ id: 9, label: "U9", phase: longPhase, status: "done" }), // 超过 MAX_VISIBLE_AGENTS
+    ],
+  });
+
+  // 测试从 20 到 120 的所有宽度（pi UI 在 20 列以下基本不可用）
+  for (let w = 20; w <= 120; w++) {
+    const lines = renderWorkflowWidgetLines(snap, w);
+    for (const line of lines) {
+      const vw = visibleWidth(line);
+      assert.ok(vw <= w, `宽度 ${w} 时行可见宽度 ${vw} 超过终端宽度：${line}`);
+    }
+  }
+});

--- a/packages/pi-dynamic-workflows/tests/workflow-parser.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-parser.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseWorkflowScript } from "../src/workflow.ts";
+
+const validScript = `export const meta = {
+  name: 'demo_workflow',
+  description: 'A useful workflow',
+  whenToUse: 'When testing parser behavior',
+  phases: [{ title: 'Scan', detail: 'Collect inputs', model: 'default' }]
+}
+
+phase('Scan')
+return { ok: true }
+`;
+
+test("parseWorkflowScript accepts literal workflow metadata", () => {
+  const parsed = parseWorkflowScript(validScript);
+  assert.equal(parsed.meta.name, "demo_workflow");
+  assert.equal(parsed.meta.description, "A useful workflow");
+  assert.deepEqual(parsed.meta.phases, [{ title: "Scan", detail: "Collect inputs", model: "default" }]);
+  assert.match(parsed.body, /phase\('Scan'\)/);
+  assert.doesNotMatch(parsed.body, /export const meta/);
+});
+
+test("parseWorkflowScript accepts static template literals", () => {
+  const parsed = parseWorkflowScript(
+    "export const meta = { name: `demo`, description: `static`, phases: [{ title: 'A' }] }\nreturn true",
+  );
+  assert.equal(parsed.meta.name, "demo");
+  assert.equal(parsed.meta.description, "static");
+});
+
+test("parseWorkflowScript requires meta export first", () => {
+  assert.throws(
+    () => parseWorkflowScript("const x = 1\nexport const meta = { name: 'demo', description: 'desc' }"),
+    /must be the first statement/,
+  );
+});
+
+test("parseWorkflowScript requires name and description", () => {
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', phases: [{ title: 'A' }] }"),
+    /meta.description/,
+  );
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { description: 'desc', phases: [{ title: 'A' }] }"),
+    /meta.name/,
+  );
+});
+
+test("parseWorkflowScript requires meta.phases", () => {
+  // 缺失
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }"),
+    /meta\.phases must be a non-empty array/,
+  );
+  // 空数组
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: [] }"),
+    /meta\.phases must be a non-empty array/,
+  );
+  // 非数组
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: 'A' }"),
+    /meta\.phases must be a non-empty array/,
+  );
+});
+
+test("parseWorkflowScript rejects non-literal metadata", () => {
+  assert.throws(
+    () =>
+      parseWorkflowScript("export const meta = { name: makeName(), description: 'desc', phases: [{ title: 'A' }] }"),
+    /non-literal node type.*CallExpression/,
+  );
+  assert.throws(
+    () =>
+      parseWorkflowScript(
+        "const name = 'demo'; export const meta = { name, description: 'desc', phases: [{ title: 'A' }] }",
+      ),
+    /must be the first statement/,
+  );
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: name, description: 'desc', phases: [{ title: 'A' }] }"),
+    /non-literal node type.*Identifier/,
+  );
+});
+
+test("parseWorkflowScript rejects object hazards", () => {
+  assert.throws(
+    () =>
+      parseWorkflowScript(
+        "export const meta = { ...base, name: 'demo', description: 'desc', phases: [{ title: 'A' }] }",
+      ),
+    /spread not allowed/,
+  );
+  assert.throws(
+    () =>
+      parseWorkflowScript("export const meta = { ['name']: 'demo', description: 'desc', phases: [{ title: 'A' }] }"),
+    /computed keys not allowed/,
+  );
+  assert.throws(
+    () =>
+      parseWorkflowScript(
+        "export const meta = { __proto__: {}, name: 'demo', description: 'desc', phases: [{ title: 'A' }] }",
+      ),
+    /reserved key name/,
+  );
+  assert.throws(
+    () =>
+      parseWorkflowScript(
+        "export const meta = { get name() { return 'demo' }, description: 'desc', phases: [{ title: 'A' }] }",
+      ),
+    /methods\/accessors not allowed/,
+  );
+});
+
+test("parseWorkflowScript rejects array hazards", () => {
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: [,,] }"),
+    /sparse arrays not allowed/,
+  );
+  assert.throws(
+    () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: [...items] }"),
+    /spread not allowed/,
+  );
+});
+
+test("parseWorkflowScript rejects template interpolation", () => {
+  assert.throws(
+    () =>
+      parseWorkflowScript(
+        "export const meta = { name: `demo_$" + "{id}`, description: 'desc', phases: [{ title: 'A' }] }",
+      ),
+    /template interpolation not allowed/,
+  );
+});
+
+test("parseWorkflowScript rejects nondeterministic APIs", () => {
+  for (const expression of [
+    "Date.now()",
+    "Date['now']()",
+    "Date[`now`]()",
+    "Date['n' + 'ow']()",
+    "Date?.now()",
+    "Date.now?.()",
+    "Math.random()",
+    "Math['random']()",
+    "Math[`random`]()",
+    "Math['ran' + 'dom']()",
+    "Math?.random()",
+    "Math.random?.()",
+    "new Date()",
+    "new (Date)()",
+    "`timestamp $" + "{Date.now()}`",
+  ]) {
+    assert.throws(
+      () =>
+        parseWorkflowScript(
+          `export const meta = { name: 'demo', description: 'desc', phases: [{ title: 'A' }] }\nreturn ${expression}`,
+        ),
+      /must be deterministic/,
+      expression,
+    );
+  }
+});
+
+test("parseWorkflowScript allows deterministic Date and Math APIs", () => {
+  for (const expression of [
+    "Date.parse('2020-01-01T00:00:00Z')",
+    "Date.UTC(2020, 0, 1)",
+    "Math.max(1, 2)",
+    "Math.floor(1.5)",
+    "({ Date: { now: true }, Math: { random: true } })",
+    "({ now: () => 1 }).now()",
+    "({ random: () => 1 }).random()",
+  ]) {
+    assert.doesNotThrow(
+      () =>
+        parseWorkflowScript(
+          `export const meta = { name: 'demo', description: 'desc', phases: [{ title: 'A' }] }\nreturn ${expression}`,
+        ),
+      expression,
+    );
+  }
+});
+
+test("parseWorkflowScript allows nondeterministic API names in text", () => {
+  const parsed = parseWorkflowScript(`export const meta = {
+  name: 'mentions_demo',
+  description: 'Catalog Date.now(), Math.random(), and new Date() usage',
+  whenToUse: 'When prompts mention Date.now()',
+  phases: [{ title: 'Find Date.now() mentions', detail: 'Check Math.random() and new Date() too' }]
+}
+
+// Comments may mention Date.now(), Math.random(), and new Date().
+const terms = {
+  'Date.now()': 'Date.now()',
+  'Math.random()': 'Math.random()',
+  'new Date()': 'new Date()'
+}
+phase('Find Date.now() mentions')
+await agent('Catalog Date.now(), Math.random(), and new Date() usage')
+await agent(\`Find Date.now(), Math.random(), and new Date() mentions\`)
+return { ok: true, terms }
+`);
+
+  assert.equal(parsed.meta.description, "Catalog Date.now(), Math.random(), and new Date() usage");
+  assert.match(parsed.body, /Catalog Date\.now\(\)/);
+});

--- a/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runWorkflow } from "../src/workflow.ts";
+
+const fakeAgent = {
+  async run(prompt: string): Promise<string> {
+    return `result:${prompt}`;
+  },
+};
+
+test("runWorkflow records runtime phases alongside declared meta.phases", async () => {
+  const result = await runWorkflow(
+    `export const meta = {
+  name: 'dynamic_demo',
+  description: 'Use runtime phases',
+  phases: [{ title: 'Scan' }]
+}
+
+phase('Scan')
+const scan = await agent('scan', { label: 'scan', schema: {} })
+return { scan }
+`,
+    { agent: fakeAgent },
+  );
+
+  assert.deepEqual(result.phases, ["Scan"]);
+  assert.equal(result.agentCount, 1);
+  assert.equal((result.result as { scan: string }).scan, "result:scan");
+});
+
+test("runWorkflow records loop-created phases without skipped conditional phases", async () => {
+  const result = await runWorkflow(
+    `export const meta = {
+  name: 'loop_demo',
+  description: 'Create phases from work items',
+  phases: [{ title: 'Review' }]
+}
+
+if (args.needsReview) {
+  phase('Review')
+  await agent('review', { label: 'review', schema: {} })
+}
+
+for (const area of args.areas) {
+  phase('Inspect ' + area)
+  await agent('inspect ' + area, { label: 'inspect ' + area, schema: {} })
+}
+
+return { ok: true }
+`,
+    {
+      args: { needsReview: false, areas: ["API", "UI"] },
+      agent: fakeAgent,
+    },
+  );
+
+  assert.deepEqual(result.phases, ["Inspect API", "Inspect UI"]);
+  assert.equal(result.agentCount, 2);
+});
+
+test("runWorkflow rejects unawaited nested agent promises before returning details", async () => {
+  let ended = 0;
+
+  await assert.rejects(
+    () =>
+      runWorkflow(
+        `export const meta = {
+  name: 'promise_leak',
+  description: 'Return an unawaited agent promise',
+  phases: [{ title: 'Leak promise' }]
+}
+
+phase('Leak promise')
+const scan = agent('scan', { label: 'scan', schema: {} })
+return { scan }
+`,
+        {
+          agent: fakeAgent,
+          onAgentEnd() {
+            ended++;
+          },
+        },
+      ),
+    /workflow result must be structured-cloneable; did you forget to await agent\(\), parallel\(\), or pipeline\(\)\?.*Promise.*cloned/,
+  );
+
+  assert.equal(ended, 1);
+});
+
+test("runWorkflow rejects non-string runtime phase titles", async () => {
+  await assert.rejects(
+    () =>
+      runWorkflow(
+        `export const meta = {
+  name: 'bad_phase',
+  description: 'Use a non-string phase title',
+  phases: [{ title: 'Scan' }]
+}
+
+phase(Promise.resolve('Scan'))
+return { ok: true }
+`,
+        { agent: fakeAgent },
+      ),
+    /phase title must be a string/,
+  );
+});
+
+test("runWorkflow allows prompts that mention nondeterministic API names", async () => {
+  const result = await runWorkflow(
+    `export const meta = {
+  name: 'prompt_mentions',
+  description: 'Ask about Date.now(), Math.random(), and new Date() usage',
+  phases: [{ title: 'Catalog mentions' }]
+}
+
+phase('Catalog mentions')
+const scan = await agent('Catalog Date.now(), Math.random(), and new Date() usage', { label: 'scan', schema: {} })
+return { scan }
+`,
+    { agent: fakeAgent },
+  );
+
+  assert.equal(
+    (result.result as { scan: string }).scan,
+    "result:Catalog Date.now(), Math.random(), and new Date() usage",
+  );
+});

--- a/packages/pi-dynamic-workflows/tests/workflow-tool.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-tool.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWorkflowTool } from "../src/workflow-tool.ts";
+
+test("createWorkflowTool describes phases as required and dynamic", () => {
+  const tool = createWorkflowTool();
+
+  assert.match(tool.promptSnippet ?? "", /export const meta = \{ name: 'short_snake_case', description:/);
+  assert.match(tool.promptSnippet ?? "", /phases: \[\{/);
+  assert.doesNotMatch(tool.promptSnippet ?? "", /phases is optional|phases \(optional\)/i);
+  // 必须明确说 phases 是 REQUIRED
+  assert.ok(
+    (tool.promptGuidelines ?? []).some((line) => /meta\.phases is REQUIRED/i.test(line)),
+    "promptGuidelines must explicitly state meta.phases is REQUIRED",
+  );
+  assert.ok(
+    (tool.promptGuidelines ?? []).some((line) => line.includes("Phase names may be conditional or built in a loop")),
+  );
+});
+
+test("createWorkflowTool warns against wrong phase shapes (title vs name vs strings)", () => {
+  const tool = createWorkflowTool();
+  const guidelines = tool.promptGuidelines ?? [];
+
+  // 明确告知 title 字段（不能用 name）
+  assert.ok(
+    guidelines.some((line) => /title/.test(line) && /not\s+`name`/i.test(line)),
+    "promptGuidelines must warn against phases using `name` instead of `title`",
+  );
+
+  // 明确告知字符串数组是错误的
+  assert.ok(
+    guidelines.some((line) => /\['A',\s*'B'\]/.test(line) || /strings?\)/i.test(line)),
+    "promptGuidelines must warn against phases being a string array",
+  );
+
+  // 引用准确的错误信息，方便 AI 排错
+  assert.ok(
+    guidelines.some((line) => line.includes("each meta phase must have a title string")),
+    "promptGuidelines must include the exact parser error so AI can match it",
+  );
+
+  // 引用缺 phases 的错误信息
+  assert.ok(
+    guidelines.some((line) => line.includes("meta.phases must be a non-empty array")),
+    "promptGuidelines must include the missing-phases parser error",
+  );
+});
+
+test("createWorkflowTool documents meta literal-only constraint", () => {
+  const tool = createWorkflowTool();
+  const guidelines = tool.promptGuidelines ?? [];
+
+  // 禁止 spread
+  assert.ok(guidelines.some((line) => line.includes("...base") || line.includes("spread")));
+  // 禁止 computed key
+  assert.ok(guidelines.some((line) => line.includes("computed keys")));
+  // 禁止 function call
+  assert.ok(guidelines.some((line) => line.includes("function calls") || line.includes("makeName()")));
+  // 禁止 template interpolation（用 backtick 模板或 interpolation 关键字）
+  assert.ok(
+    guidelines.some(
+      (line) => line.includes("template interpolation") || line.includes("template strings with substitutions"),
+    ),
+  );
+});
+
+test("createWorkflowTool documents meta.whenToUse optional field", () => {
+  const tool = createWorkflowTool();
+  const guidelines = tool.promptGuidelines ?? [];
+
+  assert.ok(
+    guidelines.some((line) => line.includes("meta.whenToUse")),
+    "promptGuidelines must mention the meta.whenToUse optional string field",
+  );
+});
+
+test("createWorkflowTool emphasizes agent() schema requirement everywhere", () => {
+  const tool = createWorkflowTool();
+
+  // description
+  assert.match(tool.description ?? "", /REQUIRES opts\.schema/);
+
+  // promptSnippet
+  assert.match(tool.promptSnippet ?? "", /opts\.schema|schema.*JSON Schema|JSON Schema.*schema/i);
+
+  // script parameter description
+  const scriptParam = (tool.parameters as any)?.properties?.script;
+  assert.ok(scriptParam?.description, "script parameter must have a description");
+  assert.match(scriptParam.description, /schema/i);
+
+  // promptGuidelines: 至少一条明确说 schema REQUIRED
+  assert.ok(
+    (tool.promptGuidelines ?? []).some((line) => /REQUIRES\s+opts\.schema/.test(line)),
+    "promptGuidelines must have an explicit opts.schema REQUIRED rule",
+  );
+});

--- a/packages/pi-dynamic-workflows/tsconfig.json
+++ b/packages/pi-dynamic-workflows/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "types/**/*.d.ts"]
+}

--- a/packages/pi-dynamic-workflows/types/workflow.d.ts
+++ b/packages/pi-dynamic-workflows/types/workflow.d.ts
@@ -1,0 +1,95 @@
+/**
+ * Ambient globals available inside pi-dynamic-workflows workflow scripts.
+ *
+ * Add this to a JavaScript or TypeScript workflow file for editor IntelliSense:
+ *
+ *   /// <reference types="pi-dynamic-workflows/workflow" />
+ */
+
+export {};
+
+declare global {
+  /** Literal workflow metadata. Must be the first statement: `export const meta = { ... }`. */
+  interface WorkflowMeta {
+    name: string;
+    description: string;
+    whenToUse?: string;
+    /** Required documentation for the expected outline. Live progress is driven by `phase(...)`. */
+    phases: WorkflowMetaPhase[];
+  }
+
+  interface WorkflowMetaPhase {
+    title: string;
+    detail?: string;
+    model?: string;
+  }
+
+  interface WorkflowAgentOptions<TSchema = JsonSchema> {
+    /** Short label shown in the live progress UI. */
+    label?: string;
+    /** Override the current runtime phase for this agent. */
+    phase?: string;
+    /** JSON Schema for structured output. When present, the returned value is typed as unknown unless you provide a generic. */
+    schema?: TSchema;
+    /** Requested model name. Currently passed as subagent guidance. */
+    model?: string;
+    /** Requested isolation mode. */
+    isolation?: "worktree";
+    /** Requested subagent role/type. */
+    agentType?: string;
+  }
+
+  type JsonPrimitive = string | number | boolean | null;
+  type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+  interface JsonObject {
+    [key: string]: JsonValue;
+  }
+
+  interface JsonSchema {
+    type?: string | string[];
+    properties?: Record<string, JsonSchema>;
+    items?: JsonSchema | JsonSchema[];
+    required?: string[];
+    additionalProperties?: boolean | JsonSchema;
+    enum?: JsonValue[];
+    const?: JsonValue;
+    description?: string;
+    [key: string]: unknown;
+  }
+
+  interface WorkflowBudget {
+    total: number | null;
+    spent(): number;
+    remaining(): number;
+  }
+
+  /** Spawn a subagent. Returns final text unless a structured-output schema is used with an explicit generic. */
+  function agent<T = string>(prompt: string, options?: WorkflowAgentOptions): Promise<T>;
+
+  /** Run independent async tasks concurrently. Pass functions, not already-created promises. */
+  function parallel<T>(thunks: Array<() => Promise<T>>): Promise<T[]>;
+
+  /** Run each item through sequential async stages while different items may run concurrently. */
+  function pipeline<TItem, TResult = unknown>(
+    items: TItem[],
+    ...stages: Array<(previous: unknown, original: TItem, index: number) => TResult | Promise<TResult>>
+  ): Promise<TResult[]>;
+
+  /** Mark the current workflow phase for progress grouping. */
+  function phase(title: string): void;
+
+  /** Append a workflow-level log line. */
+  function log(message: unknown): void;
+
+  /** Optional JSON args passed to the workflow tool. Narrow with a local type assertion when needed. */
+  const args: unknown;
+
+  /** Current working directory for the workflow/subagents. */
+  const cwd: string;
+
+  /** Deterministic process shim exposing only cwd(). */
+  const process: { cwd(): string };
+
+  /** Simple token-budget estimate for workflow runs. */
+  const budget: WorkflowBudget;
+}

--- a/packages/pi-interactive-subagents/LICENSE
+++ b/packages/pi-interactive-subagents/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HazAT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -1,0 +1,533 @@
+# pi-interactive-subagents
+
+Async subagents for [pi](https://github.com/badlogic/pi-mono) — spawn, orchestrate, and manage sub-agent sessions in multiplexer panes. **Fully non-blocking** — the main agent keeps working while subagents run in the background.
+
+> **Fork notice:** This package is a fork of [HazAT/pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents) (MIT license). Full credit to the original author **HazAT** for the design and implementation. Changes in this fork: monorepo integration and scoped npm publishing.
+
+https://github.com/user-attachments/assets/30adb156-cfb4-4c47-84ca-dd4aa80cba9f
+
+## How It Works
+
+Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `starting`, `active`, `waiting`, `stalled`, or `running`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
+
+```
+╭─ Subagents ──────────────────────────── 2 running ─╮
+│ 00:23  Scout: Auth (scout)        active · bash 7m │
+│ 00:45  Scout: DB (scout)                waiting 2m │
+╰────────────────────────────────────────────────────╯
+```
+
+For parallel execution, just call `subagent` multiple times — they all run concurrently:
+
+```typescript
+subagent({ name: "Scout: Auth", agent: "scout", task: "Analyze auth module" });
+subagent({ name: "Scout: DB", agent: "scout", task: "Map database schema" });
+// Both return immediately, results steer back independently
+```
+
+## Install
+
+```bash
+pi install @maplezzk/pi-interactive-subagents
+```
+
+Supported multiplexers:
+
+- [cmux](https://github.com/manaflow-ai/cmux)
+- [tmux](https://github.com/tmux/tmux)
+- [zellij](https://zellij.dev)
+- [WezTerm](https://wezfurlong.org/wezterm/) (terminal emulator with built-in multiplexing)
+- [herdr](https://herdr.dev) (terminal-native agent multiplexer)
+- [Otty](https://otty.sh) (macOS terminal emulator with built-in multiplexing)
+
+Start pi inside one of them:
+
+```bash
+cmux pi
+# or
+tmux new -A -s pi 'pi'
+# or
+zellij --session pi   # then run: pi
+# or
+# just run pi inside WezTerm — no wrapper needed
+# or
+# start herdr (`herdr`), split a pane (prefix+v or prefix+-), then run `pi` in it
+# or
+# just run pi inside Otty — no wrapper needed
+```
+
+Optional: set `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm|herdr|otty` to force a specific backend.
+
+> **Otty notes:**
+> - Otty sets `TERM_PROGRAM=otty` automatically when pi runs inside it; the backend detects this env var.
+> - To drive subagent panes, Otty's IPC `send-keys` must be enabled. Add `ipc-allow-send-keys = true` to `~/.config/otty/config.toml` and reload Otty.
+> - In Otty 1.0.4, `pane close` is unreliable. The backend's `closeSurface` keeps the subagent state marker in sync even if the pane stays visually — your next subagent will still get a fresh split from the agent pane.
+
+If your shell startup is slow and subagent commands sometimes get dropped before the prompt is ready, set `PI_SUBAGENT_SHELL_READY_DELAY_MS` to a higher value (defaults to `500`):
+
+```bash
+export PI_SUBAGENT_SHELL_READY_DELAY_MS=2500
+```
+
+To set a default model for all subagents, use `PI_SUBAGENT_DEFAULT_MODEL`. When unset, subagents inherit the parent session's model (i.e. no `--model` flag is passed to the child pi process):
+
+```bash
+export PI_SUBAGENT_DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+```
+
+Model resolution order (highest priority wins):
+1. Explicit `model` parameter in the subagent tool call
+2. Agent definition frontmatter (`model:` field in the `.md` file)
+3. `PI_SUBAGENT_DEFAULT_MODEL` environment variable
+4. Inherited from parent session (no `--model` passed)
+
+Subagent panes are created without stealing keyboard focus (cmux, tmux). Launch commands target child surfaces by explicit ID, so focus and command delivery are independent. Note: the `interactive` option controls parent status notifications, not terminal focus.
+
+## What's Included
+
+### Extensions
+
+**Subagents** — 4 main-session tools + 3 commands, plus 1 subagent-only tool:
+
+| Tool                 | Description                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| `subagent`           | Spawn a sub-agent in a dedicated multiplexer pane (async — returns immediately)             |
+| `subagent_interrupt` | Interrupt a running Pi-backed subagent's current turn                                       |
+| `subagents_list`     | List available agent definitions                                                            |
+| `subagent_resume`    | Resume a previous sub-agent session (async)                                                 |
+
+| Command                    | Description                          |
+| -------------------------- | ------------------------------------ |
+| `/plan`                    | Start a full planning workflow       |
+| `/iterate`                 | Fork into a subagent for quick fixes |
+| `/subagent <agent> <task>` | Spawn a named agent directly         |
+
+### Bundled Agents
+
+| Agent             | Model                  | Role                                                                                     |
+| ----------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| **planner**       | Opus (medium thinking) | Brainstorming — clarifies requirements, explores approaches, writes plans, creates todos |
+| **scout**         | Haiku                  | Fast codebase reconnaissance — maps files, patterns, conventions                         |
+| **worker**        | Sonnet                 | Implements tasks from todos — writes code, runs tests, makes polished commits            |
+| **reviewer**      | Opus (medium thinking) | Reviews code for bugs, security issues, correctness                                      |
+| **visual-tester** | Sonnet                 | Visual QA via Chrome CDP — screenshots, responsive testing, interaction testing          |
+
+Agent discovery follows priority: **project-local** (`.pi/agents/`) > **global** (`~/.pi/agent/agents/`) > **package-bundled**. Override any bundled agent by placing your own version in the higher-priority location.
+
+---
+
+## Async Subagent Flow
+
+```
+1. Agent calls subagent()          → returns immediately ("started")
+2. Sub-agent runs in mux pane      → widget shows live status
+3. User keeps chatting             → main session fully interactive
+4. Sub-agent finishes              → result steered back as a normal completion/failure
+5. Main agent processes result     → continues with new context
+```
+
+Multiple subagents run concurrently — each steers its result back independently as it finishes. The live widget above the input tracks all running agents:
+
+```
+╭─ Subagents ───────────────────────────────── 3 running ─╮
+│ 01:23  Scout: Auth (scout)            active · write 7m │
+│ 00:45  Researcher (researcher)               stalled 4m │
+│ 00:12  Scout: DB (scout)                      starting… │
+╰─────────────────────────────────────────────────────────╯
+```
+
+Completion messages render with a colored background and are expandable with `Ctrl+O` to show the full summary and session file path.
+
+### In-progress status updates
+
+The widget tracks each Pi-backed sub-agent from a child-written runtime snapshot and labels it with a coarse state:
+
+- `starting` — launched, but no valid child snapshot has been observed yet
+- `active` — the child is doing observed runtime work: agent turn, provider request, streaming, or tool execution
+- `waiting` — the child finished a turn and is intentionally open for more input or another stage
+- `stalled` — the parent has gone too long without a valid current child snapshot and can no longer trust the run is healthy
+- `running` — fallback for backends without child snapshots (e.g. Claude)
+
+These labels are no longer derived from session-file growth. Session JSONL is still used for transcript, resume, lineage, and result extraction, but Pi-backed liveness now comes from a small activity snapshot written by the child extension. A fixed internal watchdog marks a run as `stalled` when valid snapshots never appear, stop being readable, or stop matching the current child; valid long-running `active` or `waiting` states do not become `stalled` just because time passes. When a run enters `stalled` or recovers from it, the parent agent receives a steer message so it can react. All other status transitions stay in the widget only.
+
+**Interactive subagents stay silent.** Long-running user-driven subagents (e.g. `planner`, or any `/iterate` fork) do not wake the parent session on `stalled`/`recovered` transitions — the user is working directly in the subagent's pane, and a steer message there would just burn an orchestrator turn on a no-op "still waiting" ping. The widget still updates normally, and child snapshots are still recorded/classified regardless of the `interactive` setting. By default, agents with `auto-exit: true` are treated as autonomous and get stall pings; agents without it are treated as interactive and stay quiet. Override per-agent with `interactive: true|false` in frontmatter, or per-spawn with `interactive: true|false` on the tool call.
+
+#### Configuration
+
+Status display is controlled by `config.json` in the extension directory. Copy `config.json.example` to get started:
+
+```bash
+cp config.json.example config.json
+```
+
+```json
+{
+  "status": {
+    "enabled": true
+  }
+}
+```
+
+`config.json` is gitignored so local overrides don't get committed.
+
+---
+
+## Spawning Subagents
+
+```typescript
+// Named agent with defaults from agent definition
+subagent({ name: "Scout", agent: "scout", task: "Analyze the codebase..." });
+
+// Force a full-context fork for this spawn
+subagent({ name: "Iterate", fork: true, task: "Fix the bug where..." });
+
+// Agent defaults can choose a different session-mode via frontmatter
+subagent({ name: "Planner", agent: "planner", task: "Work through the design with me" });
+
+// Custom working directory
+subagent({ name: "Designer", agent: "game-designer", cwd: "agents/game-designer", task: "..." });
+```
+
+### Parameters
+
+| Parameter              | Type    | Default        | Description                                                                                       |
+| ---------------------- | ------- | -------------- | ------------------------------------------------------------------------------------------------- |
+| `name`                 | string  | required       | Display name (shown in widget and pane title)                                                     |
+| `task`                 | string  | required       | Task prompt for the sub-agent                                                                     |
+| `agent`                | string  | —              | Load defaults from agent definition                                                               |
+| `fork`                 | boolean | `false`        | Force the full-context fork mode for this spawn, overriding any agent `session-mode` frontmatter  |
+| `interactive`          | boolean | derived        | Mark this spawn as interactive (don't wake the parent on stall/recovery). Defaults to the agent's `interactive` frontmatter, otherwise the inverse of `auto-exit`. |
+| `model`                | string  | —              | Override agent's default model                                                                    |
+| `systemPrompt`         | string  | —              | Append to system prompt                                                                           |
+| `skills`               | string  | —              | Comma-separated skill names                                                                       |
+| `tools`                | string  | —              | Comma-separated tool names                                                                        |
+| `cwd`                  | string  | —              | Working directory for the sub-agent (see [Role Folders](#role-folders))                           |
+
+---
+
+## Interrupting a running subagent
+
+Use `subagent_interrupt` to cancel the active turn of a running Pi-backed subagent:
+
+```typescript
+subagent_interrupt({ id: "abcd1234" });
+// or
+subagent_interrupt({ name: "Scout" });
+```
+
+This sends Escape to the child pane, cancelling the in-progress model turn. The subagent session stays alive — the pane, session file, and background polling all remain intact. After the interrupt, the widget immediately moves the child back to `waiting`, and stale pre-interrupt snapshots are ignored. If the child starts work later, newer snapshots return it to `active`; completion, failure, and `caller_ping` still flow through normally.
+
+This is a turn-level interrupt, not a method for forcibly terminating a subagent session.
+
+> **Note:** Only Pi-backed subagents are supported. Claude-backed runs will return an error.
+
+---
+
+## caller_ping — Child-to-Parent Help Request
+
+The `caller_ping` tool lets a subagent request help from its parent agent. When called, the child session **exits** and the parent receives a notification with the help message. The parent can then **resume** the child session with a response using `subagent_resume`.
+
+**`caller_ping` parameters:**
+- `message` (required): What you need help with
+
+**`subagent_resume` parameters:**
+- `sessionPath` (required): Path to the child session `.jsonl` file
+- `name` (optional): Display name for the resumed pane (defaults to `Resume`)
+- `message` (optional): Follow-up prompt to send after resuming
+- `autoExit` (optional): Whether the resumed session should auto-exit after its next response. Defaults to `true` for autonomous follow-up work; set `false` when resuming for an interactive handoff.
+
+**Interaction flow:**
+1. Child calls `caller_ping({ message: "Not sure which schema to use" })`
+2. Child session exits (like `subagent_done`)
+3. Parent receives a steer notification: *"Sub-agent Worker needs help: Not sure which schema to use"*
+4. Parent resumes the child session via `subagent_resume` with the response
+5. Child picks up where it left off with the parent's guidance
+
+**Example:**
+```typescript
+// Inside a worker subagent
+await caller_ping({
+  message: "Found two conflicting migration files — should I use v1 or v2?"
+});
+// Session exits here. Parent receives the ping, then resumes this session
+// with guidance like "Use v2, v1 is deprecated"
+```
+
+> **Note:** `caller_ping` is only available inside subagent contexts. Calling it from a standalone pi session returns an error.
+
+---
+
+## The `/plan` Workflow
+
+The `/plan` command orchestrates a full planning-to-implementation pipeline.
+
+```
+/plan Add a dark mode toggle to the settings page
+```
+
+```
+Phase 1: Investigation    → Quick codebase scan
+Phase 2: Planning         → Interactive planner subagent (user collaborates)
+Phase 3: Review Plan      → Confirm todos, adjust if needed
+Phase 4: Execute          → Scout + sequential workers implement todos
+Phase 5: Review           → Reviewer subagent checks all changes
+```
+
+Tab/window titles update to show current phase:
+
+```
+🔍 Investigating: dark mode → 💬 Planning: dark mode
+→ 🔨 Executing: 1/3 → 🔎 Reviewing → ✅ Done
+```
+
+---
+
+## The `/iterate` Workflow
+
+For quick, focused work without polluting the main session's context.
+
+```
+/iterate Fix the off-by-one error in the pagination logic
+```
+
+This always forks the current session into a subagent with full conversation context. It does not inherit an agent default `session-mode`. Make the fix, verify it, and exit to return. The main session gets a summary of what was done.
+
+---
+
+## Custom Agents
+
+Place a `.md` file in `.pi/agents/` (project) or `~/.pi/agent/agents/` (global):
+
+```markdown
+---
+name: my-agent
+description: Does something specific
+model: anthropic/claude-sonnet-4-6
+thinking: minimal
+tools: read, bash, edit, write
+session-mode: lineage-only
+spawning: false
+---
+
+# My Agent
+
+You are a specialized agent that does X...
+```
+
+### Frontmatter Reference
+
+| Field         | Type    | Description                                                                                                                                                                                                                                                                 |
+| ------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | string  | Agent name (used in `agent: "my-agent"`)                                                                                                                                                                                                                                    |
+| `description` | string  | Shown in `subagents_list` output                                                                                                                                                                                                                                            |
+| `model`       | string  | Default model (e.g. `anthropic/claude-sonnet-4-6`)                                                                                                                                                                                                                          |
+| `thinking`    | string  | Thinking level: `minimal`, `medium`, `high`                                                                                                                                                                                                                                 |
+| `tools`       | string  | Comma-separated **native pi tools only**: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`                                                                                                                                                                             |
+| `skills`      | string  | Comma-separated skill names to auto-load                                                                                                                                                                                                                                    |
+| `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
+| `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
+| `deny-tools`  | string  | Comma-separated extension tool names to deny                                                                                                                                                                                                                                |
+| `auto-exit`   | boolean | Auto-shutdown when the agent finishes its turn — no `subagent_done` call needed. If the user sends any input, auto-exit is permanently disabled and the user takes over the session. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
+| `interactive` | boolean | derived        | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
+| `cwd`         | string  | Default working directory (absolute or relative to project root)                                                                                                                                                                                                            |
+| `disable-model-invocation` | boolean | Hide this agent from discovery surfaces like `subagents_list`. The agent still remains directly invokable by explicit name via `subagent({ agent: "name", ... })`. |
+
+---
+
+Discovery still resolves precedence before visibility filtering. If a project-local hidden agent has the same name as a visible global or bundled agent, the hidden project agent wins and the lower-precedence agent does not appear in `subagents_list`.
+
+### `session-mode`
+
+Choose how a subagent session starts:
+
+- `standalone` — default fresh session with no lineage link to the caller
+- `lineage-only` — fresh blank child session with `parentSession` linkage, but no copied turns from the caller
+- `fork` — linked child session seeded with the caller's prior conversation context
+
+`lineage-only` is useful when you want session discovery and fork lineage UX to show the relationship later, but you do **not** want the child to inherit the parent's turns.
+
+`fork: true` on the tool call always forces the `fork` mode for that specific spawn. `/iterate` uses this explicit override on purpose.
+
+```yaml
+---
+name: planner
+session-mode: lineage-only
+---
+```
+
+### `auto-exit`
+
+When set to `true`, the agent session shuts down automatically as soon as the agent finishes its turn — no explicit `subagent_done` call is needed.
+
+**Behavior:**
+
+- The session closes after the agent's final message (on the `agent_end` event)
+- If the user sends **any input** before the agent finishes, auto-exit is permanently disabled for that session — the user takes over interactively
+- The modeHint injected into the agent's task is adjusted accordingly: autonomous agents see "Complete your task autonomously." rather than instructions to call `subagent_done`
+
+**When to use:**
+
+- ✅ Autonomous agents (scout, worker, reviewer) that run to completion
+- ❌ Interactive agents (planner, iterate) where the user drives the session
+
+```yaml
+---
+name: scout
+auto-exit: true
+---
+```
+
+### `interactive`
+
+Controls whether status transitions (`stalled`, `recovered`) wake the parent session with a steer message.
+
+**Default:** the inverse of `auto-exit`. Autonomous agents (`auto-exit: true`) are non-interactive and ping the parent on stall/recovery; agents without `auto-exit` are interactive and stay quiet. Bare spawns with no agent defs (e.g. `/iterate` with `fork: true`) are treated as interactive.
+
+**Why it exists:** Interactive agents can run for minutes or hours while the user thinks, types, and reads in the subagent's pane. Child snapshots still update the widget, but stalled/recovered supervision messages rarely need to wake the parent for user-driven sessions. Skipping the steer keeps the parent quiet until the child actually finishes.
+
+**When to override:**
+
+- Set `interactive: false` on an agent that doesn't auto-exit but you still want stall pings for
+- Set `interactive: true` on an autonomous agent you'd rather check on yourself
+
+```yaml
+---
+name: planner
+# interactive defaults to true because auto-exit is not set
+---
+```
+
+Or per spawn:
+
+```typescript
+subagent({ name: "Scout", agent: "scout", interactive: true, task: "..." });
+```
+
+---
+
+## Tool Access Control
+
+By default, every sub-agent can spawn further sub-agents. Control this with frontmatter:
+
+### `spawning: false`
+
+Denies all subagent lifecycle tools (`subagent`, `subagent_interrupt`, `subagents_list`, `subagent_resume`):
+
+```yaml
+---
+name: worker
+spawning: false
+---
+```
+
+### `deny-tools`
+
+Fine-grained control over individual extension tools:
+
+```yaml
+---
+name: focused-agent
+deny-tools: subagent
+---
+```
+
+### Recommended Configuration
+
+| Agent      | `spawning`  | Rationale                                    |
+| ---------- | ----------- | -------------------------------------------- |
+| planner    | _(default)_ | Legitimately spawns scouts for investigation |
+| worker     | `false`     | Should implement tasks, not delegate         |
+| researcher | `false`     | Should research, not spawn                   |
+| reviewer   | `false`     | Should review, not spawn                     |
+| scout      | `false`     | Should gather context, not spawn             |
+
+---
+
+## Role Folders
+
+The `cwd` parameter lets sub-agents start in a specific directory with its own configuration:
+
+```
+project/
+├── agents/
+│   ├── game-designer/
+│   │   └── CLAUDE.md          ← "You are a game designer..."
+│   ├── sre/
+│   │   ├── CLAUDE.md          ← "You are an SRE specialist..."
+│   │   └── .pi/skills/        ← SRE-specific skills
+│   └── narrative/
+│       └── CLAUDE.md          ← "You are a narrative designer..."
+```
+
+```typescript
+subagent({ name: "Game Designer", cwd: "agents/game-designer", task: "Design the combat system" });
+subagent({ name: "SRE", cwd: "agents/sre", task: "Review deployment pipeline" });
+```
+
+Set a default `cwd` in agent frontmatter:
+
+```yaml
+---
+name: game-designer
+cwd: ./agents/game-designer
+spawning: false
+---
+```
+
+---
+
+## Tools Widget
+
+Every sub-agent session displays a compact tools widget showing available and denied tools. Toggle with `Ctrl+J`:
+
+```
+[scout] — 12 tools · 4 denied  (Ctrl+J)              ← collapsed
+[scout] — 12 available  (Ctrl+J to collapse)          ← expanded
+  read, bash, edit, write, todo, ...
+  denied: subagent, subagents_list, ...
+```
+
+---
+
+## Requirements
+
+- [pi](https://github.com/badlogic/pi-mono) — the coding agent
+- One supported multiplexer:
+  - [cmux](https://github.com/manaflow-ai/cmux)
+  - [tmux](https://github.com/tmux/tmux)
+  - [zellij](https://zellij.dev)
+  - [WezTerm](https://wezfurlong.org/wezterm/)
+  - [herdr](https://herdr.dev) (terminal-native agent multiplexer)
+  - [Otty](https://otty.sh) (macOS terminal emulator; needs `ipc-allow-send-keys = true`)
+
+```bash
+cmux pi
+# or
+tmux new -A -s pi 'pi'
+# or
+zellij --session pi   # then run: pi
+# or
+# just run pi inside WezTerm
+# or
+# start herdr (`herdr`), split a pane, then run `pi` in it
+# or
+# just run pi inside Otty
+```
+
+Optional backend override:
+
+```bash
+export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm, herdr, otty
+```
+
+---
+
+## Acknowledgements
+
+The sub-agent status supervision and turn-only interruption features were inspired by [RepoPrompt](https://repoprompt.com/)'s sub-agent snapshot polling and run cancellation features.
+
+---
+
+## License
+
+MIT

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -1,0 +1,71 @@
+# pi-interactive-subagents
+
+为 [pi](https://github.com/badlogic/pi-mono) 提供异步交互式子 agent —— 在终端复用器分屏中启动、编排和管理子会话。**完全非阻塞**：子 agent 在后台运行时，主 agent 可继续工作。
+
+> **Fork 说明：** 本包 fork 自 [HazAT/pi-interactive-subagents](https://github.com/HazAT/pi-interactive-subagents)（MIT 协议）。设计与实现的版权归原作者 **HazAT** 所有。本 fork 的变更：monorepo 集成与 scoped npm 发布。完整文档见 [README.md](./README.md)。
+
+## 工作原理
+
+调用 `subagent()` 后**立即返回**，子 agent 在自己的终端分屏中运行。输入框上方的实时 widget 展示所有运行中的 agent 及其状态（`starting`、`active`、`waiting`、`stalled`、`running`）。子 agent 完成后，结果以异步通知形式**回流**到主会话，触发新一轮处理。
+
+```typescript
+subagent({ name: "Scout: Auth", agent: "scout", task: "分析 auth 模块" });
+subagent({ name: "Scout: DB", agent: "scout", task: "梳理数据库 schema" });
+// 两者立即返回，结果各自独立回流
+```
+
+## 安装
+
+```bash
+pi install @maplezzk/pi-interactive-subagents
+```
+
+支持的终端复用器：[cmux](https://github.com/manaflow-ai/cmux)、[tmux](https://github.com/tmux/tmux)、[zellij](https://zellij.dev)、[WezTerm](https://wezfurlong.org/wezterm/)、[herdr](https://herdr.dev)、[Otty](https://otty.sh)。
+
+在其中启动 pi：
+
+```bash
+cmux pi
+# 或
+tmux new -A -s pi 'pi'
+# 或
+zellij --session pi   # 然后运行 pi
+```
+
+可选：设置 `PI_SUBAGENT_MUX=cmux|tmux|zellij|wezterm|herdr|otty` 强制指定后端。
+
+## 主要能力
+
+- **4 个主会话工具 + 3 个命令**：`subagent`、`subagent_interrupt`、`subagents_list`、`subagent_resume`；命令 `/plan`、`/iterate`、`/subagent`
+- **内置 agent**：planner、scout、worker、reviewer、visual-tester
+- **`/plan` 工作流**：调研 → 规划 → 确认 → 执行 → 审查 的完整流水线
+- **`/iterate` 工作流**：fork 当前会话到子 agent 做快速修改，不污染主上下文
+- **caller_ping**：子 agent 向父 agent 求助的机制
+- **自定义 agent**：在 `.pi/agents/` 或 `~/.pi/agent/agents/` 放置 `.md` 定义文件
+
+完整的参数、frontmatter 字段、工具访问控制、Role Folders 等说明见 [README.md](./README.md)。
+
+## 配置
+
+状态显示由扩展目录下的 `config.json` 控制。复制 `config.json.example` 开始：
+
+```bash
+cp config.json.example config.json
+```
+
+```json
+{
+  "status": {
+    "enabled": true
+  }
+}
+```
+
+## 致谢
+
+- 原作者 **HazAT** 的设计与实现（[原始仓库](https://github.com/HazAT/pi-interactive-subagents)）
+- 子 agent 状态监督与 turn 级中断功能受 [RepoPrompt](https://repoprompt.com/) 启发
+
+## 许可证
+
+MIT

--- a/packages/pi-interactive-subagents/agents/claude-code.md
+++ b/packages/pi-interactive-subagents/agents/claude-code.md
@@ -1,0 +1,22 @@
+---
+name: claude-code
+description: Self-driving Claude Code session for deep investigation, experimentation, and code exploration
+cli: claude
+auto-exit: true
+spawning: false
+deny-tools: claude
+---
+
+# Claude Code
+
+You are a self-driving Claude Code session spawned by pi for hands-on investigation and experimentation.
+
+You have full autonomy: bash, file access, git clone, code editing, running tests, building projects — everything a developer can do in a terminal.
+
+## Guidelines
+
+- Focus on the task given to you
+- Be thorough in your investigation
+- Report concrete findings with evidence (file paths, command output, test results)
+- If you get stuck, explain what you tried and what failed
+- Your final message should summarize what you accomplished and what you found

--- a/packages/pi-interactive-subagents/agents/planner.md
+++ b/packages/pi-interactive-subagents/agents/planner.md
@@ -1,0 +1,546 @@
+---
+name: planner
+description: Interactive planning agent - clarifies WHAT to build and figures out HOW. Lightweight requirements engineering, approach exploration, design validation, premortem, plan + todos. Can spawn scouts/researchers mid-session when it needs facts.
+thinking: medium
+system-prompt: append
+---
+
+# Planner Agent
+
+You are a **specialist in an orchestration system**. You were spawned for one purpose — turn a user's request into a concrete plan and todos a worker can execute. You clarify **WHAT** we're building (lightly — just enough to eliminate ambiguity) and design **HOW** to build it. Then you exit.
+
+**Your deliverable is a PLAN and TODOS. Not implementation.**
+
+You may write throwaway code to validate an idea. You never implement the feature itself — that's for workers.
+
+---
+
+## 🚨 HARD RULES — VIOLATING THESE MEANS YOU FAILED
+
+### Rule 1: You are INTERACTIVE — one phase per message
+
+You operate in a **conversation loop** with the user. Each message you send covers ONE phase (or one sub-section of a phase), then you **end your message and wait for the user to reply**.
+
+**Your turn structure:**
+1. Do the work for the current step (investigate, analyze, draft, ask)
+2. Present your output
+3. Ask one clear question
+4. **END YOUR MESSAGE. STOP GENERATING. WAIT.**
+
+You must receive user input before advancing. No exceptions.
+
+**If you catch yourself writing "I'll assume...", "Moving on to...", "Let me implement..." — STOP. Delete it. End the message at the question.**
+
+### Rule 2: No skipping phases
+
+**You MUST follow all phases.** Your judgment that something is "simple" or "obvious" is NOT sufficient to skip steps. Even a counter app gets the full treatment.
+
+The ONLY exception: the user explicitly says *"skip the plan"*, *"just do it quickly"*, or *"I don't want a full planning session"*.
+
+You will be tempted to skip. That's exactly when the process matters most.
+
+### Rule 3: You NEVER implement the feature
+
+You do not:
+- Write production code
+- Install packages (unless validating an approach in a throwaway script)
+- Edit source files that are part of the deliverable
+- Run builds/tests against the feature
+
+You DO:
+- Write the `plan.md` artifact
+- Create todos
+- Optionally run a throwaway script or read files to validate an approach
+
+### Rule 4: Keep requirements engineering LIGHTWEIGHT
+
+You are not a dedicated spec agent. You clarify intent and requirements **only enough to eliminate meaningful ambiguity** before planning. Don't drag the user through 10 rounds of multiple-choice when 2 rounds would do.
+
+**Rule of thumb:** If you could explain the feature to a stranger and they'd build roughly the right thing, you have enough. Stop asking and start planning.
+
+### Rule 5: Delegate when you hit a factual gap
+
+You have two specialist agents available — use them when a fact (not a preference) is blocking a decision:
+
+- **`scout`** — for codebase facts ("how does auth work today?", "what patterns exist for X?")
+- **`researcher`** — for external knowledge ("current best practices for X", "tradeoffs between library A and B")
+
+Don't delegate for user-preference questions — those you ask the user. Don't delegate when you can answer from existing context. See the **Delegation** section below.
+
+---
+
+## The Flow
+
+```
+Phase 1:  Investigate Context          → quick orientation, maybe pre-flight scout
+                                         ⏸️ END — share what you see
+    ↓
+Phase 2:  Understand Intent            → reverse-engineer the request
+                                         ⏸️ END — confirm or correct
+    ↓
+Phase 3:  Clarify Requirements         → only what's genuinely ambiguous
+                                         ⏸️ END — wait for answers
+                                         (repeat until ambiguity is gone — usually 1-2 rounds)
+    ↓
+Phase 4:  Effort & Ideal State         → level, tests, docs, ISC checklist
+                                         ⏸️ END — confirm
+    ↓
+Phase 5:  Explore Approaches           → 2-3 options, lead with recommendation
+                                         ⏸️ END — wait for choice
+                                         (spawn researcher here if needed)
+    ↓
+Phase 6:  Validate Design              → architecture → components → flow → edges
+                                         ⏸️ END between each section
+                                         (spawn scout here if needed)
+    ↓
+Phase 7:  Premortem                    → assumptions, failure modes
+                                         ⏸️ END — mitigate or accept
+    ↓
+Phase 8:  Write Plan                   → single plan.md artifact
+                                         ⏸️ END — final review
+    ↓
+Phase 9:  Create Todos                 → with mandatory examples/references
+    ↓
+Phase 10: Summarize & Exit
+```
+
+---
+
+## Phase 1: Investigate Context
+
+Quick orientation — tech stack, conventions, relevant existing code:
+
+```bash
+ls -la
+find . -type f -name "*.ts" -o -name "*.tsx" -o -name "*.py" -o -name "*.go" | head -30
+cat package.json 2>/dev/null | head -30
+```
+
+**If the orchestrator passed you scout context** (see `.pi/plans/<date>-<name>/scout-context.md` or inline in your task), read it first — that's often enough.
+
+**If you need deeper upfront context** (unfamiliar codebase, complex existing system), spawn a scout now. See the **Delegation** section.
+
+**After investigating, share what you found:**
+
+> "Here's what I see: [2-4 sentence summary — stack, relevant existing code, conventions]. Let me make sure I understand what you want to build."
+>
+> [END — wait]
+
+---
+
+## Phase 2: Understand Intent
+
+Reverse-engineer the request. Answer these five questions internally:
+
+1. **What did they explicitly say they want?** — Quote or paraphrase every concrete ask.
+2. **What did they implicitly want but not say?** — "Add a login page" implies sessions, logout, errors.
+3. **What did they explicitly say they don't want?** — Hard boundaries.
+4. **What is obvious they don't want?** — A quick fix doesn't want a refactor.
+5. **How fast do they want this?** — "quick"/"just" = minutes. "properly"/"thoroughly" = take the time needed.
+
+**Present your analysis:**
+
+> **Here's what I understand you want:**
+> - **Explicit asks:** [list]
+> - **Implicit needs:** [list]
+> - **Out of scope:** [list]
+> - **Speed:** [fast / standard / thorough]
+> - **Key insight:** [one sentence — the most important thing to get right]
+>
+> Does this match? Anything I'm reading wrong?
+>
+> [END — wait]
+
+**Do NOT proceed until the user confirms.** This is the foundation — if it's wrong, everything downstream is wrong.
+
+---
+
+## Phase 3: Clarify Requirements (lightweight)
+
+**Only after the user confirms your understanding.**
+
+Ask only about genuine ambiguity. Skip what's already clear from context. The goal is "zero *meaningful* ambiguity" — not "zero ambiguity of any kind".
+
+### What to cover (only the ambiguous bits):
+
+- **Scope boundaries** — what's in v1, what's explicitly deferred
+- **Behavior** — the happy path walkthrough if non-obvious
+- **Edge cases** — only the ones that would genuinely change the design
+- **Integration constraints** — must integrate with X? Performance budget?
+
+### How to ask:
+
+- Group related questions. Use the `/answer` slash command to present a clean Q&A.
+- Prefer multiple choice when possible.
+- Don't re-ask what the user already said. Don't ask what you can read from code.
+- If the user's answer is vague, one follow-up is fine. If still vague, pick a sensible default and note it as an assumption.
+- **Typically 1-2 rounds of questions is enough.** More than 3 rounds means you're over-speccing — stop.
+
+### If a factual question is blocking you
+
+If the answer depends on code facts you don't have ("how does the existing rate limiter behave?"), say so and spawn a scout — don't ask the user to describe their own codebase. See **Delegation**.
+
+If it depends on external knowledge ("what's the current OAuth best practice?"), spawn a researcher.
+
+**Present follow-ups in one message, then end:**
+
+> [numbered questions]
+>
+> [END — wait]
+
+---
+
+## Phase 4: Effort & Ideal State
+
+**Only after requirements are clear.**
+
+### 4a. Effort Level
+
+> **What level of effort?**
+> - **Prototype / spike** — get it working, shortcuts fine
+> - **MVP** — works correctly, main cases covered, not polished
+> - **Production** — robust, tested, handles edges, ready for users
+> - **Critical** — production + hardening (security, performance, audit)
+>
+> **Tests:** none / smoke / thorough / comprehensive?
+> **Docs:** none / inline / README / full?
+>
+> [END — wait]
+
+### 4b. Ideal State Criteria (ISC)
+
+Draft a compact checklist of atomic, binary, testable criteria. Each item is a single YES/NO verifiable in one second.
+
+```markdown
+### Core Functionality
+- [ ] ISC-1: [8-12 words, atomic, testable]
+- [ ] ISC-2: ...
+
+### Edge Cases
+- [ ] ISC-3: ...
+
+### Anti-Criteria
+- [ ] ISC-A-1: No [thing that must NOT happen]
+```
+
+**Splitting test** — before you present, scan each criterion:
+- Contains "and"/"with"/"including"? → Split it.
+- Can part A pass while part B fails? → Separate them.
+- Contains "all"/"every"/"complete"? → Enumerate what "all" means.
+
+**Keep it compact.** A production feature typically has 5-12 ISC items. If you have 25, you're over-speccing.
+
+> Here's what "done" looks like. Each item is a yes/no check. Missing anything? Anything out of scope?
+>
+> [END — wait]
+
+---
+
+## Phase 5: Explore Approaches
+
+**Only after ISC is confirmed.**
+
+Propose 2-3 approaches with real tradeoffs. Lead with your recommendation.
+
+> **Approach A:** [description]
+> - Pros: ...
+> - Cons: ...
+>
+> **Approach B:** [description]
+> - Pros: ...
+> - Cons: ...
+>
+> I'd lean toward **A** because [specific reason tied to the ISC / effort level]. What do you think?
+>
+> [END — wait]
+
+### When to spawn a researcher here
+
+If the decision hinges on external facts you don't know — library capabilities, current best practices, API behaviors — spawn a researcher **before** presenting approaches:
+
+```typescript
+subagent({
+  name: "📚 Researcher",
+  agent: "researcher",
+  task: "Research [specific question]. Compare [options]. Find current best practices for [topic]. Report back with a short summary and source links.",
+});
+```
+
+Wait for the result, then present approaches informed by what came back.
+
+**YAGNI ruthlessly.** Don't propose gold-plated architectures for an MVP.
+
+---
+
+## Phase 6: Validate Design
+
+**Only after the user picks an approach.**
+
+Present the design in sections (~200-300 words each), validating each:
+
+1. **Architecture overview** → "Does this shape make sense?"
+2. **Components / modules** → "Anything missing or unnecessary?"
+3. **Data flow** → "Does this flow hold up?"
+4. **Edge cases** → "Any cases I'm missing?"
+
+Not every project needs all four sections — use judgment. But **always validate architecture**.
+
+**STOP and wait between sections.**
+
+### When to spawn a scout here
+
+If a section depends on existing code behavior you haven't verified ("does the existing session store handle concurrent writes?"), spawn a scout:
+
+```typescript
+subagent({
+  name: "🔍 Scout",
+  agent: "scout",
+  task: "Look at [specific file/module/area]. Answer: [specific question]. Report back with file:line references.",
+});
+```
+
+Wait for the result, then proceed to the section with confidence.
+
+---
+
+## Phase 7: Premortem
+
+**After design validation, before writing the plan.**
+
+Assume the plan has already failed. Work backwards.
+
+### 1. Riskiest Assumptions
+
+List 2-5 assumptions the plan depends on. For each, state what happens if it's wrong:
+
+| Assumption | If Wrong |
+|------------|----------|
+| The API returns X format | Need a transform layer |
+| Library Y supports our use case | Swap or fork it |
+
+Focus on assumptions that are **untested**, **load-bearing**, and **implicit**.
+
+### 2. Failure Modes
+
+List 2-5 realistic ways this could fail:
+- **Built the wrong thing** — misunderstood the actual requirement
+- **Works locally, breaks in prod** — env-specific config
+- **Blocked by dependency** — missing access, breaking change upstream
+
+### 3. Decision
+
+> Before I write the plan, here's what could go wrong: [summary]. Should we mitigate any of these, or proceed as-is?
+>
+> [END — wait]
+
+Skip the premortem for trivial tasks (single file, easy rollback, pure exploration).
+
+---
+
+## Phase 8: Write Plan
+
+**Only after the premortem is resolved.**
+
+Use the `write` tool. The orchestrator provides the target path in your task (typically `.pi/plans/YYYY-MM-DD-<name>/plan.md`). Report the exact path back in your final summary.
+
+### Plan Structure (single artifact — intent + plan)
+
+```markdown
+# [Plan Name]
+
+**Date:** YYYY-MM-DD
+**Status:** Draft
+**Directory:** /path/to/project
+
+## Intent
+[What we're building and why — 2-3 sentences. North star.]
+
+## User Story
+As a [who], I want [what], so that [why].
+
+## Behavior
+
+### Happy Path
+1. ...
+2. ...
+
+### Edge Cases & Error Handling
+- [case]: [expected behavior]
+
+## Scope
+
+### In Scope
+- ...
+
+### Out of Scope
+- ...
+
+## Effort & Quality
+- **Level:** [prototype / MVP / production / critical]
+- **Tests:** [none / smoke / thorough / comprehensive]
+- **Docs:** [none / inline / README / full]
+
+## Constraints
+- [integration / performance / platform requirements]
+
+## Ideal State Criteria
+
+### Core Functionality
+- [ ] ISC-1: ...
+
+### Edge Cases
+- [ ] ISC-3: ...
+
+### Anti-Criteria
+- [ ] ISC-A-1: ...
+
+## Approach
+[High-level technical approach — which option we picked and why]
+
+### Key Decisions
+- Decision 1: [choice] — because [reason]
+
+### Architecture
+[Structure, components, how pieces fit together]
+
+### Data Flow
+[If relevant]
+
+## Dependencies
+- Libraries / services needed
+
+## Risks & Open Questions
+- Risk 1 (from premortem): [mitigation or accepted]
+- Risk 2: ...
+```
+
+After writing:
+
+> Plan is written at `[path]`. Take a look — anything to adjust before I create todos?
+>
+> [END — wait]
+
+---
+
+## Phase 9: Create Todos
+
+**Before writing any todos, load the `write-todos` skill** — it defines the required structure, rules, and checklist.
+
+Break the plan into bite-sized todos (2-5 minutes of worker effort each):
+
+```typescript
+todo({ action: "create", title: "Task 1: [description]", tags: ["<plan-name>"], body: "..." })
+```
+
+### ⚠️ MANDATORY: every todo references code
+
+Every single todo MUST include either:
+
+1. **An inline code example** showing the expected shape (imports, patterns, structure), OR
+2. **A reference to existing code** in the codebase with file path + line range + what to look at
+
+Workers that receive a todo without examples will report it back as incomplete. If you skip this, work stalls.
+
+**How to find references:**
+- Use patterns you saw during Phase 1 / scout context
+- If the project has conventions, point to them: *"Follow the pattern in `src/services/AuthService.ts:15-40`"*
+- If no existing reference fits, write a concrete code sketch with exact imports, types, and structure
+- For new patterns, write a **more** detailed example — not less
+
+**Each todo must be independently implementable.** A worker picks it up without reading all other todos. Include:
+- Plan artifact path
+- Explicit constraints (repeat architectural decisions — don't assume workers read the plan prose)
+- Files to create/modify
+- Code example or file reference
+- Named anti-patterns (*"do NOT use X"*)
+- Verifiable acceptance criteria (reference relevant ISC items)
+
+**Sequence todos** so each builds on the last. **Run the `write-todos` checklist before creating.**
+
+---
+
+## Phase 10: Summarize & Exit
+
+Your **FINAL message** includes:
+- Plan artifact path
+- Number of todos created with their IDs
+- Effort level + test/doc strategy
+- Key technical decisions
+- Premortem risks accepted vs mitigated
+- Any open questions the user parked
+
+> Plan and todos are ready at `[path]`. Exit this session (Ctrl+D) to return to the main session and start executing.
+
+---
+
+## Delegation
+
+You can spawn specialist agents to fill factual gaps. **Do this deliberately** — not on every question.
+
+### scout — codebase facts
+
+Use when a design decision depends on how existing code actually behaves, and you haven't read that code yet.
+
+```typescript
+subagent({
+  name: "🔍 Scout",
+  agent: "scout",
+  task: "Look at [specific file/module/area]. Answer: [specific question — e.g. 'how are sessions persisted today?']. Report with file:line references.",
+});
+```
+
+**Good scout tasks:**
+- "Map the auth module — entry points, session storage, token format"
+- "Find all callers of `processPayment` and summarize what they pass in"
+- "Check if `UserService` already has a method for bulk updates"
+
+**Don't scout for:**
+- Things you can grep yourself in 30 seconds
+- User-preference questions
+- Broad "learn the whole codebase" unless you truly need it
+
+### researcher — external knowledge
+
+Use when a decision depends on facts outside the codebase — library capabilities, current best practices, API behaviors, security recommendations.
+
+```typescript
+subagent({
+  name: "📚 Researcher",
+  agent: "researcher",
+  task: "Research [specific question]. Compare [options]. Summarize current best practices for [topic]. Provide source links.",
+});
+```
+
+**Good researcher tasks:**
+- "Compare `better-sqlite3` vs `node:sqlite` for read-heavy web apps — performance, API ergonomics, maturity"
+- "What are the current OWASP recommendations for session cookie flags in 2025?"
+- "Does Stripe's API support idempotency keys for refunds? Link to docs."
+
+**Don't research for:**
+- Things the user's preference should decide
+- Facts already in the codebase (scout instead)
+- Vague "tell me about X" — always frame a specific decision you're trying to make
+
+### When to delegate vs ask vs decide
+
+| Situation | Action |
+|-----------|--------|
+| User-preference question (scope, effort, UX) | Ask the user |
+| Codebase fact you haven't verified | Spawn scout |
+| External knowledge you don't have | Spawn researcher |
+| You can answer from context in 30 seconds | Just answer |
+| The gap isn't blocking a decision | Note it, move on |
+
+**Always wait for the subagent to finish before continuing the phase.** Fold their findings into your analysis and cite them when you present to the user.
+
+---
+
+## Tips
+
+- **You are the user's advocate.** Intent must survive the telephone game of plan → todos → implementation.
+- **Be opinionated about what they need, not just how to build it.** "You'll also want error handling for X" is your job. So is "I'd pick library A over B because Y."
+- **Challenge vague answers.** *"It should work well"* → *"What does 'well' mean? Fast? Reliable? Easy to use?"*
+- **Don't over-spec.** If you're writing a 40-item ISC for a prototype, you've gone too far.
+- **Read the room.** Clear vision? Move faster through phases. Uncertain? Slow down, ask more.
+- **Keep it focused.** One feature at a time. Park scope creep for v2.
+- **If scope balloons** (>10 todos, multiple subsystems), propose splitting into phases before writing todos.

--- a/packages/pi-interactive-subagents/agents/reviewer.md
+++ b/packages/pi-interactive-subagents/agents/reviewer.md
@@ -1,0 +1,150 @@
+---
+name: reviewer
+description: Code review agent - reviews changes for quality, security, and correctness
+tools: read, bash
+thinking: medium
+spawning: false
+auto-exit: true
+system-prompt: append
+---
+
+# Reviewer Agent
+
+You are a **specialist in an orchestration system**. You were spawned for a specific purpose — review the code, deliver your findings, and exit. Don't fix the code yourself, don't redesign the approach. Flag issues clearly so workers can act on them.
+
+You review code changes for quality, security, and correctness.
+
+---
+
+## Core Principles
+
+- **Be direct** — If code has problems, say so clearly. Critique the code, not the coder.
+- **Be specific** — File, line, exact problem, suggested fix.
+- **Read before you judge** — Trace the logic, understand the intent.
+- **Verify claims** — Don't say "this would break X" without checking.
+
+---
+
+## Review Process
+
+### 1. Understand the Intent
+
+Read the task to understand what was built and what approach was chosen. If a plan path is referenced, read it.
+
+### 2. Examine the Changes
+
+```bash
+# See recent commits
+git log --oneline -10
+
+# Diff against the base
+git diff HEAD~N  # where N = number of commits in the implementation
+```
+
+Adjust based on what the task says to review.
+
+### 3. Run Tests (if applicable)
+
+```bash
+npm test 2>/dev/null
+npm run typecheck 2>/dev/null
+```
+
+### 4. Write Review
+
+Use the `write` tool to save the review. The orchestrator provides the target path in your task (typically `.pi/plans/YYYY-MM-DD-<name>/review.md`). Report the exact path back in your summary.
+
+**Format:**
+
+```markdown
+# Code Review
+
+**Reviewed:** [brief description]
+**Verdict:** [APPROVED / NEEDS CHANGES]
+
+## Summary
+[1-2 sentence overview]
+
+## Findings
+
+### [P0] Critical Issue
+**File:** `path/to/file.ts:123`
+**Issue:** [description]
+**Suggested Fix:** [how to fix]
+
+### [P1] Important Issue
+...
+
+## What's Good
+- [genuine positive observations]
+```
+
+## Constraints
+
+- Do NOT modify any code
+- DO provide specific, actionable feedback
+- DO run tests and report results
+
+---
+
+## Review Rubric
+
+### Determining What to Flag
+
+Flag issues that:
+1. Meaningfully impact accuracy, performance, security, or maintainability
+2. Are discrete and actionable
+3. Don't demand rigor inconsistent with the rest of the codebase
+4. Were introduced in the changes being reviewed (not pre-existing)
+5. The author would likely fix if aware of them
+6. Have provable impact (not speculation)
+
+### Untrusted User Input
+
+1. Be careful with open redirects — must always check for trusted domains
+2. Always flag SQL that is not parametrized
+3. User-supplied URL fetches need protection against local resource access (intercept DNS resolver)
+4. Escape, don't sanitize if you have the option
+
+### State Sync / Broadcast Exposure
+
+When frameworks auto-sync state to clients (e.g. Cloudflare Agents `setState()`, Redux devtools, WebSocket broadcast), check what's in that state. Secrets, answers, API keys, internal IDs — anything the client shouldn't see is a P0 if it's in the broadcast payload. The developer may not realize the framework sends the full object.
+
+### Review Priorities
+
+1. Call out newly added dependencies explicitly
+2. Prefer simple, direct solutions over unnecessary abstractions
+3. Favor fail-fast behavior; avoid logging-and-continue that hides errors
+4. Prefer predictable production behavior; crashing > silent degradation
+5. Treat back pressure handling as critical
+6. Apply system-level thinking; flag operational risk
+7. Ensure errors are checked against codes/stable identifiers, never messages
+
+### Priority Levels — Be Ruthlessly Pragmatic
+
+The bar for flagging is HIGH. Ask: "Will this actually cause a real problem?"
+
+- **[P0]** — Drop everything. Will break production, lose data, or create a security hole. Must be provable. **Includes:** leaking secrets/answers to clients, auth bypass, data exposure via auto-sync/broadcast mechanisms.
+- **[P1]** — Genuine foot gun. Someone WILL trip over this and waste hours.
+- **[P2]** — Worth mentioning. Real improvement, but code works without it.
+- **[P3]** — Almost irrelevant.
+
+### What NOT to Flag
+
+- Naming preferences (unless actively misleading)
+- Hypothetical edge cases (check if they're actually possible first)
+- Style differences
+- "Best practice" violations where the code works fine
+- Speculative future scaling problems
+
+### What TO Flag
+
+- Real bugs that will manifest in actual usage
+- Security issues with concrete exploit scenarios
+- Logic errors where code doesn't match the plan's intent
+- Missing error handling where errors WILL occur
+- Genuinely confusing code that will cause the next person to introduce bugs
+
+### Output
+
+If the code works and is readable, a short review with few findings is the RIGHT answer. Don't manufacture findings.

--- a/packages/pi-interactive-subagents/agents/scout.md
+++ b/packages/pi-interactive-subagents/agents/scout.md
@@ -1,0 +1,104 @@
+---
+name: scout
+description: Fast codebase reconnaissance - maps existing code, conventions, and patterns for a task
+tools: read, bash
+deny-tools: claude
+output: context.md
+spawning: false
+auto-exit: true
+system-prompt: append
+---
+
+# Scout Agent
+
+You are a **codebase reconnaissance specialist**. You were spawned to quickly explore an existing codebase and gather the context another agent needs to do its work. Lean hard into what's asked, deliver your findings, and exit.
+
+**You only operate on existing codebases.** Your entire value is reading and understanding what's already there — the files, patterns, conventions, dependencies, and gotchas. If there's no codebase to explore, you have nothing to do.
+
+---
+
+## Principles
+
+- **Read before you assess** — Actually look at the files. Never assume what code does.
+- **Be thorough but fast** — Cover the relevant areas without rabbit holes. Your output feeds other agents.
+- **Be direct** — Facts, not fluff. No excessive praise or hedging.
+- **Try before asking** — Need to know if a tool or config exists? Just check.
+
+---
+
+## Approach
+
+1. **Orient** — Understand what the task needs. What are we building, fixing, or changing?
+2. **Map the territory** — Find relevant files, modules, entry points, and their relationships.
+3. **Read the code** — Don't just list files. Read the important ones. Understand the actual logic.
+4. **Surface conventions** — Coding style, naming, project structure, error handling patterns, test patterns.
+5. **Flag gotchas** — Anything that could trip up implementation: implicit assumptions, tight coupling, missing validation, undocumented behavior.
+
+### What to look for
+
+- **Project structure** — How is the code organized? Monorepo? Flat? Feature-based?
+- **Entry points** — Where does execution start? What's the request/data flow?
+- **Related code** — What existing code touches the area we're changing?
+- **Conventions** — How are similar things done elsewhere in this codebase?
+- **Dependencies** — What libraries matter for this task? How are they used?
+- **Config & environment** — Build config, env vars, feature flags that affect the area.
+- **Tests** — How is this area tested? What patterns do tests follow?
+
+### Useful commands
+
+```bash
+# Structure
+ls -la
+find . -type f -name "*.ts" | head -40
+tree -L 2 -I node_modules 2>/dev/null
+
+# Search
+rg "pattern" --type ts -l
+rg "functionName" -A 5 -B 2
+rg "import.*from" path/to/file.ts
+
+# Dependencies & config
+cat package.json 2>/dev/null | head -60
+cat tsconfig.json 2>/dev/null
+```
+
+---
+
+## Output
+
+Use the `write` tool to save your findings. The orchestrator provides the target path in your task (typically `.pi/plans/YYYY-MM-DD-<name>/scout-context.md`). Report the exact path back in your summary so downstream agents can read it.
+
+**Content template:**
+
+```markdown
+# Context for: [task summary]
+
+## Relevant Files
+- `path/to/file.ts` — [what it does, why it matters for this task]
+
+## Project Structure
+[How the codebase is organized — just the parts relevant to the task]
+
+## Conventions
+[Coding style, naming, patterns to follow — based on what you actually read]
+
+## Dependencies
+[Libraries relevant to the task and how they're used]
+
+## Key Findings
+[What you learned that directly affects implementation]
+
+## Gotchas
+[Things that could trip up implementation — coupling, assumptions, edge cases]
+```
+
+Only include sections that have substance. Skip empty ones.
+
+---
+
+## Constraints
+
+- **Read-only** — Do NOT modify any files
+- **No builds or tests** — Leave that for the worker
+- **No implementation decisions** — Leave that for the planner
+- **Stay focused** — Only explore what's relevant to the task at hand

--- a/packages/pi-interactive-subagents/agents/visual-tester.md
+++ b/packages/pi-interactive-subagents/agents/visual-tester.md
@@ -1,0 +1,197 @@
+---
+name: visual-tester
+description: Visual QA tester — navigates web UIs via Chrome CDP, spots visual issues, tests interactions, produces structured reports
+tools: bash, read, write
+skill: chrome-cdp
+spawning: false
+auto-exit: true
+system-prompt: append
+---
+
+# Visual Tester
+
+You are a **specialist in an orchestration system**. You were spawned for a specific purpose — test the UI visually, report what's wrong, and exit. Don't fix CSS or rewrite components. Produce a clear report so workers can act on your findings.
+
+You are a visual QA tester. You use Chrome CDP (`scripts/cdp.mjs`) to control the browser, take screenshots, inspect accessibility trees, interact with elements, and report what looks wrong.
+
+This is not a formal test suite — it's "let me look at this and check if it's right."
+
+---
+
+## Setup
+
+### Prerequisites
+
+- Chrome with remote debugging enabled: `chrome://inspect/#remote-debugging` → toggle the switch
+- The target page open in a Chrome tab
+
+### Getting Started
+
+```bash
+# 1. Find your target tab
+scripts/cdp.mjs list
+
+# 2. Take a screenshot to verify connection
+scripts/cdp.mjs shot <target> /tmp/screenshot.png
+
+# 3. Get the page structure
+scripts/cdp.mjs snap <target>
+```
+
+Use the targetId prefix (e.g. `6BE827FA`) for all commands. Read the **chrome-cdp** skill for the full command reference.
+
+---
+
+## What to Look For
+
+### Layout & Spacing
+
+- Elements not aligned, inconsistent padding/margins
+- Content touching container edges, overflowing containers
+- Unexpected scrollbars
+
+### Typography
+
+- Text clipped/truncated, overflowing containers
+- Font size hierarchy wrong (h1 smaller than h2)
+- Missing or broken web fonts
+
+### Colors & Contrast
+
+- Text hard to read against background
+- Focus indicators invisible or missing
+- Inconsistent color usage
+
+### Images & Media
+
+- Broken images, wrong aspect ratios
+- Images not responsive
+
+### Z-index & Overlapping
+
+- Modals/dropdowns behind other elements
+- Fixed headers overlapping content
+
+### Empty & Edge States
+
+- No data state, very long/short text, error states, loading states
+
+---
+
+## Responsive Testing
+
+Test at key breakpoints:
+
+| Name    | Width | Height |
+| ------- | ----- | ------ |
+| Mobile  | 375   | 812    |
+| Tablet  | 768   | 1024   |
+| Desktop | 1280  | 800    |
+
+```bash
+scripts/cdp.mjs evalraw <target> Emulation.setDeviceMetricsOverride '{"width":375,"height":812,"deviceScaleFactor":2,"mobile":true}'
+scripts/cdp.mjs shot <target> /tmp/mobile.png
+```
+
+Reset after: `scripts/cdp.mjs evalraw <target> Emulation.clearDeviceMetricsOverride`
+
+Use judgment — not every page needs all breakpoints.
+
+---
+
+## Interaction Testing
+
+```bash
+# Click elements
+scripts/cdp.mjs click <target> 'button[type="submit"]'
+scripts/cdp.mjs shot <target> /tmp/after-click.png
+
+# Fill forms
+scripts/cdp.mjs click <target> 'input[name="email"]'
+scripts/cdp.mjs type <target> 'test@example.com'
+
+# Navigate
+scripts/cdp.mjs nav <target> http://localhost:3000/other-page
+```
+
+**Always screenshot after actions** to verify results.
+
+---
+
+## Dark Mode
+
+```bash
+scripts/cdp.mjs evalraw <target> Emulation.setEmulatedMedia '{"features":[{"name":"prefers-color-scheme","value":"dark"}]}'
+scripts/cdp.mjs shot <target> /tmp/dark-mode.png
+```
+
+Reset: `scripts/cdp.mjs evalraw <target> Emulation.setEmulatedMedia '{"features":[]}'`
+
+---
+
+## Report
+
+Use the `write` tool to save the report. The orchestrator provides the target path in your task (typically `.pi/plans/YYYY-MM-DD-<name>/visual-test-report.md`). Report the exact path back in your summary.
+
+**Format:**
+
+```markdown
+# Visual Test Report
+
+**URL:** http://localhost:3000
+**Viewports tested:** Mobile (375), Desktop (1280)
+
+## Summary
+
+Brief overall impression. Ready to ship?
+
+## Findings
+
+### P0 — Blockers
+
+#### [Title]
+
+- **Location:** Page/component
+- **Description:** What's wrong
+- **Suggested fix:** How to fix
+
+### P1 — Major
+
+...
+
+### P2 — Minor
+
+...
+
+## What's Working Well
+
+- Positive observations
+```
+
+| Level  | Meaning           | Examples                                 |
+| ------ | ----------------- | ---------------------------------------- |
+| **P0** | Broken / unusable | Button doesn't work, content invisible   |
+| **P1** | Major visual/UX   | Layout broken on mobile, text unreadable |
+| **P2** | Cosmetic          | Misaligned elements, wrong colors        |
+| **P3** | Polish            | Slightly off margins                     |
+
+---
+
+## Cleanup
+
+Before writing the report, restore the browser:
+
+```bash
+scripts/cdp.mjs evalraw <target> Emulation.clearDeviceMetricsOverride
+scripts/cdp.mjs evalraw <target> Emulation.setEmulatedMedia '{"features":[]}'
+scripts/cdp.mjs nav <target> <original-url>
+```
+
+---
+
+## Tips
+
+- **Screenshot liberally.** Before/after for interactions.
+- **Use accessibility snapshots** to understand structure.
+- **Happy path first.** Basic flow before edge cases.
+- **Use common sense.** Not every page needs all breakpoints and dark mode.

--- a/packages/pi-interactive-subagents/agents/worker.md
+++ b/packages/pi-interactive-subagents/agents/worker.md
@@ -1,0 +1,103 @@
+---
+name: worker
+description: Implements tasks from todos - writes code, runs tests, commits with polished messages
+tools: read, bash, write, edit
+deny-tools: claude
+thinking: minimal
+spawning: false
+auto-exit: true
+system-prompt: append
+---
+
+# Worker Agent
+
+You are a **specialist in an orchestration system**. You were spawned for a specific purpose — lean hard into what's asked, deliver, and exit. Don't redesign, don't re-plan, don't expand scope. Trust that scouts gathered context and planners made decisions. Your job is execution.
+
+You are a senior engineer picking up a well-scoped task. The planning is done — your job is to implement it with quality and care.
+
+---
+
+## Engineering Standards
+
+### You Own What You Ship
+Care about readability, naming, structure. If something feels off, fix it or flag it.
+
+### Keep It Simple
+Write the simplest code that solves the problem. No abstractions for one-time operations, no helpers nobody asked for, no "improvements" beyond scope.
+
+### Read Before You Edit
+Never modify code you haven't read. Understand existing patterns and conventions first.
+
+### Investigate, Don't Guess
+When something breaks, read error messages, form a hypothesis based on evidence. No shotgun debugging.
+
+### Evidence Before Assertions
+Never say "done" without proving it. Run the test, show the output. No "should work."
+
+---
+
+## Workflow
+
+### 1. Read Your Task
+
+Everything you need is in the task message:
+- What to implement (usually a TODO reference)
+- Plan path or context (if provided)
+- Acceptance criteria
+
+If a plan path is mentioned, read it. If a TODO is referenced, read its details:
+```
+todo(action: "get", id: "TODO-xxxx")
+```
+
+### 2. Verify Todo Has Examples & References
+
+**Before claiming the todo, check that it contains:**
+- [ ] A code example or snippet showing expected shape (imports, patterns, structure)
+- [ ] OR an explicit reference to existing code to extrapolate from (file path + what to look at)
+- [ ] Explicit constraints (libraries to use, patterns to follow, anti-patterns to avoid)
+
+**If any of these are missing, STOP and report back.** Do NOT guess or improvise. Write a clear message explaining what's missing:
+
+> "TODO-xxxx is missing [examples / references / constraints]. I need:
+> - [specific thing 1: e.g., 'a code example showing how to structure the Effect service']
+> - [specific thing 2: e.g., 'which existing file to use as a reference for the component pattern']
+>
+> Cannot implement without this context."
+
+Then **release the todo** and exit. The orchestrator will provide the missing context and re-assign.
+
+This is not a failure — it's quality control. Guessing leads to building the wrong thing. Asking leads to building the right thing.
+
+### 3. Claim the Todo
+
+```
+todo(action: "claim", id: "TODO-xxxx")
+```
+
+### 4. Implement
+
+- Follow existing patterns — your code should look like it belongs
+- Keep changes minimal and focused
+- Test as you go
+
+### 5. Verify
+
+Before marking done:
+- Run tests or verify the feature works
+- Check for regressions
+- **For integration/framework changes** (new hooks, decorators, state management, API changes): start the dev server and hit the actual endpoint or load the page. Type errors pass `vp check` but runtime crashes (missing bindings, framework initialization order, RPC serialization) only surface when you run it.
+- **Check against ISC if provided** — if the plan includes Ideal State Criteria, verify your work against each relevant ISC item. Mark them with evidence (command output, file path, test result). "Should work" is not evidence.
+
+### 6. Commit
+
+Load the commit skill and make a polished, descriptive commit:
+```
+/skill:commit
+```
+
+### 7. Close the Todo
+
+```
+todo(action: "update", id: "TODO-xxxx", status: "closed")
+```

--- a/packages/pi-interactive-subagents/config.json.example
+++ b/packages/pi-interactive-subagents/config.json.example
@@ -1,0 +1,5 @@
+{
+  "status": {
+    "enabled": true
+  }
+}

--- a/packages/pi-interactive-subagents/index.ts
+++ b/packages/pi-interactive-subagents/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./pi-extension/subagents/index.ts";

--- a/packages/pi-interactive-subagents/locales/index.json
+++ b/packages/pi-interactive-subagents/locales/index.json
@@ -1,0 +1,6 @@
+{
+  "agentEndNudge": {
+    "zh-CN": "【自动提醒】\n• 已完成 → 调用 subagent_done 结束。\n• 结束前自检：是否在原地打转？若是，立刻收敛结果，用 caller_ping 抛回主 agent，不要过度思考。\n• 还在处理 → 忽略。",
+    "en-US": "[Auto reminder]\n• Done → call subagent_done to finish.\n• Before finishing, self-check: are you spinning in place? If so, converge your result immediately and hand it back to the main agent with caller_ping — don't overthink.\n• Still working → ignore."
+  }
+}

--- a/packages/pi-interactive-subagents/package.json
+++ b/packages/pi-interactive-subagents/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@maplezzk/pi-interactive-subagents",
+  "version": "3.7.1",
+  "description": "Interactive async subagents for pi — spawn, orchestrate, and manage sub-agent sessions in multiplexer panes. Fork of HazAT/pi-interactive-subagents.",
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "pi-extension",
+    "agents",
+    "locales",
+    "config.json.example",
+    "README.md",
+    "README.zh-CN.md"
+  ],
+  "scripts": {
+    "test": "tsx --test test/test.ts",
+    "test:integration": "tsx --test --test-concurrency=1 test/integration/*.test.ts",
+    "typecheck": "tsc --noEmit --pretty false",
+    "build": "npm run typecheck",
+    "check": "npm run typecheck && npm test && npm pack --dry-run --json > /dev/null"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "author": "HazAT",
+  "contributors": [
+    "maplezzk"
+  ],
+  "homepage": "https://github.com/maplezzk/pi-extensions/tree/main/packages/pi-interactive-subagents",
+  "bugs": "https://github.com/maplezzk/pi-extensions/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maplezzk/pi-extensions.git",
+    "directory": "packages/pi-interactive-subagents"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-extension",
+    "coding-agent",
+    "subagents",
+    "multiplexer"
+  ],
+  "dependencies": {
+    "ajv": "^8.20.0",
+    "pi-extensions-i18n": "^0.3.0",
+    "pi-terminal-mux": "^0.2.1"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+    "@earendil-works/pi-tui": ">=0.80.0 <0.81.0",
+    "@sinclair/typebox": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
+    "@sinclair/typebox": "^0.34.49",
+    "@types/node": "24.12.4",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/activity.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/activity.ts
@@ -1,0 +1,511 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type SubagentActivityPhase = "starting" | "active" | "waiting" | "done";
+export type SubagentActivityScope = "agent" | "turn" | "provider" | "streaming" | "tool";
+
+export type SubagentActivityEvent =
+  | "session_start"
+  | "input"
+  | "before_agent_start"
+  | "agent_start"
+  | "agent_end"
+  | "turn_start"
+  | "turn_end"
+  | "before_provider_request"
+  | "after_provider_response"
+  | "message_update"
+  | "tool_execution_start"
+  | "tool_call"
+  | "tool_execution_update"
+  | "tool_result"
+  | "tool_execution_end"
+  | "caller_ping"
+  | "subagent_done"
+  | "session_shutdown";
+
+export interface SubagentActivityState {
+  version: 1;
+  runningChildId: string;
+  createdAt: number;
+  updatedAt: number;
+  sequence: number;
+  latestEvent: SubagentActivityEvent;
+  phase: SubagentActivityPhase;
+  agentActive: boolean;
+  turnActive: boolean;
+  providerActive: boolean;
+  toolActive: boolean;
+  activeScope?: SubagentActivityScope;
+  activeSince?: number;
+  waitingSince?: number;
+  turnIndex?: number;
+  messageEventType?: string;
+  toolCallId?: string;
+  toolName?: string;
+  toolStartedAt?: number;
+  toolEndedAt?: number;
+}
+
+export type ActivityReadResult =
+  | { ok: true; activity: SubagentActivityState }
+  | { ok: false; reason: "missing" | "invalid" | "wrong-id"; error?: string };
+
+export type SubagentShutdownReason = "quit" | "reload" | "new" | "resume" | "fork";
+
+export interface SubagentActivityRecorder {
+  sessionStart(): void;
+  input(): void;
+  beforeAgentStart(): void;
+  agentStart(): void;
+  agentEndWaiting(): void;
+  agentEndDone(): void;
+  turnStart(turnIndex?: number): void;
+  turnEnd(turnIndex?: number): void;
+  beforeProviderRequest(): void;
+  afterProviderResponse(): void;
+  messageUpdate(messageEventType?: string): void;
+  toolExecutionStart(toolCallId?: string, toolName?: string): void;
+  toolCall(toolCallId?: string, toolName?: string): void;
+  toolExecutionUpdate(toolCallId?: string, toolName?: string): void;
+  toolResult(toolCallId?: string, toolName?: string): void;
+  toolExecutionEnd(toolCallId?: string, toolName?: string): void;
+  callerPing(): void;
+  subagentDone(): void;
+  sessionShutdown(reason: SubagentShutdownReason): void;
+}
+
+const ACTIVITY_UPDATE_THROTTLE_MS = 500;
+const MAX_WRITE_FAILURES = 3;
+const KNOWN_PHASES = new Set<SubagentActivityPhase>(["starting", "active", "waiting", "done"]);
+const KNOWN_SCOPES = new Set<SubagentActivityScope>(["agent", "turn", "provider", "streaming", "tool"]);
+const KNOWN_EVENTS = new Set<SubagentActivityEvent>([
+  "session_start",
+  "input",
+  "before_agent_start",
+  "agent_start",
+  "agent_end",
+  "turn_start",
+  "turn_end",
+  "before_provider_request",
+  "after_provider_response",
+  "message_update",
+  "tool_execution_start",
+  "tool_call",
+  "tool_execution_update",
+  "tool_result",
+  "tool_execution_end",
+  "caller_ping",
+  "subagent_done",
+  "session_shutdown",
+]);
+const MAX_ACTIVITY_STRING_LENGTH = 200;
+
+export function getSubagentActivityFile(artifactDir: string, runningChildId: string): string {
+  return join(artifactDir, "subagent-activity", `${runningChildId}.json`);
+}
+
+function requireObject(value: unknown): Record<string, unknown> | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function validateFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isFinite(object[fieldName]) ? null : `${fieldName} must be finite`;
+}
+
+function validateOptionalFiniteNumber(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isFinite(value) ? null : `${fieldName} must be finite when present`;
+}
+
+function validateInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  return Number.isInteger(object[fieldName]) ? null : `${fieldName} must be an integer`;
+}
+
+function validateOptionalInteger(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  return value == null || Number.isInteger(value) ? null : `${fieldName} must be an integer when present`;
+}
+
+function validateBoolean(object: Record<string, unknown>, fieldName: string): string | null {
+  return typeof object[fieldName] === "boolean" ? null : `${fieldName} must be a boolean`;
+}
+
+function validateOptionalActivityString(object: Record<string, unknown>, fieldName: string): string | null {
+  const value = object[fieldName];
+  if (value == null) return null;
+  if (typeof value !== "string") return `${fieldName} must be a string when present`;
+  if (/\r|\n/.test(value)) return `${fieldName} must not contain newlines`;
+  return value.length <= MAX_ACTIVITY_STRING_LENGTH ? null : `${fieldName} is too long`;
+}
+
+function invalidActivity(error: string): ActivityReadResult {
+  return { ok: false, reason: "invalid", error };
+}
+
+function validateActivity(value: unknown, expectedRunningChildId: string): ActivityReadResult {
+  const object = requireObject(value);
+  if (!object) return invalidActivity("activity must be an object");
+  if (object.version !== 1) return invalidActivity("unsupported activity version");
+  if (typeof object.runningChildId !== "string") return invalidActivity("runningChildId must be a string");
+  if (object.runningChildId !== expectedRunningChildId) return { ok: false, reason: "wrong-id" };
+  if (typeof object.latestEvent !== "string" || !KNOWN_EVENTS.has(object.latestEvent as SubagentActivityEvent)) {
+    return invalidActivity("unknown latestEvent");
+  }
+  if (typeof object.phase !== "string" || !KNOWN_PHASES.has(object.phase as SubagentActivityPhase)) {
+    return invalidActivity("unknown activity phase");
+  }
+  if (
+    object.activeScope != null &&
+    (typeof object.activeScope !== "string" || !KNOWN_SCOPES.has(object.activeScope as SubagentActivityScope))
+  ) {
+    return invalidActivity("unknown activeScope");
+  }
+
+  const validationError = [
+    validateFiniteNumber(object, "createdAt"),
+    validateFiniteNumber(object, "updatedAt"),
+    validateInteger(object, "sequence"),
+    validateBoolean(object, "agentActive"),
+    validateBoolean(object, "turnActive"),
+    validateBoolean(object, "providerActive"),
+    validateBoolean(object, "toolActive"),
+    validateOptionalFiniteNumber(object, "activeSince"),
+    validateOptionalFiniteNumber(object, "waitingSince"),
+    validateOptionalInteger(object, "turnIndex"),
+    validateOptionalFiniteNumber(object, "toolStartedAt"),
+    validateOptionalFiniteNumber(object, "toolEndedAt"),
+    validateOptionalActivityString(object, "messageEventType"),
+    validateOptionalActivityString(object, "toolCallId"),
+    validateOptionalActivityString(object, "toolName"),
+  ].find((error) => error != null);
+  if (validationError) return invalidActivity(validationError);
+
+  return { ok: true, activity: object as unknown as SubagentActivityState };
+}
+
+export function readSubagentActivityFile(
+  activityFile: string,
+  expectedRunningChildId: string,
+): ActivityReadResult {
+  if (!existsSync(activityFile)) return { ok: false, reason: "missing" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(activityFile, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "invalid", error: message };
+  }
+
+  return validateActivity(parsed, expectedRunningChildId);
+}
+
+export function writeSubagentActivityFile(activityFile: string, activity: SubagentActivityState): void {
+  const dir = dirname(activityFile);
+  mkdirSync(dir, { recursive: true });
+  const tempFile = join(dir, `${activity.runningChildId}.json.${process.pid}.${activity.sequence}.tmp`);
+
+  try {
+    writeFileSync(tempFile, `${JSON.stringify(activity)}\n`, "utf8");
+    renameSync(tempFile, activityFile);
+  } catch (error) {
+    try {
+      unlinkSync(tempFile);
+    } catch (cleanupError) {
+      // Temp cleanup is best effort; preserve the original write/rename failure
+      void cleanupError;
+    }
+    throw error;
+  }
+}
+
+function createNoopRecorder(): SubagentActivityRecorder {
+  return {
+    sessionStart() {},
+    input() {},
+    beforeAgentStart() {},
+    agentStart() {},
+    agentEndWaiting() {},
+    agentEndDone() {},
+    turnStart() {},
+    turnEnd() {},
+    beforeProviderRequest() {},
+    afterProviderResponse() {},
+    messageUpdate() {},
+    toolExecutionStart() {},
+    toolCall() {},
+    toolExecutionUpdate() {},
+    toolResult() {},
+    toolExecutionEnd() {},
+    callerPing() {},
+    subagentDone() {},
+    sessionShutdown() {},
+  };
+}
+
+function clearActiveState(activity: SubagentActivityState): void {
+  activity.agentActive = false;
+  activity.turnActive = false;
+  activity.providerActive = false;
+  activity.toolActive = false;
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function refreshActiveScope(activity: SubagentActivityState): void {
+  if (activity.toolActive) {
+    activity.phase = "active";
+    activity.activeScope = "tool";
+    return;
+  }
+  if (activity.providerActive) {
+    activity.phase = "active";
+    activity.activeScope = "provider";
+    return;
+  }
+  if (activity.turnActive) {
+    activity.phase = "active";
+    activity.activeScope = "turn";
+    return;
+  }
+  if (activity.agentActive) {
+    activity.phase = "active";
+    activity.activeScope = "agent";
+    return;
+  }
+  delete activity.activeScope;
+  delete activity.activeSince;
+}
+
+function markActive(
+  activity: SubagentActivityState,
+  scope: SubagentActivityScope,
+  now: number,
+  resetActiveSince = false,
+): void {
+  activity.phase = "active";
+  activity.activeScope = scope;
+  if (activity.activeSince == null || resetActiveSince) activity.activeSince = now;
+  delete activity.waitingSince;
+}
+
+export function createSubagentActivityRecorder(params: {
+  runningChildId?: string;
+  activityFile?: string;
+  now?: () => number;
+}): SubagentActivityRecorder {
+  const runningChildId = params.runningChildId?.trim();
+  const activityFile = params.activityFile?.trim();
+  if (!runningChildId || !activityFile) return createNoopRecorder();
+
+  const now = params.now ?? (() => Date.now());
+  const createdAt = now();
+  const activity: SubagentActivityState = {
+    version: 1,
+    runningChildId,
+    createdAt,
+    updatedAt: createdAt,
+    sequence: 0,
+    latestEvent: "session_start",
+    phase: "starting",
+    agentActive: false,
+    turnActive: false,
+    providerActive: false,
+    toolActive: false,
+  };
+
+  let disabled = false;
+  let failureCount = 0;
+  let lastFlushAt = 0;
+  let pendingFlush: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPendingFlush(): void {
+    if (!pendingFlush) return;
+    clearTimeout(pendingFlush);
+    pendingFlush = null;
+  }
+
+  function disable(): void {
+    disabled = true;
+    clearPendingFlush();
+  }
+
+  function flushNow(): void {
+    if (disabled) return;
+    try {
+      writeSubagentActivityFile(activityFile, activity);
+      lastFlushAt = now();
+      failureCount = 0;
+    } catch {
+      failureCount += 1;
+      if (failureCount >= MAX_WRITE_FAILURES) disable();
+    }
+  }
+
+  function scheduleFlush(): void {
+    if (disabled || pendingFlush) return;
+
+    const remainingMs = Math.max(0, ACTIVITY_UPDATE_THROTTLE_MS - (now() - lastFlushAt));
+    if (remainingMs === 0) {
+      flushNow();
+      return;
+    }
+
+    pendingFlush = setTimeout(() => {
+      pendingFlush = null;
+      flushNow();
+    }, remainingMs);
+  }
+
+  function record(
+    latestEvent: SubagentActivityEvent,
+    update: (current: SubagentActivityState, now: number) => void,
+    flush: "immediate" | "throttled",
+  ): void {
+    if (disabled) return;
+    if (flush === "immediate") clearPendingFlush();
+
+    const observedAt = now();
+    activity.latestEvent = latestEvent;
+    activity.updatedAt = observedAt;
+    activity.sequence += 1;
+    update(activity, observedAt);
+
+    if (flush === "immediate") flushNow();
+    else scheduleFlush();
+  }
+
+  function markDone(latestEvent: SubagentActivityEvent): void {
+    record(latestEvent, (current) => {
+      current.phase = "done";
+      clearActiveState(current);
+      delete current.waitingSince;
+    }, "immediate");
+    disable();
+  }
+
+  return {
+    sessionStart() {
+      record("session_start", (current) => {
+        current.phase = "starting";
+        clearActiveState(current);
+        delete current.waitingSince;
+      }, "immediate");
+    },
+    input() {
+      record("input", () => {}, "immediate");
+    },
+    beforeAgentStart() {
+      record("before_agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentStart() {
+      record("agent_start", (current, observedAt) => {
+        current.agentActive = true;
+        markActive(current, "agent", observedAt);
+      }, "immediate");
+    },
+    agentEndWaiting() {
+      record("agent_end", (current, observedAt) => {
+        clearActiveState(current);
+        current.phase = "waiting";
+        current.waitingSince = observedAt;
+      }, "immediate");
+    },
+    agentEndDone() {
+      markDone("agent_end");
+    },
+    turnStart(turnIndex) {
+      record("turn_start", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        markActive(current, current.toolActive || current.providerActive ? current.activeScope ?? "turn" : "turn", observedAt);
+      }, "immediate");
+    },
+    turnEnd(turnIndex) {
+      record("turn_end", (current) => {
+        current.turnActive = false;
+        current.providerActive = false;
+        current.toolActive = false;
+        if (turnIndex != null) current.turnIndex = turnIndex;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    beforeProviderRequest() {
+      record("before_provider_request", (current, observedAt) => {
+        current.providerActive = true;
+        markActive(current, "provider", observedAt, true);
+      }, "immediate");
+    },
+    afterProviderResponse() {
+      record("after_provider_response", (current) => {
+        current.providerActive = false;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    messageUpdate(messageEventType) {
+      record("message_update", (current, observedAt) => {
+        current.agentActive = true;
+        current.turnActive = true;
+        current.messageEventType = messageEventType;
+        if (!current.toolActive) markActive(current, "streaming", observedAt);
+      }, "throttled");
+    },
+    toolExecutionStart(toolCallId, toolName) {
+      record("tool_execution_start", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId;
+        current.toolName = toolName;
+        current.toolStartedAt = observedAt;
+        markActive(current, "tool", observedAt, true);
+      }, "immediate");
+    },
+    toolCall(toolCallId, toolName) {
+      record("tool_call", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "immediate");
+    },
+    toolExecutionUpdate(toolCallId, toolName) {
+      record("tool_execution_update", (current, observedAt) => {
+        current.toolActive = true;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        markActive(current, "tool", observedAt);
+      }, "throttled");
+    },
+    toolResult(toolCallId, toolName) {
+      record("tool_result", (current) => {
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    toolExecutionEnd(toolCallId, toolName) {
+      record("tool_execution_end", (current, observedAt) => {
+        current.toolActive = false;
+        current.toolCallId = toolCallId ?? current.toolCallId;
+        current.toolName = toolName ?? current.toolName;
+        current.toolEndedAt = observedAt;
+        refreshActiveScope(current);
+      }, "immediate");
+    },
+    callerPing() {
+      markDone("caller_ping");
+    },
+    subagentDone() {
+      markDone("subagent_done");
+    },
+    sessionShutdown(reason) {
+      if (reason === "quit") markDone("session_shutdown");
+      else disable();
+    },
+  };
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
@@ -1,0 +1,2248 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { keyHint } from "@earendil-works/pi-coding-agent";
+import { Type, type Static } from "@sinclair/typebox";
+import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import {
+  createSurface,
+  sendLongCommand,
+  pollForExit,
+  closeSurface,
+  muxLog,
+  getMuxBackend,
+  isMuxAvailable,
+  sendEscape,
+  shellEscape,
+  renameCurrentTab,
+  renameWorkspace,
+  renameAgent,
+  readScreen,
+  getLastSplitSource,
+  clearLastSplitSource,
+} from "pi-terminal-mux";
+
+import {
+  findLastAssistantMessage,
+  getNewEntries,
+  seedSubagentSessionFile,
+} from "./session.ts";
+import {
+  type StatusSnapshot,
+  type SubagentStatusState,
+  advanceStatusState,
+  capStatusLines,
+  classifyStatus,
+  createStatusState,
+  forceStatusAfterInterrupt,
+  formatStatusAggregate,
+  formatTransitionLine,
+  observeStatus,
+  loadStatusConfig,
+} from "./status.ts";
+import {
+  getSubagentActivityFile,
+  readSubagentActivityFile,
+  type ActivityReadResult,
+  type SubagentActivityState,
+} from "./activity.ts";
+
+/** Absolute path to `pi-extension/subagents`. https://github.com/nodejs/node/issues/37845 */
+const SUBAGENTS_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** 从 content 数组提取第一个 TextContent 的文本（若存在） */
+function extractFirstText(content: Array<{ type: string; text?: string }>): string {
+  const first = content[0];
+  return first && typeof first.text === "string" ? first.text : "";
+}
+
+/**
+ * 默认 subagent 模型。
+ *
+ * 解析优先级（高 → 低）：
+ *   1. 调用方传入的 `model` 参数（subagent tool 调用时显式指定）
+ *   2. agent 配置文件 frontmatter 里的 `model` 字段
+ *   3. 环境变量 PI_SUBAGENT_DEFAULT_MODEL
+ *   4. undefined — 不传 --model，子 pi 继承父 session 的默认模型
+ */
+function getDefaultSubagentModel(): string | undefined {
+  return process.env.PI_SUBAGENT_DEFAULT_MODEL?.trim() || undefined;
+}
+
+// Survive /reload: clear timers and abort poll loops from the previous module load.
+// /reload re-imports this file, giving fresh module-level state, but closures from
+// the old module keep running. See https://github.com/HazAT/pi-interactive-subagents/issues/5
+const WIDGET_INTERVAL_KEY = Symbol.for("pi-subagents/widget-interval");
+const STATUS_INTERVAL_KEY = Symbol.for("pi-subagents/status-interval");
+const POLL_ABORT_KEY = Symbol.for("pi-subagents/poll-abort-controller");
+
+{
+  const prevInterval = (globalThis as any)[WIDGET_INTERVAL_KEY];
+  if (prevInterval) {
+    clearInterval(prevInterval);
+    (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+  }
+  const prevStatusInterval = (globalThis as any)[STATUS_INTERVAL_KEY];
+  if (prevStatusInterval) {
+    clearInterval(prevStatusInterval);
+    (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+  }
+  const prevAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+  if (prevAbort) prevAbort.abort();
+  (globalThis as any)[POLL_ABORT_KEY] = new AbortController();
+}
+
+function getModuleAbortSignal(): AbortSignal {
+  // 自愈：若 controller 已被 abort（session_shutdown 会调 abort 但不重置），
+  // 自动重建一个新 controller，避免下一次 watchSubagent 拿到 aborted signal
+  // 导致 pollForExit 第一行 throw "Aborted while waiting..."、子 pi 来不及启动
+  // 就被 close。现象：pane run 后 ~0ms pane close、无任何 pane read 轮询日志、
+  // workflow 报 "subagent never actually started"。
+  const existing = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+  if (!existing || existing.signal.aborted) {
+    const fresh = new AbortController();
+    (globalThis as any)[POLL_ABORT_KEY] = fresh;
+    muxLog(`[getModuleAbortSignal] self-healed: ${existing ? "was aborted" : "missing"} → created new controller\n`);
+    return fresh.signal;
+  }
+  return existing.signal;
+}
+
+const SubagentParams = Type.Object({
+  name: Type.String({ description: "Display name for the subagent" }),
+  task: Type.String({ description: "Task/prompt for the sub-agent" }),
+  agent: Type.Optional(
+    Type.String({
+      description:
+        "Agent name to load defaults from (e.g. 'worker', 'scout', 'reviewer'). Reads ~/.pi/agent/agents/<name>.md for model, tools, skills.",
+    }),
+  ),
+  systemPrompt: Type.Optional(
+    Type.String({ description: "Appended to system prompt (role instructions)" }),
+  ),
+  model: Type.Optional(Type.String({ description: "Model override (overrides agent default)" })),
+  skills: Type.Optional(
+    Type.String({ description: "Comma-separated skills (overrides agent default)" }),
+  ),
+  tools: Type.Optional(
+    Type.String({ description: "Comma-separated tools (overrides agent default)" }),
+  ),
+  cwd: Type.Optional(
+    Type.String({
+      description:
+        "Working directory for the sub-agent. The agent starts in this folder and picks up its local .pi/ config, CLAUDE.md, skills, and extensions. Use for role-specific subfolders.",
+    }),
+  ),
+  fork: Type.Optional(
+    Type.Boolean({
+      description:
+        "Force the full-context fork mode for this spawn. The sub-agent inherits the current session conversation, overriding any agent frontmatter session-mode.",
+    }),
+  ),
+  interactive: Type.Optional(
+    Type.Boolean({
+      description:
+        "Mark the subagent as interactive (long-running, user drives the conversation in its own pane). When true, the main session is not woken by status transitions (stalled/recovered) for this subagent. If omitted, falls back to the agent's `interactive` frontmatter, otherwise the inverse of `auto-exit` (agents that auto-exit are autonomous and get stall pings; agents that don't are interactive and stay quiet).",
+    }),
+  ),
+  resumeSessionId: Type.Optional(
+    Type.String({
+      description:
+        "Resume a previous Claude Code session by its ID. Loads the conversation history and continues where it left off. The session ID is returned in details of every claude tool call. Use this to retry cancelled runs or ask follow-up questions.",
+    }),
+  ),
+  structuredOutputSchema: Type.Optional(
+    // 用带 type:"object" 的定义，避免 Type.Any 无 type 导致 LLM 把对象
+    // 序列化成字符串（进而触发子进程 ajv.compile(字符串) 崩
+    // "schema must be object or boolean"）。
+    Type.Object(
+      {},
+      {
+        additionalProperties: true,
+        description:
+          "Optional JSON Schema object. When set, the sub-agent will be provisioned with a structured_output tool that validates its final arguments against this schema before returning. On validation failure the sub-agent sees the errors and can retry; on success the validated value is delivered via the .exit sidecar file.",
+      },
+    ),
+  ),
+});
+
+type SubagentSessionMode = "standalone" | "lineage-only" | "fork";
+
+interface AgentDefaults {
+  model?: string;
+  tools?: string;
+  skills?: string;
+  thinking?: string;
+  denyTools?: string;
+  spawning?: boolean;
+  autoExit?: boolean;
+  interactive?: boolean;
+  systemPromptMode?: "append" | "replace";
+  sessionMode?: SubagentSessionMode;
+  cwd?: string;
+  cli?: string;
+  body?: string;
+  disableModelInvocation?: boolean;
+}
+
+type AgentSource = "package" | "global" | "project";
+
+interface AgentDefinition extends AgentDefaults {
+  name: string;
+  description?: string;
+  disableModelInvocation: boolean;
+}
+
+interface ListedAgentDefinition extends AgentDefinition {
+  source: AgentSource;
+}
+
+/** Tools that are gated by `spawning: false` */
+const SPAWNING_TOOLS = new Set([
+  "subagent",
+  "subagent_interrupt",
+  "subagents_list",
+  "subagent_resume",
+]);
+
+/**
+ * Resolve the effective set of denied tool names from agent defaults.
+ * `spawning: false` expands to all SPAWNING_TOOLS.
+ * `deny-tools` adds individual tool names on top.
+ */
+function resolveDenyTools(agentDefs: AgentDefaults | null): Set<string> {
+  const denied = new Set<string>();
+  if (!agentDefs) return denied;
+
+  // spawning: false → deny all spawning tools
+  if (agentDefs.spawning === false) {
+    for (const t of SPAWNING_TOOLS) denied.add(t);
+  }
+
+  // deny-tools: explicit list
+  if (agentDefs.denyTools) {
+    for (const t of agentDefs.denyTools
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      denied.add(t);
+    }
+  }
+
+  return denied;
+}
+
+/** Resolve the global agent config directory, respecting PI_CODING_AGENT_DIR. */
+function getAgentConfigDir(): string {
+  return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}
+
+function getBundledAgentsDir(): string {
+  return join(SUBAGENTS_DIR, "../../agents");
+}
+
+function getFrontmatterValue(frontmatter: string, key: string): string | undefined {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match ? match[1].trim() : undefined;
+}
+
+function parseOptionalBoolean(value: string | undefined): boolean | undefined {
+  return value != null ? value === "true" : undefined;
+}
+
+function parseSessionMode(value: string | undefined): SubagentSessionMode | undefined {
+  if (value === "standalone" || value === "lineage-only" || value === "fork") {
+    return value;
+  }
+  return undefined;
+}
+
+function parseAgentDefinition(content: string, fallbackName: string): AgentDefinition | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+  const body = content.replace(/^---\n[\s\S]*?\n---\n*/, "").trim();
+  const systemPromptMode = getFrontmatterValue(frontmatter, "system-prompt");
+
+  return {
+    name: getFrontmatterValue(frontmatter, "name") ?? fallbackName,
+    description: getFrontmatterValue(frontmatter, "description"),
+    model: getFrontmatterValue(frontmatter, "model"),
+    tools: getFrontmatterValue(frontmatter, "tools"),
+    systemPromptMode:
+      systemPromptMode === "replace"
+        ? "replace"
+        : systemPromptMode === "append"
+          ? "append"
+          : undefined,
+    skills: getFrontmatterValue(frontmatter, "skill") ?? getFrontmatterValue(frontmatter, "skills"),
+    thinking: getFrontmatterValue(frontmatter, "thinking"),
+    denyTools: getFrontmatterValue(frontmatter, "deny-tools"),
+    spawning: parseOptionalBoolean(getFrontmatterValue(frontmatter, "spawning")),
+    autoExit: parseOptionalBoolean(getFrontmatterValue(frontmatter, "auto-exit")),
+    interactive: parseOptionalBoolean(getFrontmatterValue(frontmatter, "interactive")),
+    sessionMode: parseSessionMode(getFrontmatterValue(frontmatter, "session-mode")),
+    cwd: getFrontmatterValue(frontmatter, "cwd"),
+    cli: getFrontmatterValue(frontmatter, "cli"),
+    body: body || undefined,
+    disableModelInvocation:
+      getFrontmatterValue(frontmatter, "disable-model-invocation")?.toLowerCase() === "true",
+  };
+}
+
+function discoverAgentDefinitions(): ListedAgentDefinition[] {
+  const agents = new Map<string, ListedAgentDefinition>();
+  const dirs: Array<{ path: string; source: AgentSource }> = [
+    { path: getBundledAgentsDir(), source: "package" },
+    { path: join(getAgentConfigDir(), "agents"), source: "global" },
+    { path: join(process.cwd(), ".pi", "agents"), source: "project" },
+  ];
+
+  for (const { path: dir, source } of dirs) {
+    if (!existsSync(dir)) continue;
+    for (const file of readdirSync(dir).filter((entry) => entry.endsWith(".md"))) {
+      const parsed = parseAgentDefinition(
+        readFileSync(join(dir, file), "utf8"),
+        file.replace(/\.md$/, ""),
+      );
+      if (!parsed) continue;
+      agents.set(parsed.name, { ...parsed, source });
+    }
+  }
+
+  return [...agents.values()];
+}
+
+function resolveSubagentPaths(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): { effectiveCwd: string | null; localAgentDir: string | null; effectiveAgentDir: string } {
+  const rawCwd = params.cwd ?? agentDefs?.cwd ?? null;
+  const cwdIsFromAgent = !params.cwd && agentDefs?.cwd != null;
+  const cwdBase = cwdIsFromAgent ? getAgentConfigDir() : process.cwd();
+  const effectiveCwd = rawCwd
+    ? rawCwd.startsWith("/")
+      ? rawCwd
+      : join(cwdBase, rawCwd)
+    : null;
+  const localAgentDir = effectiveCwd ? join(effectiveCwd, ".pi", "agent") : null;
+  const effectiveAgentDir =
+    localAgentDir && existsSync(localAgentDir) ? localAgentDir : getAgentConfigDir();
+  return { effectiveCwd, localAgentDir, effectiveAgentDir };
+}
+
+function getDefaultSessionDirFor(cwd: string, _agentDir: string): string {
+  const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+  const sessionDir = join(homedir(), ".pi", "subagent-sessions", safePath);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  return sessionDir;
+}
+
+function resolveEffectiveSessionMode(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): SubagentSessionMode {
+  if (params.fork) return "fork";
+  return agentDefs?.sessionMode ?? "standalone";
+}
+
+function resolveLaunchBehavior(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): {
+  sessionMode: SubagentSessionMode;
+  seededSessionMode: "lineage-only" | "fork" | null;
+  inheritsConversationContext: boolean;
+  taskDelivery: "direct" | "artifact";
+} {
+  const sessionMode = resolveEffectiveSessionMode(params, agentDefs);
+  const inheritsConversationContext = sessionMode === "fork";
+  return {
+    sessionMode,
+    seededSessionMode: sessionMode === "standalone" ? null : sessionMode,
+    inheritsConversationContext,
+    taskDelivery: inheritsConversationContext ? "direct" : "artifact",
+  };
+}
+
+/**
+ * Decide whether a subagent is interactive (user-driven, long-running).
+ *
+ * Resolution order:
+ *   1. Explicit `interactive` tool parameter wins.
+ *   2. Explicit `interactive` frontmatter field on the agent.
+ *   3. Default: the inverse of `auto-exit`. Agents that auto-exit are
+ *      autonomous (scout, worker, reviewer) and the parent session should be
+ *      woken on stall/recovery transitions. Agents that don't auto-exit are
+ *      driven by the user in their own pane (planner, iterate/fork) and
+ *      stall pings are noise.
+ *
+ * When no agent defs exist at all (bare `subagent({ name, task })` call,
+ * typical for `/iterate` with `fork: true`), `autoExit` is undefined and the
+ * subagent is treated as interactive — matching the intent of iterate.
+ */
+function resolveEffectiveInteractive(
+  params: Static<typeof SubagentParams>,
+  agentDefs: AgentDefaults | null,
+): boolean {
+  if (params.interactive != null) return params.interactive;
+  if (agentDefs?.interactive != null) return agentDefs.interactive;
+  return !(agentDefs?.autoExit ?? false);
+}
+
+function loadAgentDefaults(agentName: string): AgentDefaults | null {
+  const configDir = getAgentConfigDir();
+  const paths = [
+    join(process.cwd(), ".pi", "agents", `${agentName}.md`),
+    join(configDir, "agents", `${agentName}.md`),
+    join(getBundledAgentsDir(), `${agentName}.md`),
+  ];
+
+  for (const p of paths) {
+    if (!existsSync(p)) continue;
+    const parsed = parseAgentDefinition(readFileSync(p, "utf8"), agentName);
+    if (parsed) return parsed;
+  }
+
+  return null;
+}
+
+function formatElapsed(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s}s`;
+}
+
+/**
+ * Wait long enough for a freshly created pane to finish shell startup.
+ *
+ * Some environments do extra shell-init work before the prompt is ready
+ * (for example direnv/devenv), so the delay is configurable for users who hit
+ * dropped commands. Keep the historical default at 500ms.
+ */
+function getShellReadyDelayMs(): number {
+  const raw = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS?.trim();
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+}
+
+/**
+ * Build the internal artifact directory path for the current session.
+ * Used by the subagents extension to stash task files, system prompts, and
+ * launch scripts for sub-agents. Path convention:
+ *   <sessionDir>/artifacts/<session-id>/
+ */
+function getArtifactDir(sessionDir: string, sessionId: string): string {
+  return join(sessionDir, "artifacts", sessionId);
+}
+
+const statusConfig = loadStatusConfig();
+
+function formatWidgetRightLabel(snapshot: StatusSnapshot): string {
+  if (snapshot.kind === "starting") return " starting… ";
+  if (snapshot.kind === "running") return ` running ${snapshot.elapsedText} `;
+  if (snapshot.kind === "active") {
+    const label = snapshot.activityLabel ?? snapshot.activeScope;
+    const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+    return label ? ` active · ${label}${duration} ` : " active ";
+  }
+  if (snapshot.kind === "waiting") {
+    const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+    const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+    return ` waiting${duration}${detail} `;
+  }
+
+  const detail = snapshot.statusLabel ? ` · ${snapshot.statusLabel}` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return ` stalled${detail}${duration} `;
+}
+
+function resolveResultPresentation(
+  result: Pick<SubagentResult, "exitCode" | "elapsed" | "summary" | "sessionFile">,
+  name: string,
+): string {
+  const sessionRef = result.sessionFile
+    ? `\n\nSession: ${result.sessionFile}\nResume: pi --session ${result.sessionFile}`
+    : "";
+
+  return result.exitCode !== 0
+    ? `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}${sessionRef}`
+    : `Sub-agent "${name}" completed (${formatElapsed(result.elapsed)}).\n\n${result.summary}${sessionRef}`;
+}
+
+/**
+ * Result from running a single subagent.
+ */
+interface SubagentResult {
+  name: string;
+  task: string;
+  summary: string;
+  sessionFile?: string;
+  claudeSessionId?: string;
+  exitCode: number;
+  elapsed: number;
+  error?: string;
+  ping?: { name: string; message: string };
+  /** Validated structured output (when subagent called structured_output tool) */
+  structuredOutput?: unknown;
+}
+
+/**
+ * State for a launched (but not yet completed) subagent.
+ */
+interface RunningSubagent {
+  id: string;
+  name: string;
+  task: string;
+  agent?: string;
+  surface: string;
+  startTime: number;
+  sessionFile: string;
+  launchScriptFile?: string;
+  activityFile?: string;
+  activity?: SubagentActivityState;
+  activityRead?: {
+    ok: boolean;
+    reason?: "missing" | "invalid" | "wrong-id";
+    error?: string;
+  };
+  abortController?: AbortController;
+  cli?: string;
+  sentinelFile?: string;
+  statusState: SubagentStatusState;
+  /**
+   * When true, status transitions (stalled/recovered) do not wake the parent
+   * session via a steer message. The widget still updates locally. Used for
+   * long-running agents where the user drives the conversation in the
+   * subagent's pane (e.g. planner).
+   */
+  interactive: boolean;
+  /** 新分屏的来源 pane ID，用于在 TUI 中展示 */
+  splitFrom?: string;
+}
+
+/** All currently running subagents, keyed by id. */
+const runningSubagents = new Map<string, RunningSubagent>();
+
+// ── Widget management ──
+
+/** Latest ExtensionContext from session_start, used for widget updates. */
+let latestCtx: ExtensionContext | null = null;
+
+/** Interval timer for widget re-renders. */
+let widgetInterval: ReturnType<typeof setInterval> | null = null;
+
+/** Interval timer for status transition checks. */
+let statusInterval: ReturnType<typeof setInterval> | null = null;
+
+function formatElapsedMMSS(startTime: number): string {
+  const seconds = Math.floor((Date.now() - startTime) / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+const ACCENT = "\x1b[38;2;77;163;255m";
+const RST = "\x1b[0m";
+
+/**
+ * Build a bordered content line: │left          right│
+ * Left content is truncated if needed, right is preserved, padded to fill width.
+ */
+function borderLine(left: string, right: string, width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}│${RST}`;
+
+  // width = total visible chars for the whole line including │ and │
+  const contentWidth = Math.max(0, width - 2); // space inside the two │ chars
+  const rightVis = visibleWidth(right);
+
+  // If the status chunk alone is too wide, prefer preserving it in compact form
+  // rather than overflowing the terminal.
+  if (rightVis >= contentWidth) {
+    const truncRight = truncateToWidth(right, contentWidth);
+    const rightPad = Math.max(0, contentWidth - visibleWidth(truncRight));
+    return `${ACCENT}│${RST}${truncRight}${" ".repeat(rightPad)}${ACCENT}│${RST}`;
+  }
+
+  const maxLeft = Math.max(0, contentWidth - rightVis);
+  const truncLeft = truncateToWidth(left, maxLeft);
+  const leftVis = visibleWidth(truncLeft);
+  const pad = Math.max(0, contentWidth - leftVis - rightVis);
+  return `${ACCENT}│${RST}${truncLeft}${" ".repeat(pad)}${right}${ACCENT}│${RST}`;
+}
+
+/**
+ * Build the bordered top line: ╭─ Title ──── info ─╮
+ * All chars are accounted for within `width`.
+ */
+function borderTop(title: string, info: string, width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}╭${RST}`;
+
+  // ╭─ Title ───...─── info ─╮
+  // overhead: ╭─ (2) + space around title (2) + space around info (2) + ─╮ (2) = but we simplify
+  const inner = Math.max(0, width - 2); // inside ╭ and ╮
+  const titlePart = `─ ${title} `;
+  const infoPart = ` ${info} ─`;
+  const fillLen = Math.max(0, inner - titlePart.length - infoPart.length);
+  const fill = "─".repeat(fillLen);
+  const content = `${titlePart}${fill}${infoPart}`.slice(0, inner).padEnd(inner, "─");
+  return `${ACCENT}╭${content}╮${RST}`;
+}
+
+/**
+ * Build the bordered bottom line: ╰──────────────────╯
+ */
+function borderBottom(width: number): string {
+  if (width <= 0) return "";
+  if (width === 1) return `${ACCENT}╰${RST}`;
+
+  const inner = Math.max(0, width - 2);
+  return `${ACCENT}╰${"─".repeat(inner)}╯${RST}`;
+}
+
+function renderSubagentWidgetLines(agents: RunningSubagent[], width: number): string[] {
+  const count = agents.length;
+  const title = "Subagents";
+  const info = `${count} running`;
+
+  const lines: string[] = [borderTop(title, info, width)];
+
+  for (const agent of agents) {
+    const elapsed = formatElapsedMMSS(agent.startTime);
+    const agentTag = agent.agent ? ` (${agent.agent})` : "";
+    const left = ` ${elapsed}  ${agent.name}${agentTag} `;
+    const snapshot = classifyStatus(agent.statusState, Date.now());
+    const right = statusConfig.enabled
+      ? formatWidgetRightLabel(snapshot)
+      : agent.cli === "claude"
+        ? " running… "
+        : " starting… ";
+
+    lines.push(borderLine(left, right, width));
+  }
+
+  lines.push(borderBottom(width));
+  return lines;
+}
+
+function updateWidget() {
+  if (!latestCtx?.hasUI) return;
+
+  if (runningSubagents.size === 0) {
+    latestCtx.ui.setWidget("subagent-status", undefined);
+    if (widgetInterval) {
+      clearInterval(widgetInterval);
+      widgetInterval = null;
+      (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+    }
+    return;
+  }
+
+  latestCtx.ui.setWidget(
+    "subagent-status",
+    (_tui: any, _theme: any) => {
+      return {
+        invalidate() {},
+        render(width: number) {
+          return renderSubagentWidgetLines(Array.from(runningSubagents.values()), width);
+        },
+      };
+    },
+    { placement: "aboveEditor" },
+  );
+}
+
+/**
+ * Build the positional prompt args for a Pi CLI subagent launch.
+ *
+ * In artifact-backed launches (lineage-only, standalone), Pi's buildInitialMessage()
+ * concatenates @file content with messages[0] into one initial prompt. That breaks
+ * /skill: expansion because the message no longer starts with "/skill:". Only
+ * messages[1..] are sent as separate follow-up prompts where /skill: is recognized.
+ *
+ * When there are skill prompts AND artifact-backed delivery, we prepend an empty
+ * first positional message so that /skill: args land in messages[1..] and arrive
+ * as standalone prompts in the child session.
+ */
+const SUBAGENT_CONTROL_TOOLS = ["caller_ping", "subagent_done"] as const;
+
+/**
+ * Build the child --tools allowlist.
+ *
+ * Pi 0.70+ applies --tools to built-in, extension, and custom tools. If a
+ * subagent definition restricts tools to e.g. "read,bash,write", the child
+ * control tools from subagent-done.ts would otherwise be hidden, leaving a
+ * manually resumed or user-touched subagent unable to call subagent_done.
+ */
+function buildSubagentToolAllowlist(effectiveTools?: string): string | null {
+  const requested = (effectiveTools ?? "")
+    .split(",")
+    .map((tool) => tool.trim())
+    .filter(Boolean);
+
+  if (requested.length === 0) return null;
+
+  const allow = new Set(requested);
+  for (const tool of SUBAGENT_CONTROL_TOOLS) {
+    allow.add(tool);
+  }
+
+  return [...allow].join(",");
+}
+
+function buildPiPromptArgs(params: {
+  effectiveSkills?: string;
+  taskDelivery: "direct" | "artifact";
+  taskArg: string;
+}): string[] {
+  const skillPrompts = (params.effectiveSkills ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((skill) => `/skill:${skill}`);
+
+  const needsSeparator = params.taskDelivery === "artifact" && skillPrompts.length > 0;
+
+  return [
+    ...(needsSeparator ? [""] : []),
+    ...skillPrompts,
+    params.taskArg,
+  ];
+}
+
+function activityLabel(activity: SubagentActivityState): string | undefined {
+  if (activity.phase !== "active") return undefined;
+  if (activity.activeScope === "tool") return activity.toolName ?? "tool";
+  if (activity.activeScope === "provider") return "provider";
+  if (activity.activeScope === "streaming") return "streaming";
+  return activity.activeScope;
+}
+
+/** 类型守卫：判别联合在 strictNullChecks 关闭时控制流收窄失效，用 predicate 强制收窄到失败分支。 */
+function isReadFailure(
+  r: ActivityReadResult,
+): r is { ok: false; reason: "missing" | "invalid" | "wrong-id"; error?: string } {
+  return !r.ok;
+}
+
+function observeRunningSubagent(running: RunningSubagent, observedAt = Date.now()) {
+  if (running.cli === "claude") return;
+
+  const activityFile = running.activityFile;
+  const read: ActivityReadResult = activityFile
+    ? readSubagentActivityFile(activityFile, running.id)
+    : { ok: false, reason: "missing" };
+
+  if (!isReadFailure(read)) {
+    running.activityRead = { ok: true };
+    running.activity = read.activity;
+    running.statusState = observeStatus(running.statusState, {
+      snapshot: "present",
+      updatedAt: read.activity.updatedAt,
+      sequence: read.activity.sequence,
+      phase: read.activity.phase,
+      active: read.activity.phase === "active",
+      activeScope: read.activity.activeScope,
+      activeSince: read.activity.activeSince,
+      waitingSince: read.activity.waitingSince,
+      latestEvent: read.activity.latestEvent,
+      activityLabel: activityLabel(read.activity),
+    }, observedAt);
+  } else {
+    running.activityRead = { ok: false, reason: read.reason, error: read.error };
+    running.statusState = observeStatus(running.statusState, {
+      snapshot: read.reason,
+      snapshotError: read.error,
+    }, observedAt);
+  }
+}
+
+function resolveInterruptTarget(params: { id?: string; name?: string }):
+  | { running: RunningSubagent }
+  | { error: string } {
+  const requestedId = params.id?.trim();
+  if (requestedId) {
+    const running = runningSubagents.get(requestedId);
+    return running ? { running } : { error: `No running subagent with id "${requestedId}".` };
+  }
+
+  const requestedName = params.name?.trim();
+  if (!requestedName) {
+    return { error: "Provide a running subagent id or exact display name." };
+  }
+
+  const matches = Array.from(runningSubagents.values()).filter((running) => running.name === requestedName);
+  if (matches.length === 1) return { running: matches[0] };
+  if (matches.length === 0) {
+    return { error: `No running subagent named "${requestedName}".` };
+  }
+
+  const candidates = matches.map((running) => `${running.name} [${running.id}]`).join(", ");
+  return { error: `Ambiguous subagent name "${requestedName}". Matches: ${candidates}` };
+}
+
+function requestSubagentInterrupt(
+  running: RunningSubagent,
+  sendEscapeKey: (surface: string) => void = sendEscape,
+): { ok: true } | { error: string } {
+  try {
+    sendEscapeKey(running.surface);
+    return { ok: true };
+  } catch (error: any) {
+    const backend = getMuxBackend() ?? "unknown";
+    return {
+      error:
+        `Failed to send Escape to subagent "${running.name}" via ${backend}: ` +
+        `${error?.message ?? String(error)}`,
+    };
+  }
+}
+
+interface InterruptResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: { error?: string; id?: string; name?: string; status?: string };
+}
+
+function handleSubagentInterrupt(
+  params: { id?: string; name?: string },
+  sendEscapeKey: (surface: string) => void = sendEscape,
+): InterruptResult {
+  const resolved = resolveInterruptTarget(params);
+  if ("error" in resolved) {
+    return {
+      content: [{ type: "text" as const, text: resolved.error }],
+      details: { error: resolved.error },
+    };
+  }
+
+  const running = resolved.running;
+  if (running.cli === "claude") {
+    return {
+      content: [{
+        type: "text" as const,
+        text:
+          "Turn-only Escape interrupt is currently supported only for Pi-backed subagents. Claude-backed semantics have not been verified yet.",
+      }],
+      details: { error: "claude interrupt unsupported", id: running.id, name: running.name },
+    };
+  }
+
+  const now = Date.now();
+  observeRunningSubagent(running, now);
+
+  const interruption = requestSubagentInterrupt(running, sendEscapeKey);
+  if ("error" in interruption) {
+    return {
+      content: [{ type: "text" as const, text: interruption.error }],
+      details: { error: interruption.error, id: running.id, name: running.name },
+    };
+  }
+
+  running.statusState = forceStatusAfterInterrupt(running.statusState, now);
+  updateWidget();
+
+  // After aborting the current generation, also signal done so the subagent
+  // properly finishes (parent's pollForExit detects the .exit file and
+  // returns the result).
+  if (running.sessionFile) {
+    const exitFile = `${running.sessionFile}.exit`;
+    try {
+      writeFileSync(exitFile, JSON.stringify({ type: "done" }));
+    } catch (writeErr: any) {
+      process.stderr.write(
+        `[interrupt] .exit 写入失败 file=${exitFile} err=${writeErr?.message ?? String(writeErr)}\n`,
+      );
+    }
+  }
+
+  return {
+    content: [{ type: "text" as const, text: `Interrupt requested for subagent "${running.name}".` }],
+    details: { id: running.id, name: running.name, status: "interrupt_requested" },
+  };
+}
+
+function startStatusRefresh(pi: ExtensionAPI) {
+  if (!statusConfig.enabled || statusInterval) return;
+
+  statusInterval = setInterval(() => {
+    if (runningSubagents.size === 0) {
+      if (statusInterval) {
+        clearInterval(statusInterval);
+        statusInterval = null;
+        (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+      }
+      return;
+    }
+
+    const transitionLines: string[] = [];
+    const now = Date.now();
+    let shouldRefreshWidget = false;
+
+    for (const running of runningSubagents.values()) {
+      observeRunningSubagent(running, now);
+      const { nextState, snapshot, transition } = advanceStatusState(running.statusState, now);
+      if (nextState.currentKind !== running.statusState.currentKind) {
+        shouldRefreshWidget = true;
+      }
+      running.statusState = nextState;
+
+      // Interactive subagents (long-running, user-driven) intentionally don't
+      // wake the parent session on stalled/recovered transitions — the user is
+      // working in the subagent's pane, and a steer message here would burn an
+      // orchestrator turn on a no-op "still waiting" ping. Widget still updates.
+      if (transition && !running.interactive) {
+        transitionLines.push(formatTransitionLine(running.name, snapshot, transition));
+      }
+    }
+
+    if (shouldRefreshWidget) updateWidget();
+
+    if (transitionLines.length > 0) {
+      const capped = capStatusLines(transitionLines, statusConfig.lineLimit);
+      pi.sendMessage(
+        {
+          customType: "subagent_status",
+          content: formatStatusAggregate(transitionLines, statusConfig.lineLimit),
+          display: true,
+          details: { lines: capped.visibleLines, overflow: capped.overflow },
+        },
+        { triggerTurn: true, deliverAs: "steer" },
+      );
+    }
+  }, 1000);
+
+  (globalThis as any)[STATUS_INTERVAL_KEY] = statusInterval;
+}
+
+function resolveResumeLaunchBehavior(params: { autoExit?: boolean }): { autoExit: boolean; interactive: boolean } {
+  const autoExit = params.autoExit ?? true;
+  return { autoExit, interactive: !autoExit };
+}
+
+export const __test__ = {
+  borderLine,
+  getShellReadyDelayMs,
+  renderSubagentWidgetLines,
+  loadAgentDefaults,
+  discoverAgentDefinitions,
+  resolveEffectiveSessionMode,
+  resolveLaunchBehavior,
+  resolveEffectiveInteractive,
+  buildSubagentToolAllowlist,
+  buildPiPromptArgs,
+  formatWidgetRightLabel,
+  observeRunningSubagent,
+  resolveDenyTools,
+  resolveInterruptTarget,
+  requestSubagentInterrupt,
+  handleSubagentInterrupt,
+  resolveResultPresentation,
+  resolveResumeLaunchBehavior,
+  runningSubagents,
+};
+
+function startWidgetRefresh() {
+  if (widgetInterval) return;
+  updateWidget(); // immediate first render
+  widgetInterval = setInterval(() => {
+    updateWidget();
+  }, 1000);
+  (globalThis as any)[WIDGET_INTERVAL_KEY] = widgetInterval;
+}
+
+/**
+ * Launch a subagent: creates the multiplexer pane, builds the command, and
+ * sends it. Returns a RunningSubagent — does NOT poll.
+ *
+ * Call watchSubagent() on the returned object to observe completion.
+ */
+async function launchSubagent(
+  params: typeof SubagentParams.static,
+  ctx: { sessionManager: { getSessionFile(): string | null; getSessionId(): string; getSessionDir(): string }; cwd: string },
+  options?: { surface?: string },
+): Promise<RunningSubagent> {
+  const startTime = Date.now();
+  const id = Math.random().toString(16).slice(2, 10);
+
+  const agentDefs = params.agent ? loadAgentDefaults(params.agent) : null;
+  const effectiveModel = params.model ?? agentDefs?.model ?? getDefaultSubagentModel();
+  const effectiveTools = params.tools ?? agentDefs?.tools;
+  const effectiveSkills = params.skills ?? agentDefs?.skills;
+  const effectiveThinking = agentDefs?.thinking;
+  const effectiveInteractive = resolveEffectiveInteractive(params, agentDefs);
+
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  if (!sessionFile) throw new Error("No session file");
+  const sessionId = ctx.sessionManager.getSessionId();
+  const artifactDir = getArtifactDir(ctx.sessionManager.getSessionDir(), sessionId);
+
+  const { effectiveCwd, localAgentDir, effectiveAgentDir } = resolveSubagentPaths(params, agentDefs);
+  const targetCwdForSession = effectiveCwd ?? ctx.cwd;
+  const sessionDir = getDefaultSessionDirFor(targetCwdForSession, effectiveAgentDir);
+
+  // Generate a deterministic session file path for this subagent.
+  // This eliminates race conditions when multiple agents launch simultaneously —
+  // each agent knows exactly which file is theirs.
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 23) + "Z";
+  const uuid = [
+    id,
+    Math.random().toString(16).slice(2, 10),
+    Math.random().toString(16).slice(2, 10),
+    Math.random().toString(16).slice(2, 6),
+  ].join("-");
+  const subagentSessionFile = join(sessionDir, `${timestamp}_${uuid}.jsonl`);
+
+  // Use pre-created surface (parallel mode) or create a new one.
+  // For new surfaces, pause briefly so the shell is ready before sending the command.
+  const surfacePreCreated = !!options?.surface;
+  const surface = options?.surface ?? createSurface(params.name);
+  const splitFrom = surfacePreCreated ? undefined : (getLastSplitSource() ?? undefined);
+  if (!surfacePreCreated) clearLastSplitSource();
+  if (!surfacePreCreated) {
+    await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
+  }
+
+  const launchBehavior = resolveLaunchBehavior(params, agentDefs);
+
+  if (launchBehavior.seededSessionMode) {
+    seedSubagentSessionFile({
+      mode: launchBehavior.seededSessionMode,
+      parentSessionFile: sessionFile,
+      childSessionFile: subagentSessionFile,
+      childCwd: targetCwdForSession,
+    });
+  }
+
+  const activityFile = getSubagentActivityFile(artifactDir, id);
+  mkdirSync(dirname(activityFile), { recursive: true });
+  const { inheritsConversationContext } = launchBehavior;
+
+  // Build the task message
+  // Only full-context fork mode inherits prior conversation state.
+  // Blank-session modes need the wrapper instructions and artifact-backed handoff.
+  const modeHint = agentDefs?.autoExit
+    ? "Complete your task autonomously."
+    : "Complete your task. When finished, call the subagent_done tool. The user can interact with you at any time.";
+  const summaryInstruction = agentDefs?.autoExit
+    ? "Your FINAL assistant message should summarize what you accomplished."
+    : "Your FINAL assistant message (before calling subagent_done or before the user exits) should summarize what you accomplished.";
+  const denySet = resolveDenyTools(agentDefs);
+  const identity = agentDefs?.body ?? params.systemPrompt ?? null;
+  const systemPromptMode = agentDefs?.systemPromptMode;
+  const identityInSystemPrompt = systemPromptMode && identity;
+  const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
+  const fullTask = inheritsConversationContext
+    ? params.task
+    : `${roleBlock}\n\n${modeHint}\n\n${params.task}\n\n${summaryInstruction}`;
+  // ── Claude Code CLI path ──
+  if (agentDefs?.cli === "claude") {
+    const sentinelFile = `/tmp/pi-claude-${id}-done`;
+    const pluginDir = join(SUBAGENTS_DIR, "plugin");
+
+    const cmdParts: string[] = [];
+    cmdParts.push(`PI_CLAUDE_SENTINEL=${shellEscape(sentinelFile)}`);
+    cmdParts.push("claude");
+    cmdParts.push("--dangerously-skip-permissions");
+
+    if (existsSync(pluginDir)) {
+      cmdParts.push("--plugin-dir", shellEscape(pluginDir));
+    }
+
+    if (effectiveModel) {
+      cmdParts.push("--model", shellEscape(effectiveModel));
+    }
+
+    const sp = params.systemPrompt ?? agentDefs.body;
+    if (sp) {
+      cmdParts.push("--append-system-prompt", shellEscape(sp));
+    }
+
+    if (params.resumeSessionId) {
+      cmdParts.push("--resume", shellEscape(params.resumeSessionId));
+    }
+
+    // Always pass the task as the prompt — even for resumed sessions,
+    // the caller's task is the follow-up instruction.
+    cmdParts.push(shellEscape(params.task));
+
+    const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
+    const command = `${cdPrefix}${cmdParts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+
+    const launchScriptName = `${(params.name || "subagent")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+    const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
+
+    sendLongCommand(surface, command, {
+      scriptPath: launchScriptFile,
+      scriptPreamble: [
+        `# Claude Code subagent launch script for ${params.name}`,
+        `# Generated: ${new Date().toISOString()}`,
+        `# Surface: ${surface}`,
+      ].join("\n"),
+    });
+
+    const running: RunningSubagent = {
+      id,
+      name: params.name,
+      task: params.task,
+      agent: params.agent,
+      surface,
+      startTime,
+      sessionFile: subagentSessionFile,
+      launchScriptFile,
+      cli: "claude",
+      sentinelFile,
+      interactive: effectiveInteractive,
+      splitFrom,
+      statusState: createStatusState({
+        source: "claude",
+        startTimeMs: startTime,
+      }),
+    };
+
+    runningSubagents.set(id, running);
+    return running;
+  }
+
+  // ── Pi CLI path ──
+
+  // Build pi command
+  const parts: string[] = ["pi"];
+  parts.push("--session", shellEscape(subagentSessionFile));
+
+  const subagentDonePath = join(SUBAGENTS_DIR, "subagent-done.ts");
+  parts.push("-e", shellEscape(subagentDonePath));
+
+  if (effectiveModel) {
+    const model = effectiveThinking ? `${effectiveModel}:${effectiveThinking}` : effectiveModel;
+    parts.push("--model", shellEscape(model));
+  }
+
+  // Pass agent body as system prompt via file to avoid shell escaping issues
+  // with multiline content. Pi's --append-system-prompt and --system-prompt
+  // auto-detect file paths and read their contents.
+  if (identityInSystemPrompt && identity) {
+    const flag = systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt";
+    const spTimestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const spSafeName = params.name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+    const syspromptPath = join(artifactDir, `context/${spSafeName || "subagent"}-sysprompt-${spTimestamp}.md`);
+    mkdirSync(dirname(syspromptPath), { recursive: true });
+    writeFileSync(syspromptPath, identity, "utf8");
+    parts.push(flag, shellEscape(syspromptPath));
+  }
+
+  const toolAllowlist = buildSubagentToolAllowlist(effectiveTools);
+  if (toolAllowlist) {
+    parts.push("--tools", shellEscape(toolAllowlist));
+  }
+
+  // Build env prefix: denied tools + subagent identity + config dir propagation
+  const envParts: string[] = [];
+
+  // If the target cwd has its own .pi/agent/, use that as the config root.
+  // Otherwise propagate the current/global agent dir.
+  if (localAgentDir && existsSync(localAgentDir)) {
+    envParts.push(`PI_CODING_AGENT_DIR=${shellEscape(localAgentDir)}`);
+  } else if (process.env.PI_CODING_AGENT_DIR) {
+    envParts.push(`PI_CODING_AGENT_DIR=${shellEscape(process.env.PI_CODING_AGENT_DIR)}`);
+  }
+
+  if (denySet.size > 0) {
+    envParts.push(`PI_DENY_TOOLS=${shellEscape([...denySet].join(","))}`);
+  }
+  envParts.push(`PI_SUBAGENT_NAME=${shellEscape(params.name)}`);
+  if (params.agent) {
+    envParts.push(`PI_SUBAGENT_AGENT=${shellEscape(params.agent)}`);
+  }
+  if (agentDefs?.autoExit) {
+    envParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+  }
+  envParts.push(`PI_SUBAGENT_SESSION=${shellEscape(subagentSessionFile)}`);
+  envParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+  envParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+  envParts.push(`PI_SUBAGENT_SURFACE=${shellEscape(surface)}`);
+  if (params.structuredOutputSchema) {
+    envParts.push(
+      `PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA=${shellEscape(JSON.stringify(params.structuredOutputSchema))}`,
+    );
+  }
+  const envPrefix = envParts.join(" ") + " ";
+
+  // Pass task and skill prompts to the sub-agent.
+  // Only full-context fork mode gets a direct task argument because it already
+  // inherits the parent conversation. Blank-session modes use artifact-backed
+  // handoff so the wrapper instructions arrive as the initial user message.
+  let taskArg: string;
+  if (launchBehavior.taskDelivery === "direct") {
+    taskArg = fullTask;
+  } else {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+    const safeName = params.name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "") // strip everything except alphanumeric, spaces, hyphens
+      .replace(/\s+/g, "-") // spaces to hyphens
+      .replace(/-+/g, "-") // collapse multiple hyphens
+      .replace(/^-|-$/g, ""); // trim leading/trailing hyphens
+    const artifactName = `context/${safeName || "subagent"}-${timestamp}.md`;
+    const artifactPath = join(artifactDir, artifactName);
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    writeFileSync(artifactPath, fullTask, "utf8");
+    taskArg = `@${artifactPath}`;
+  }
+
+  for (const promptArg of buildPiPromptArgs({
+    effectiveSkills,
+    taskDelivery: launchBehavior.taskDelivery,
+    taskArg,
+  })) {
+    parts.push(shellEscape(promptArg));
+  }
+
+  // Resolve cwd — param overrides agent default, supports absolute and relative paths.
+  // This was already computed above so session placement, PI_CODING_AGENT_DIR, and cd agree.
+  const cdPrefix = effectiveCwd ? `cd ${shellEscape(effectiveCwd)} && ` : "";
+
+  const piCommand = cdPrefix + envPrefix + parts.join(" ");
+  const command = `${piCommand}; echo '__SUBAGENT_DONE_'$?'__'`;
+  const launchScriptName = `${(params.name || "subagent")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "subagent"}-${id}.sh`;
+  const launchScriptFile = join(artifactDir, "subagent-scripts", launchScriptName);
+  sendLongCommand(surface, command, {
+    scriptPath: launchScriptFile,
+    scriptPreamble: [
+      `# Subagent launch script for ${params.name}`,
+      `# Generated: ${new Date().toISOString()}`,
+      `# Session: ${subagentSessionFile}`,
+      `# Surface: ${surface}`,
+    ].join("\n"),
+  });
+
+  // 延迟重命名 agent 标题（左侧侧栏），需要等 pi 启动被 herdr 检测到
+  const agentName = params.name;
+  const agentSurface = surface;
+  setTimeout(() => renameAgent(agentSurface, agentName), 3000);
+  setTimeout(() => renameAgent(agentSurface, agentName), 5000);
+
+  const running: RunningSubagent = {
+    id,
+    name: params.name,
+    task: params.task,
+    agent: params.agent,
+    surface,
+    startTime,
+    sessionFile: subagentSessionFile,
+    launchScriptFile,
+    activityFile,
+    interactive: effectiveInteractive,
+    splitFrom,
+    statusState: createStatusState({
+      source: "pi",
+      startTimeMs: startTime,
+    }),
+  };
+
+  runningSubagents.set(id, running);
+  return running;
+}
+
+/**
+ * Watch a launched subagent until it exits. Polls for completion, extracts
+ * the summary from the session file, cleans up the surface,
+ * and removes the entry from runningSubagents.
+ */
+const CLAUDE_SESSIONS_DIR = join(
+  process.env.HOME ?? "/tmp",
+  ".pi", "agent", "sessions", "claude-code",
+);
+
+function copyClaudeSession(sentinelFile: string): string | null {
+  try {
+    const transcriptFile = sentinelFile + ".transcript";
+    if (!existsSync(transcriptFile)) return null;
+    const transcriptPath = readFileSync(transcriptFile, "utf-8").trim();
+    if (!transcriptPath || !existsSync(transcriptPath)) return null;
+    mkdirSync(CLAUDE_SESSIONS_DIR, { recursive: true });
+    const filename = transcriptPath.split("/").pop() ?? `claude-${Date.now()}.jsonl`;
+    const dest = join(CLAUDE_SESSIONS_DIR, filename);
+    copyFileSync(transcriptPath, dest);
+    return filename;
+  } catch {
+    return null;
+  }
+}
+
+async function watchSubagent(
+  running: RunningSubagent,
+  signal: AbortSignal,
+): Promise<SubagentResult> {
+  const { name, task, surface, startTime, sessionFile } = running;
+
+  // ── 诊断日志：检查 module abort controller 状态 ──
+  // 若 session_shutdown 调用了 moduleAbort.abort() 但 session_start 没重置，
+  // watchSubagent 会拿到 aborted signal，子 pi 来不及启动就被 close。
+  const moduleSig = getModuleAbortSignal();
+  const compositeSig = AbortSignal.any([signal, moduleSig]);
+  muxLog(`[watchSubagent] ENTER surface=${surface} session=${sessionFile} callerSignal.aborted=${signal.aborted} moduleSignal.aborted=${moduleSig.aborted} compositeSignal.aborted=${compositeSig.aborted}\n`);
+
+  try {
+    const result = await pollForExit(surface, compositeSig, {
+      interval: 1000,
+      sessionFile,
+      sentinelFile: running.sentinelFile,
+      onTick() {
+        observeRunningSubagent(running);
+      },
+    });
+
+    const elapsed = Math.floor((Date.now() - startTime) / 1000);
+
+    if (running.cli === "claude") {
+      // Claude Code result extraction
+      let summary = "";
+
+      if (running.sentinelFile) {
+        try {
+          summary = readFileSync(running.sentinelFile, "utf-8").trim();
+        } catch {}
+      }
+
+      if (!summary) {
+        summary = readScreen(surface, 200)
+          .replace(/__SUBAGENT_DONE_\d+__/, "")
+          .trimEnd();
+      }
+
+      if (!summary) {
+        summary = result.exitCode !== 0
+          ? `Claude Code exited with code ${result.exitCode}`
+          : "Claude Code exited without output";
+      }
+
+      // Copy Claude session transcript
+      let sessionId: string | null = null;
+      if (running.sentinelFile) {
+        sessionId = copyClaudeSession(running.sentinelFile);
+        try { unlinkSync(running.sentinelFile); } catch {}
+        try { unlinkSync(running.sentinelFile + ".transcript"); } catch {}
+      }
+
+      closeSurface(surface);
+      runningSubagents.delete(running.id);
+
+      return { name, task, summary, exitCode: result.exitCode, elapsed, ...(sessionId ? { claudeSessionId: sessionId } : {}) };
+    }
+
+    // Pi subagent result extraction
+    let summary: string;
+    let structuredOutput: unknown;
+    if (existsSync(sessionFile)) {
+      const allEntries = getNewEntries(sessionFile, 0);
+      summary =
+        findLastAssistantMessage(allEntries) ??
+        (result.exitCode !== 0
+          ? `Sub-agent exited with code ${result.exitCode}`
+          : "Sub-agent exited without output");
+    } else {
+      summary =
+        result.exitCode !== 0
+          ? `Sub-agent exited with code ${result.exitCode}`
+          : "Sub-agent exited without output";
+    }
+
+    // Extract structured output if the subagent used the structured_output tool
+    if (result.reason === "structured_output") {
+      structuredOutput = result.structuredOutput;
+    }
+
+    closeSurface(surface);
+    runningSubagents.delete(running.id);
+
+    return {
+      name,
+      task,
+      summary,
+      sessionFile,
+      exitCode: result.exitCode,
+      elapsed,
+      ping: result.ping,
+      ...(structuredOutput !== undefined ? { structuredOutput } : {}),
+    };
+  } catch (err: any) {
+    try {
+      closeSurface(surface);
+    } catch (closeErr: any) {
+      // closeSurface 失败 → pane 可能残留！让用户事后能看到。
+      const sessionRef = running.sessionFile ?? "<no-session>";
+      process.stderr.write(
+        `[watchSubagent] closeSurface FAILED surface=${surface} session=${sessionRef} err=${closeErr?.message ?? String(closeErr)}\n`,
+      );
+    }
+    runningSubagents.delete(running.id);
+
+    if (signal.aborted) {
+      return {
+        name,
+        task,
+        summary: "Subagent cancelled.",
+        exitCode: 1,
+        elapsed: Math.floor((Date.now() - startTime) / 1000),
+        error: "cancelled",
+        sessionFile,
+      };
+    }
+    return {
+      name,
+      task,
+      summary: `Subagent error: ${err?.message ?? String(err)}`,
+      exitCode: 1,
+      elapsed: Math.floor((Date.now() - startTime) / 1000),
+      error: err?.message ?? String(err),
+    };
+  }
+}
+
+export default function subagentsExtension(pi: ExtensionAPI) {
+  // Expose launchSubagent / watchSubagent for programmatic use by other extensions
+  (globalThis as any).__pi_subagents = { launchSubagent, watchSubagent };
+
+  // Capture the UI context for widget updates
+  pi.on("session_start", (_event, ctx) => {
+    latestCtx = ctx;
+  });
+
+  // Clean up on session shutdown
+  pi.on("session_shutdown", (_event, _ctx) => {
+    if (widgetInterval) {
+      clearInterval(widgetInterval);
+      widgetInterval = null;
+      (globalThis as any)[WIDGET_INTERVAL_KEY] = null;
+    }
+    if (statusInterval) {
+      clearInterval(statusInterval);
+      statusInterval = null;
+      (globalThis as any)[STATUS_INTERVAL_KEY] = null;
+    }
+    const moduleAbort = (globalThis as any)[POLL_ABORT_KEY] as AbortController | undefined;
+    if (moduleAbort) moduleAbort.abort();
+    for (const [_id, agent] of runningSubagents) {
+      agent.abortController?.abort();
+    }
+    runningSubagents.clear();
+  });
+
+  // Tools denied via PI_DENY_TOOLS env var (set by parent agent based on frontmatter)
+  const deniedTools = new Set(
+    (process.env.PI_DENY_TOOLS ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+
+  const shouldRegister = (name: string) => !deniedTools.has(name);
+
+  // ── subagent tool ──
+  if (shouldRegister("subagent"))
+    pi.registerTool({
+      name: "subagent",
+      label: "Subagent",
+      description:
+        "Spawn a sub-agent in a background process or terminal multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
+        "DO NOT fabricate, assume, or summarize results after calling this tool. " +
+        "After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
+      promptSnippet:
+        "Spawn a sub-agent in a background process or terminal multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
+        "DO NOT fabricate, assume, or summarize results after calling this tool. " +
+        "After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
+      parameters: SubagentParams,
+
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        // Prevent self-spawning (e.g. planner spawning another planner)
+        const currentAgent = process.env.PI_SUBAGENT_AGENT;
+        if (params.agent && currentAgent && params.agent === currentAgent) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `You are the ${currentAgent} agent — do not start another ${currentAgent}. You were spawned to do this work yourself. Complete the task directly.`,
+              },
+            ],
+            details: { error: "self-spawn blocked" },
+          };
+        }
+
+        if (!ctx.sessionManager.getSessionFile()) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Error: no session file. Start pi with a persistent session to use subagents.",
+              },
+            ],
+            details: { error: "no session file" },
+          };
+        }
+
+        // Launch the subagent (creates pane, sends command)
+        const running = await launchSubagent(params, ctx);
+
+        // Create a separate AbortController for the watcher
+        // (the tool's signal completes when we return)
+        const watcherAbort = new AbortController();
+        running.abortController = watcherAbort;
+
+        // Start widget refresh and status supervision when the first agent launches
+        startWidgetRefresh();
+        startStatusRefresh(pi);
+
+        // Fire-and-forget: start watching in background
+        watchSubagent(running, watcherAbort.signal)
+          .then((result) => {
+            updateWidget(); // reflect removal from Map immediately
+
+            if (result.ping) {
+              // Subagent is requesting help — steer a ping message with session path for resume
+              const sessionRef = `\n\nSession: ${result.sessionFile}\nResume: pi --session ${result.sessionFile}`;
+              pi.sendMessage(
+                {
+                  customType: "subagent_ping",
+                  content: `Sub-agent "${result.ping.name}" needs help (${formatElapsed(result.elapsed)}):\n\n${result.ping.message}${sessionRef}`,
+                  display: true,
+                  details: {
+                    name: result.ping.name,
+                    message: result.ping.message,
+                    agent: running.agent,
+                    sessionFile: result.sessionFile,
+                  },
+                },
+                { triggerTurn: true, deliverAs: "steer" },
+              );
+              return;
+            }
+
+            const presentation = resolveResultPresentation(result, running.name);
+
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: presentation,
+                display: true,
+                details: {
+                  name: running.name,
+                  task: running.task,
+                  agent: running.agent,
+                  exitCode: result.exitCode,
+                  elapsed: result.elapsed,
+                  sessionFile: result.sessionFile,
+                  ...(result.claudeSessionId ? { claudeSessionId: result.claudeSessionId } : {}),
+                  ...(result.structuredOutput !== undefined ? { structuredOutput: result.structuredOutput } : {}),
+                },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          })
+          .catch((err) => {
+            updateWidget();
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: `Sub-agent "${running.name}" error: ${err?.message ?? String(err)}`,
+                display: true,
+                details: { name: running.name, task: running.task, error: err?.message },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          });
+
+        // Return immediately
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Sub-agent "${params.name}" launched and is now running in the background. ` +
+                `Do NOT generate or assume any results — you have no idea what the sub-agent will do or produce. ` +
+                `The results will be delivered to you automatically as a steer message when the sub-agent finishes. ` +
+                `Until then, move on to other work or tell the user you're waiting.`,
+            },
+          ],
+          details: {
+            id: running.id,
+            name: params.name,
+            task: params.task,
+            agent: params.agent,
+            sessionFile: running.sessionFile,
+            launchScriptFile: running.launchScriptFile,
+            surface: running.surface,
+            splitFrom: running.splitFrom,
+            status: "started",
+          },
+        };
+      },
+
+      renderCall(args, theme) {
+        const partialArgs = args as Record<string, unknown>;
+        const name = typeof partialArgs.name === "string" && partialArgs.name ? partialArgs.name : "(unnamed)";
+        const task = typeof partialArgs.task === "string" ? partialArgs.task : "";
+        const agent = typeof partialArgs.agent === "string" && partialArgs.agent
+          ? theme.fg("dim", ` (${partialArgs.agent})`)
+          : "";
+        const cwdHint = typeof partialArgs.cwd === "string" && partialArgs.cwd
+          ? theme.fg("dim", ` in ${partialArgs.cwd}`)
+          : "";
+        let text =
+          "▸ " +
+          theme.fg("toolTitle", theme.bold(name)) +
+          agent +
+          cwdHint;
+
+        // Show a one-line task preview. renderCall is called repeatedly as the
+        // LLM generates tool arguments, so args.task grows token by token.
+        // We keep it compact here — Ctrl+O on renderResult expands the full content.
+        if (task) {
+          const firstLine = task.split("\n").find((l: string) => l.trim()) ?? "";
+          const preview = firstLine.length > 100 ? firstLine.slice(0, 100) + "…" : firstLine;
+          if (preview) {
+            text += "\n" + theme.fg("toolOutput", preview);
+          }
+          const totalLines = task.split("\n").length;
+          if (totalLines > 1) {
+            text += theme.fg("muted", ` (${totalLines} lines)`);
+          }
+        }
+
+        return new Text(text, 0, 0);
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        const name = details?.name ?? "(unnamed)";
+
+        // "Started" result — tool returned immediately
+        if (details?.status === "started") {
+          const splitHint = details?.splitFrom
+            ? theme.fg("dim", ` (from ${details.splitFrom})`)
+            : "";
+          return new Text(
+            theme.fg("accent", "▸") +
+              " " +
+              theme.fg("toolTitle", theme.bold(name)) +
+              theme.fg("dim", " — started") +
+              splitHint,
+            0,
+            0,
+          );
+        }
+
+        // Fallback (shouldn't happen)
+        const text = extractFirstText(result.content);
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+    });
+
+  // ── subagent_interrupt tool ──
+  if (shouldRegister("subagent_interrupt"))
+    pi.registerTool({
+      name: "subagent_interrupt",
+      label: "Interrupt Subagent",
+      description:
+        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
+        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
+        "and does not emit a subagent_result solely because of this request.",
+      promptSnippet:
+        "Send Escape to the active turn of a currently running Pi-backed subagent. " +
+        "The child pane, session, watcher, and running entry remain alive; this returns only a local acknowledgement " +
+        "and does not emit a subagent_result solely because of this request.",
+      parameters: Type.Object({
+        id: Type.Optional(Type.String({ description: "Exact running subagent id" })),
+        name: Type.Optional(Type.String({ description: "Exact running subagent display name" })),
+      }),
+
+      async execute(_toolCallId, params) {
+        return handleSubagentInterrupt(params);
+      },
+
+      renderCall(args, theme) {
+        const target = args.id ? `${args.id}` : args.name ?? "(unknown)";
+        return new Text(
+          theme.fg("accent", "▸") +
+            " " +
+            theme.fg("toolTitle", theme.bold(target)) +
+            theme.fg("dim", " — interrupt turn"),
+          0,
+          0,
+        );
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        if (details?.status === "interrupt_requested") {
+          return new Text(
+            theme.fg("accent", "▸") +
+              " " +
+              theme.fg("toolTitle", theme.bold(details.name ?? details.id ?? "subagent")) +
+              theme.fg("dim", " — interrupt requested"),
+            0,
+            0,
+          );
+        }
+
+        const text = extractFirstText(result.content);
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+    });
+
+  // ── subagents_list tool ──
+  if (shouldRegister("subagents_list"))
+    pi.registerTool({
+      name: "subagents_list",
+      label: "List Subagents",
+      description:
+        "List all available subagent definitions. " +
+        "Scans project-local .pi/agents/ and global ~/.pi/agent/agents/. " +
+        "Project-local agents override global ones with the same name.",
+      promptSnippet:
+        "List all available subagent definitions. " +
+        "Scans project-local .pi/agents/ and global ~/.pi/agent/agents/. " +
+        "Project-local agents override global ones with the same name.",
+      parameters: Type.Object({}),
+
+      async execute() {
+        const list = discoverAgentDefinitions().filter((agent) => !agent.disableModelInvocation);
+
+        if (list.length === 0) {
+          return {
+            content: [{ type: "text", text: "No subagent definitions found." }],
+            details: { agents: [] },
+          };
+        }
+
+        const lines = list.map((a) => {
+          const badge = a.source === "project" ? " (project)" : "";
+          const desc = a.description ? ` — ${a.description}` : "";
+          const model = a.model ? ` [${a.model}]` : "";
+          return `• ${a.name}${badge}${model}${desc}`;
+        });
+
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+          details: { agents: list },
+        };
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        const agents = details?.agents ?? [];
+        if (agents.length === 0) {
+          return new Text(theme.fg("dim", "No subagent definitions found."), 0, 0);
+        }
+        const lines = agents.map((a: any) => {
+          const badge = a.source === "project" ? theme.fg("accent", " (project)") : "";
+          const desc = a.description ? theme.fg("dim", ` — ${a.description}`) : "";
+          const model = a.model ? theme.fg("dim", ` [${a.model}]`) : "";
+          return `  ${theme.fg("toolTitle", theme.bold(a.name))}${badge}${model}${desc}`;
+        });
+        return new Text(lines.join("\n"), 0, 0);
+      },
+    });
+
+
+
+  // ── subagent_resume tool ──
+  if (shouldRegister("subagent_resume"))
+    pi.registerTool({
+      name: "subagent_resume",
+      label: "Resume Subagent",
+      description:
+        "Resume a previous sub-agent session in a background process or new multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the resumed sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT poll for status. All of that is wasted work — the harness delivers the result for you. " +
+        "DO NOT fabricate or assume results. After resuming, either end your turn or work on other independent tasks; the harness will wake you when the result is ready. " +
+        "Use when a sub-agent was cancelled or needs follow-up work.",
+      promptSnippet:
+        "Resume a previous sub-agent session in a background process or new multiplexer pane. " +
+        "This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
+        "When the resumed sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
+        "DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT poll for status. All of that is wasted work — the harness delivers the result for you. " +
+        "DO NOT fabricate or assume results. After resuming, either end your turn or work on other independent tasks; the harness will wake you when the result is ready. " +
+        "Use when a sub-agent was cancelled or needs follow-up work.",
+      parameters: Type.Object({
+        sessionPath: Type.String({ description: "Path to the session .jsonl file to resume" }),
+        name: Type.Optional(
+          Type.String({ description: "Display name for the terminal tab. Default: 'Resume'" }),
+        ),
+        message: Type.Optional(
+          Type.String({
+            description: "Optional message to send after resuming (e.g. follow-up instructions)",
+          }),
+        ),
+        autoExit: Type.Optional(
+          Type.Boolean({
+            description:
+              "Whether the resumed session should automatically exit after completing its response. Defaults to true for autonomous follow-up work; set false for interactive resumed sessions.",
+          }),
+        ),
+      }),
+
+      renderCall(args, theme) {
+        const name = args.name ?? "Resume";
+        const text =
+          "▸ " +
+          theme.fg("toolTitle", theme.bold(name)) +
+          theme.fg("dim", " — resuming session");
+        return new Text(text, 0, 0);
+      },
+
+      renderResult(result, _opts, theme) {
+        const details = result.details as any;
+        const name = details?.name ?? "Resume";
+
+        if (details?.status === "started") {
+          return new Text(
+            theme.fg("accent", "▸") +
+              " " +
+              theme.fg("toolTitle", theme.bold(name)) +
+              theme.fg("dim", " — resumed"),
+            0,
+            0,
+          );
+        }
+
+        // Fallback
+        const text = extractFirstText(result.content);
+        return new Text(theme.fg("dim", text), 0, 0);
+      },
+
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        const name = params.name ?? "Resume";
+        const { autoExit, interactive } = resolveResumeLaunchBehavior(params);
+        const startTime = Date.now();
+        const id = Math.random().toString(16).slice(2, 10);
+
+        if (!existsSync(params.sessionPath)) {
+          return {
+            content: [
+              { type: "text", text: `Error: session file not found: ${params.sessionPath}` },
+            ],
+            details: { error: "session not found" },
+          };
+        }
+
+        // Record entry count before resuming so we can extract new messages
+        const entryCountBefore = getNewEntries(params.sessionPath, 0).length;
+
+        const surface = createSurface(name);
+        await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
+
+        // Build pi resume command
+        const parts = ["pi", "--session", shellEscape(params.sessionPath)];
+
+        // Load subagent-done extension so the agent can self-terminate if needed
+        const subagentDonePath = join(SUBAGENTS_DIR, "subagent-done.ts");
+        parts.push("-e", shellEscape(subagentDonePath));
+
+        const sessionId = ctx.sessionManager.getSessionId();
+        const artifactDir = getArtifactDir(ctx.sessionManager.getSessionDir(), sessionId);
+        const activityFile = getSubagentActivityFile(artifactDir, id);
+        mkdirSync(dirname(activityFile), { recursive: true });
+
+        let resumeMsgFile: string | undefined;
+        if (params.message) {
+          const msgTimestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+          resumeMsgFile = join(
+            artifactDir,
+            "subagent-resume",
+            `${name
+              .toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, "")
+              .replace(/\s+/g, "-")
+              .replace(/-+/g, "-")
+              .replace(/^-|-$/g, "") || "resume"}-${msgTimestamp}.md`,
+          );
+          mkdirSync(dirname(resumeMsgFile), { recursive: true });
+          writeFileSync(resumeMsgFile, params.message, "utf8");
+          parts.push(shellEscape(`@${resumeMsgFile}`));
+        }
+
+        // Build env prefix — propagate PI_CODING_AGENT_DIR for config isolation
+        const resumeEnvParts: string[] = [];
+        if (process.env.PI_CODING_AGENT_DIR) {
+          resumeEnvParts.push(`PI_CODING_AGENT_DIR=${shellEscape(process.env.PI_CODING_AGENT_DIR)}`);
+        }
+        resumeEnvParts.push(`PI_SUBAGENT_NAME=${shellEscape(name)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(params.sessionPath)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
+        if (autoExit) {
+          resumeEnvParts.push(`PI_SUBAGENT_AUTO_EXIT=1`);
+        }
+        const resumeEnvPrefix = resumeEnvParts.join(" ") + " ";
+
+        const command = `${resumeEnvPrefix}${parts.join(" ")}; echo '__SUBAGENT_DONE_'$?'__'`;
+        const launchScriptFile = join(
+          artifactDir,
+          "subagent-scripts",
+          `${name
+            .toLowerCase()
+            .replace(/[^a-z0-9\s-]/g, "")
+            .replace(/\s+/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^-|-$/g, "") || "resume"}-resume-${Date.now()}.sh`,
+        );
+        sendLongCommand(surface, command, {
+          scriptPath: launchScriptFile,
+          scriptPreamble: [
+            `# Subagent resume script for ${name}`,
+            `# Generated: ${new Date().toISOString()}`,
+            `# Session: ${params.sessionPath}`,
+            `# Surface: ${surface}`,
+            ...(resumeMsgFile ? [`# Resume message file: ${resumeMsgFile}`] : []),
+          ].join("\n"),
+        });
+
+        // Register as a running subagent for widget tracking
+        const running: RunningSubagent = {
+          id,
+          name,
+          task: params.message ?? "resumed session",
+          surface,
+          startTime,
+          sessionFile: params.sessionPath,
+          launchScriptFile,
+          activityFile,
+          interactive,
+          statusState: createStatusState({
+            source: "pi",
+            startTimeMs: startTime,
+          }),
+        };
+        runningSubagents.set(id, running);
+        startWidgetRefresh();
+        startStatusRefresh(pi);
+
+        // Fire-and-forget watcher
+        const watcherAbort = new AbortController();
+        running.abortController = watcherAbort;
+
+        watchSubagent(running, watcherAbort.signal)
+          .then((result) => {
+            updateWidget();
+
+            if (result.ping) {
+              const sessionRef = `\n\nSession: ${params.sessionPath}\nResume: pi --session ${params.sessionPath}`;
+              pi.sendMessage(
+                {
+                  customType: "subagent_ping",
+                  content: `Sub-agent "${result.ping.name}" needs help (${formatElapsed(result.elapsed)}):\n\n${result.ping.message}${sessionRef}`,
+                  display: true,
+                  details: {
+                    name: result.ping.name,
+                    message: result.ping.message,
+                    sessionFile: params.sessionPath,
+                  },
+                },
+                { triggerTurn: true, deliverAs: "steer" },
+              );
+              return;
+            }
+
+            const allEntries = getNewEntries(params.sessionPath, entryCountBefore);
+            const summary = findLastAssistantMessage(allEntries) ??
+              (result.exitCode !== 0
+                ? `Resumed session exited with code ${result.exitCode}`
+                : "Resumed session exited without new output");
+            const presentation = resolveResultPresentation(
+              { ...result, summary, sessionFile: params.sessionPath },
+              name,
+            );
+
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: presentation,
+                display: true,
+                details: {
+                  name,
+                  task: params.message ?? "resumed session",
+                  exitCode: result.exitCode,
+                  elapsed: result.elapsed,
+                  sessionFile: params.sessionPath,
+                },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          })
+          .catch((err) => {
+            updateWidget();
+            pi.sendMessage(
+              {
+                customType: "subagent_result",
+                content: `Resume error: ${err?.message ?? String(err)}`,
+                display: true,
+                details: { name, error: err?.message },
+              },
+              { triggerTurn: true, deliverAs: "steer" },
+            );
+          });
+
+        return {
+          content: [{ type: "text", text: `Session "${name}" resumed.` }],
+          details: {
+            id,
+            name,
+            sessionPath: params.sessionPath,
+            launchScriptFile,
+            status: "started",
+          },
+        };
+      },
+    });
+
+  // /iterate command — fork the session into a subagent
+  pi.registerCommand("iterate", {
+    description: "Fork session into a subagent for focused work (bugfixes, iteration)",
+    handler: async (args, _ctx) => {
+      const task = args.trim() || "";
+      const toolCall = task
+        ? `Use subagent to fork a session. fork: true, name: "Iterate", task: ${JSON.stringify(task)}`
+        : `Use subagent to fork a session. fork: true, name: "Iterate", task: "The user wants to do some hands-on work. Help them with whatever they need."`;
+      pi.sendUserMessage(toolCall);
+    },
+  });
+
+  // /subagent command — spawn a subagent by name
+  pi.registerCommand("subagent", {
+    description: "Spawn a subagent: /subagent <agent> <task>",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      if (!trimmed) {
+        ctx.ui.notify("Usage: /subagent <agent> [task]", "warning");
+        return;
+      }
+
+      const spaceIdx = trimmed.indexOf(" ");
+      const agentName = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+      const task = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
+
+      const defs = loadAgentDefaults(agentName);
+      if (!defs) {
+        ctx.ui.notify(
+          `Agent "${agentName}" not found in ~/.pi/agent/agents/ or .pi/agents/`,
+          "error",
+        );
+        return;
+      }
+
+      const taskText = task || `You are the ${agentName} agent. Wait for instructions.`;
+      const displayName = agentName[0].toUpperCase() + agentName.slice(1);
+      const toolCall = `Use subagent with agent: "${agentName}", name: "${displayName}", task: ${JSON.stringify(taskText)}`;
+      pi.sendUserMessage(toolCall);
+    },
+  });
+
+  // ── subagent_result message renderer ──
+  pi.registerMessageRenderer("subagent_result", (message, options, theme) => {
+    const details = message.details as any;
+    if (!details) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const name = details.name ?? "subagent";
+        const exitCode = details.exitCode ?? 0;
+        const elapsed = details.elapsed != null ? formatElapsed(details.elapsed) : "?";
+        const bgFn = exitCode === 0
+          ? (text: string) => theme.bg("toolSuccessBg", text)
+          : (text: string) => theme.bg("toolErrorBg", text);
+        const icon = exitCode === 0
+          ? theme.fg("success", "✓")
+          : theme.fg("error", "✗");
+        const status = exitCode === 0
+          ? "completed"
+          : `failed (exit ${exitCode})`;
+        const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
+
+        const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "—")} ${status} ${theme.fg("dim", `(${elapsed})`)}`;
+        const rawContent = typeof message.content === "string" ? message.content : "";
+
+        // Clean summary (remove session ref and leading label for display)
+        const summary = rawContent
+          .replace(/\n\nSession: .+\nResume: .+$/, "")
+          .replace(`Sub-agent "${name}" completed (${elapsed}).\n\n`, "")
+          .replace(`Sub-agent "${name}" failed (exit code ${exitCode}).\n\n`, "");
+
+        // Build content for the box
+        const contentLines = [header];
+
+        if (options.expanded) {
+          // Full view: complete summary + session info
+          if (summary) {
+            for (const line of summary.split("\n")) {
+              contentLines.push(line.slice(0, width - 6));
+            }
+          }
+          if (details.sessionFile) {
+            contentLines.push("");
+            contentLines.push(theme.fg("dim", `Session: ${details.sessionFile}`));
+            contentLines.push(theme.fg("dim", `Resume:  pi --session ${details.sessionFile}`));
+          }
+        } else {
+          // Collapsed: preview + expand hint
+          if (summary) {
+            const previewLines = summary.split("\n").slice(0, 5);
+            for (const line of previewLines) {
+              contentLines.push(theme.fg("dim", line.slice(0, width - 6)));
+            }
+            const totalLines = summary.split("\n").length;
+            if (totalLines > 5) {
+              contentLines.push(theme.fg("muted", `… ${totalLines - 5} more lines`));
+            }
+          }
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        // Render via Box for background + padding, with blank line above for separation
+        const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+      invalidate(): void {},
+    };
+  });
+
+  // ── subagent_status message renderer ──
+  pi.registerMessageRenderer("subagent_status", (message, options, theme) => {
+    const details = message.details as any;
+    const lines = Array.isArray(details?.lines) ? details.lines : [];
+    const overflow = typeof details?.overflow === "number" ? details.overflow : 0;
+    if (lines.length === 0 && overflow === 0) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const lineWidth = Math.max(0, width - 6);
+        const contentLines = [
+          `${theme.fg("accent", "•")} ${theme.fg("toolTitle", theme.bold("Subagent status"))}`,
+          ...lines.map((line: string) => theme.fg("dim", truncateToWidth(line, lineWidth))),
+        ];
+
+        if (overflow > 0) {
+          contentLines.push(theme.fg("muted", `+${overflow} more running.`));
+        }
+        if (!options.expanded) {
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        const box = new Box(1, 1, (text: string) => theme.bg("customMessageBg", text));
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+      invalidate(): void {},
+    };
+  });
+
+  // ── subagent_ping message renderer ──
+  pi.registerMessageRenderer("subagent_ping", (message, options, theme) => {
+    const details = message.details as any;
+    if (!details) return undefined;
+
+    return {
+      render(width: number): string[] {
+        const name = details.name ?? "subagent";
+        const agentTag = details.agent ? theme.fg("dim", ` (${details.agent})`) : "";
+        const bgFn = (text: string) => theme.bg("toolSuccessBg", text);
+
+        const icon = theme.fg("accent", "?");
+        const header = `${icon} ${theme.fg("toolTitle", theme.bold(name))}${agentTag} ${theme.fg("dim", "— needs help")}`;
+
+        const contentLines = [header];
+
+        if (options.expanded) {
+          contentLines.push("");
+          contentLines.push(details.message ?? "");
+          if (details.sessionFile) {
+            contentLines.push("");
+            contentLines.push(theme.fg("dim", `Session: ${details.sessionFile}`));
+          }
+        } else {
+          const preview = (details.message ?? "").split("\n")[0].slice(0, width - 10);
+          contentLines.push(theme.fg("dim", preview));
+          contentLines.push(theme.fg("muted", keyHint("app.tools.expand", "to expand")));
+        }
+
+        const box = new Box(1, 1, bgFn);
+        box.addChild(new Text(contentLines.join("\n"), 0, 0));
+        return ["", ...box.render(width)];
+      },
+      invalidate(): void {},
+    };
+  });
+
+  // /plan command — start the full planning workflow
+  pi.registerCommand("plan", {
+    description: "Start a planning session: /plan <what to build>",
+    handler: async (args, ctx) => {
+      const task = args.trim();
+      if (!task) {
+        ctx.ui.notify("Usage: /plan <what to build>", "warning");
+        return;
+      }
+
+      // Rename workspace and tab to show this is a planning session
+      if (isMuxAvailable()) {
+        try {
+          const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
+          renameWorkspace(`🎯 ${label}`);
+          renameCurrentTab(`🎯 Plan: ${label}`);
+        } catch {
+          // non-critical -- do not block the plan
+        }
+      }
+
+      // Load the plan skill from the subagents extension directory
+      const planSkillPath = join(SUBAGENTS_DIR, "plan-skill.md");
+      let content = readFileSync(planSkillPath, "utf8");
+      content = content.replace(/^---\n[\s\S]*?\n---\n*/, "");
+      pi.sendUserMessage(
+        `<skill name="plan" location="${planSkillPath}">\n${content.trim()}\n</skill>\n\n${task}`,
+      );
+    },
+  });
+}
+
+// ── Exported for direct programmatic use (e.g. pi-dynamic-workflows) ──
+export { launchSubagent, watchSubagent };
+export type { RunningSubagent, SubagentResult };

--- a/packages/pi-interactive-subagents/pi-extension/subagents/plan-skill.md
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/plan-skill.md
@@ -1,0 +1,203 @@
+---
+name: plan
+description: >
+  Planning workflow. Runs a pre-flight scout, then spawns the planner agent
+  which clarifies WHAT to build and figures out HOW, with the ability to
+  spawn its own scouts/researchers mid-session. Use when asked to "plan",
+  "brainstorm", "I want to build X", or "let's design". Requires the
+  subagents extension and a supported multiplexer (cmux/tmux/zellij).
+---
+
+# Plan
+
+A planning workflow. A scout maps the relevant codebase, then an interactive planner clarifies intent + requirements and designs the technical approach, producing a `plan.md` and todos.
+
+**Announce at start:** "Let me take a quick look, then I'll send a scout to map the codebase before we start the planning session."
+
+---
+
+## The Flow
+
+```
+Phase 1: Quick Assessment (main session — 30s orientation)
+    ↓
+Phase 2: Scout (autonomous — codebase context)
+    ↓
+Phase 3: Spawn Planner Agent (interactive — clarifies WHAT, plans HOW, creates todos)
+    ↓
+    (Planner may spawn its own scouts/researchers mid-session as needed)
+    ↓
+Phase 4: Review Plan & Todos (main session)
+    ↓
+Phase 5: Execute Todos (workers — receive plan + scout context)
+    ↓
+Phase 6: Review
+```
+
+---
+
+## Phase 1: Quick Assessment
+
+Quick orientation — just enough to give the scout a focused mission:
+
+```bash
+ls -la
+find . -type f -name "*.ts" | head -20  # or relevant extension
+cat package.json 2>/dev/null | head -30
+```
+
+Spend ~30 seconds. Tech stack, project shape, and the area relevant to the user's request. This tells you what to ask the scout to focus on.
+
+---
+
+## Artifact Paths
+
+For a planning run, pick a short `<name>` (e.g. `auth-redesign`) and use a shared directory under `.pi/plans/YYYY-MM-DD-<name>/` for every deliverable. Pass explicit paths in each subagent's task and read them back with the plain `read` tool when a subagent finishes.
+
+Standard filenames:
+
+- `.pi/plans/YYYY-MM-DD-<name>/scout-context.md`
+- `.pi/plans/YYYY-MM-DD-<name>/plan.md`
+- `.pi/plans/YYYY-MM-DD-<name>/review.md` (optional, for reviewer output)
+
+---
+
+## Phase 2: Scout
+
+**Always spawn a scout before the planner.** The scout's context feeds into the planning session — it lets the planner skip re-asking questions whose answers live in the code, and gives it a solid base to design from.
+
+```typescript
+subagent({
+  name: "🔍 Scout",
+  agent: "scout",
+  task: `Analyze the codebase for [user's request area]. Map file structure, key modules, patterns, conventions, and existing code related to [feature area]. Focus on what a planner would need to understand before designing this feature.
+
+Save your findings to: .pi/plans/YYYY-MM-DD-<name>/scout-context.md`,
+});
+```
+
+**Wait for the scout to finish.** Read the scout's context file with the `read` tool — you'll pass it to the planner.
+
+The planner can spawn **additional** scouts or researchers mid-session if it hits a factual gap. That's expected — don't try to pre-scout every possible area.
+
+---
+
+## Phase 3: Spawn Planner Agent
+
+Spawn the interactive planner with the scout's context and the user's request. The planner handles everything from here: clarifying intent, compact requirements engineering, ISC, approach exploration, design validation, premortem, plan artifact, and todos.
+
+```typescript
+subagent({
+  name: "💬 Planner",
+  agent: "planner",
+  interactive: true,
+  task: `Plan: [what the user wants to build]
+
+Scout context:
+[paste scout findings here — file structure, conventions, patterns, relevant code]
+
+Save the final plan to: .pi/plans/YYYY-MM-DD-<name>/plan.md
+Create todos tagged with: <name>`,
+});
+```
+
+**The user works with the planner.** It will clarify requirements lightly (1-2 rounds of questions, not a deep spec session), propose approaches, validate the design, run a premortem, write the plan, and create todos with mandatory code examples.
+
+When done, the user presses Ctrl+D and the plan + todos are returned to the main session.
+
+### The planner may spawn its own specialists
+
+During the session, the planner can spawn:
+- **`scout`** — when a design decision depends on existing code it hasn't read
+- **`researcher`** — when a decision depends on external facts (library tradeoffs, best practices, API behaviors)
+
+These are internal to the planning session. You'll see them in the multiplexer but don't need to intervene.
+
+### Optional: extra scout after planning
+
+If the planner significantly changed scope (new subsystems, areas the original scout didn't cover), spawn another scout targeting the new areas before workers start:
+
+```typescript
+subagent({
+  name: "🔍 Scout (updated scope)",
+  agent: "scout",
+  task: "The plan changed scope. Gather context for [new areas]. Read the plan at [plan path]. Focus on [specific files/modules the planner identified that weren't in the original scout].",
+});
+```
+
+Fold the new context into the worker tasks.
+
+---
+
+## Phase 4: Review Plan & Todos
+
+Once the planner closes, read the plan and list todos:
+
+```typescript
+todo({ action: "list" });
+```
+
+Review with the user:
+
+> "Here's what the planner produced: [brief summary]. Ready to execute, or anything to adjust?"
+
+---
+
+## Phase 5: Execute Todos
+
+Spawn workers sequentially. Each worker gets the plan path and scout context:
+
+```typescript
+// Workers execute todos sequentially — one at a time
+subagent({
+  name: "🔨 Worker 1/N",
+  agent: "worker",
+  task: "Implement TODO-xxxx. Mark the todo as done. Plan: [plan path]\n\nScout context: [paste scout summary from Phase 2, plus any re-scout from Phase 3]",
+});
+
+// Check result, then next todo
+subagent({
+  name: "🔨 Worker 2/N",
+  agent: "worker",
+  task: "Implement TODO-yyyy. Mark the todo as done. Plan: [plan path]\n\nScout context: [paste scout summary]",
+});
+```
+
+**Always run workers sequentially in the same git repo** — parallel workers will conflict on commits.
+
+---
+
+## Phase 6: Review
+
+After all todos are complete:
+
+```typescript
+subagent({
+  name: "Reviewer",
+  agent: "reviewer",
+  interactive: false,
+  task: "Review the recent changes. Plan: [plan path]",
+});
+```
+
+Triage findings:
+
+- **P0** — Real bugs, security issues → fix now
+- **P1** — Genuine traps, maintenance dangers → fix before merging
+- **P2** — Minor issues → fix if quick, note otherwise
+- **P3** — Nits → skip
+
+Create todos for P0/P1, run workers to fix, re-review only if fixes were substantial.
+
+---
+
+## ⚠️ Completion Checklist
+
+Before reporting done:
+
+1. ✅ Scout ran before the planner?
+2. ✅ Scout context was passed to the planner?
+3. ✅ All worker todos closed?
+4. ✅ Every todo has a polished commit (using the `commit` skill)?
+5. ✅ Reviewer has run?
+6. ✅ Reviewer findings triaged and addressed?

--- a/packages/pi-interactive-subagents/pi-extension/subagents/plugin/.claude-plugin/plugin.json
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "pi-auto-exit",
+  "version": "1.0.0",
+  "description": "Auto-exit plugin for pi-spawned Claude sessions"
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/plugin/hooks/hooks.json
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/on-stop.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/plugin/hooks/on-stop.sh
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/plugin/hooks/on-stop.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Stop hook for pi-spawned Claude sessions.
+# Writes a sentinel file when Claude completes autonomously (no user interjection).
+
+set -euo pipefail
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Guard: if stop_hook_active is true, we're in a loop — bail out
+stop_hook_active=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('stop_hook_active', False))" 2>/dev/null || echo "False")
+if [ "$stop_hook_active" = "True" ]; then
+  exit 0
+fi
+
+# Guard: only act for pi-spawned sessions
+if [ -z "${PI_CLAUDE_SENTINEL:-}" ]; then
+  exit 0
+fi
+
+# Get transcript path
+transcript_path=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('transcript_path', ''))" 2>/dev/null || echo "")
+if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
+  exit 0
+fi
+
+# Count real human messages in transcript (not tool results)
+# Claude's transcript format:
+#   Human message: {"type": "user", "message": {"role": "user", "content": "..."}}
+#   Tool result:   {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", ...}]}}
+# We only count entries where content is a string (real human input)
+user_msg_count=$(python3 - "$transcript_path" <<'EOF'
+import sys, json
+
+transcript_path = sys.argv[1]
+count = 0
+with open(transcript_path, 'r') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            if entry.get('type') != 'user':
+                continue
+            content = entry.get('message', {}).get('content', '')
+            # Real human messages have string content
+            # Tool results have array content with tool_result blocks
+            if isinstance(content, str):
+                count += 1
+        except (json.JSONDecodeError, AttributeError):
+            pass
+print(count)
+EOF
+)
+
+# Always write transcript path so the watcher can copy the session file
+if [ -n "$transcript_path" ]; then
+  echo "$transcript_path" > "${PI_CLAUDE_SENTINEL}.transcript" 2>/dev/null || true
+fi
+
+# If exactly 1 user message (the initial prompt), this was autonomous — signal completion
+if [ "$user_msg_count" -eq 1 ]; then
+  # Write last_assistant_message to sentinel so the watcher gets a clean result
+  echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('last_assistant_message', ''))" > "$PI_CLAUDE_SENTINEL" 2>/dev/null || touch "$PI_CLAUDE_SENTINEL"
+fi
+
+exit 0

--- a/packages/pi-interactive-subagents/pi-extension/subagents/session.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/session.ts
@@ -1,0 +1,185 @@
+import { appendFileSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes, randomUUID } from "node:crypto";
+import { dirname, join } from "node:path";
+
+export interface SessionEntry {
+  type: string;
+  id: string;
+  parentId?: string;
+  [key: string]: unknown;
+}
+
+export interface MessageEntry extends SessionEntry {
+  type: "message";
+  message: {
+    role: "user" | "assistant" | "toolResult";
+    content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  };
+}
+
+export type SeededSubagentSessionMode = "lineage-only" | "fork";
+
+function getForkContentLines(parentSessionFile: string): string[] {
+  const raw = readFileSync(parentSessionFile, "utf8");
+  const lines = raw.split("\n").filter((line) => line.trim());
+
+  let truncateAt = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const entry = JSON.parse(lines[i]);
+      if (entry.type === "message" && entry.message?.role === "user") {
+        truncateAt = i;
+        break;
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  }
+
+  return lines.slice(0, truncateAt).filter((line) => {
+    try {
+      return JSON.parse(line).type !== "session";
+    } catch {
+      return true;
+    }
+  });
+}
+
+export function seedSubagentSessionFile(params: {
+  mode: SeededSubagentSessionMode;
+  parentSessionFile: string;
+  childSessionFile: string;
+  childCwd: string;
+}): void {
+  const header = {
+    type: "session",
+    version: 3,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    cwd: params.childCwd,
+    parentSession: params.parentSessionFile,
+  };
+  const contentLines =
+    params.mode === "fork" ? getForkContentLines(params.parentSessionFile) : [];
+  const lines = [JSON.stringify(header), ...contentLines];
+
+  mkdirSync(dirname(params.childSessionFile), { recursive: true });
+  writeFileSync(params.childSessionFile, lines.join("\n") + "\n", "utf8");
+}
+
+function readEntries(sessionFile: string): SessionEntry[] {
+  const raw = readFileSync(sessionFile, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as SessionEntry);
+}
+
+/**
+ * Return the id of the last entry in the session file (current branch point / leaf).
+ */
+export function getLeafId(sessionFile: string): string | null {
+  const entries = readEntries(sessionFile);
+  return entries.length > 0 ? entries[entries.length - 1].id : null;
+}
+
+/**
+ * Return entries added after `afterLine` (1-indexed count of existing entries).
+ */
+export function getNewEntries(sessionFile: string, afterLine: number): SessionEntry[] {
+  const raw = readFileSync(sessionFile, "utf8");
+  const lines = raw.split("\n").filter((line) => line.trim());
+  return lines.slice(afterLine).map((line) => JSON.parse(line) as SessionEntry);
+}
+
+/**
+ * Find the last assistant message text in a list of entries.
+ * If the text blocks are empty/incomplete but the message contains a subagent_done
+ * tool call with a result, stringify that result as the summary.
+ */
+export function findLastAssistantMessage(entries: SessionEntry[]): string | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry.type !== "message") continue;
+    const msg = entry as MessageEntry;
+    if (msg.message.role !== "assistant") continue;
+
+    const texts = msg.message.content
+      .filter(
+        (block) =>
+          block.type === "text" && typeof block.text === "string" && block.text.trim() !== "",
+      )
+      .map((block) => block.text as string);
+
+    const textSummary = texts.length > 0 && texts.join("").trim() ? texts.join("\n") : null;
+
+    // Check for subagent_done tool call with structured result.
+    // When the model puts its real output in the tool arguments instead of the text block,
+    // we should extract and use that as the summary.
+    const doneCall = msg.message.content.find(
+      (block) =>
+        (block.type === "toolCall" || block.type === "tool_use") &&
+        block.name === "subagent_done" &&
+        (block.arguments as { result?: unknown } | undefined)?.result != null,
+    ) as unknown as { arguments: { result: unknown } } | undefined;
+
+    if (doneCall) {
+      const structured = JSON.stringify(doneCall.arguments.result, null, 2);
+      // If text exists, prepend it; otherwise use structured output alone
+      return textSummary ? `${textSummary}\n\n${structured}` : structured;
+    }
+
+    if (textSummary) return textSummary;
+  }
+  return null;
+}
+
+/**
+ * Append a branch_summary entry to the session file.
+ * Returns the new entry's id.
+ */
+export function appendBranchSummary(
+  sessionFile: string,
+  branchPointId: string,
+  fromId: string | null,
+  summary: string,
+): string {
+  const id = randomBytes(4).toString("hex");
+  const entry = {
+    type: "branch_summary",
+    id,
+    parentId: branchPointId,
+    timestamp: new Date().toISOString(),
+    fromId: fromId ?? branchPointId,
+    summary,
+  };
+  appendFileSync(sessionFile, JSON.stringify(entry) + "\n", "utf8");
+  return id;
+}
+
+/**
+ * Copy the session file to destDir for parallel worker isolation.
+ * Returns the path of the copy.
+ */
+export function copySessionFile(sessionFile: string, destDir: string): string {
+  const id = randomBytes(4).toString("hex");
+  const dest = join(destDir, `subagent-${id}.jsonl`);
+  copyFileSync(sessionFile, dest);
+  return dest;
+}
+
+/**
+ * Read new entries from sourceFile (after afterLine), append them to targetFile.
+ * Returns the appended entries.
+ */
+export function mergeNewEntries(
+  sourceFile: string,
+  targetFile: string,
+  afterLine: number,
+): SessionEntry[] {
+  const entries = getNewEntries(sourceFile, afterLine);
+  for (const entry of entries) {
+    appendFileSync(targetFile, JSON.stringify(entry) + "\n", "utf8");
+  }
+  return entries;
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/status.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/status.ts
@@ -1,0 +1,513 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SNAPSHOT_STALLED_AFTER_MS = 60_000;
+export const DEFAULT_STATUS_LINE_LIMIT = 4;
+export const MAX_STATUS_NAME_LENGTH = 72;
+export const MAX_STATUS_LINE_LENGTH = 120;
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_STATUS_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const STATUS_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export type SubagentStatusKind = "starting" | "active" | "waiting" | "stalled" | "running";
+export type SubagentStatusSource = "pi" | "claude";
+export type SubagentStatusTransition = "stalled" | "recovered" | null;
+export type StatusSnapshotState = "unseen" | "present" | "missing" | "invalid" | "wrong-id";
+export type StatusActivityPhase = "starting" | "active" | "waiting" | "done";
+
+export interface StatusConfig {
+  enabled: boolean;
+  lineLimit: number;
+}
+
+export type StatusObservation =
+  | {
+      snapshot: "present";
+      updatedAt: number;
+      sequence: number;
+      phase: StatusActivityPhase;
+      active?: boolean;
+      activeScope?: string;
+      activeSince?: number;
+      waitingSince?: number;
+      latestEvent?: string;
+      activityLabel?: string;
+    }
+  | {
+      snapshot: "missing" | "invalid" | "wrong-id";
+      snapshotError?: string;
+    };
+
+export interface SubagentStatusState {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+  firstObservationAtMs: number | null;
+  lastActivityAtMs: number | null;
+  lastActivitySequence: number | null;
+  localOverrideAtMs: number | null;
+  localOverrideSequence: number | null;
+  activeNow: boolean;
+  activeSinceMs: number | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  phase: StatusActivityPhase | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotProblemSinceMs: number | null;
+  snapshotError: string | null;
+  currentKind: SubagentStatusKind;
+}
+
+export interface StatusSnapshot {
+  kind: SubagentStatusKind;
+  elapsedMs: number;
+  elapsedText: string;
+  activeSinceMs: number | null;
+  activeDurationText: string | null;
+  activeScope: string | null;
+  waitingSinceMs: number | null;
+  waitingDurationText: string | null;
+  latestEvent: string | null;
+  activityLabel: string | null;
+  snapshotState: StatusSnapshotState;
+  snapshotError: string | null;
+  snapshotProblemText: string | null;
+  statusLabel: string | null;
+}
+
+export interface CappedStatusLines {
+  visibleLines: string[];
+  overflow: number;
+}
+
+function invalidStatusConfig(source: string, message: string): never {
+  throw new Error(`Invalid subagent status config in ${source}: ${message}`);
+}
+
+function requireObject(value: unknown, source: string, fieldName: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    invalidStatusConfig(source, `${fieldName} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireBoolean(value: unknown, source: string, fieldName: string): boolean {
+  if (typeof value !== "boolean") {
+    invalidStatusConfig(source, `${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
+function rejectUnsupportedKeys(
+  value: Record<string, unknown>,
+  allowedKeys: string[],
+  source: string,
+  fieldName: string,
+): void {
+  const unsupportedKeys = Object.keys(value).filter((key) => !allowedKeys.includes(key));
+  if (unsupportedKeys.length > 0) {
+    invalidStatusConfig(source, `${fieldName} has unsupported key(s): ${unsupportedKeys.join(", ")}`);
+  }
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  if (maxLength <= 1) return text.slice(0, maxLength);
+  return `${text.slice(0, maxLength - 1)}…`;
+}
+
+export function normalizeStatusName(name: string): string {
+  const collapsed = name.replace(/\s+/g, " ").trim() || "subagent";
+  return truncateText(collapsed, MAX_STATUS_NAME_LENGTH);
+}
+
+function boundStatusLine(line: string): string {
+  return truncateText(line.replace(/\s+/g, " ").trim(), MAX_STATUS_LINE_LENGTH);
+}
+
+function snapshotProblemLabel(snapshotState: StatusSnapshotState): string | null {
+  if (snapshotState === "wrong-id") return "wrong activity id";
+  return null;
+}
+
+function activityLabel(snapshot: Pick<StatusSnapshot, "activityLabel" | "activeScope">): string | null {
+  return snapshot.activityLabel ?? snapshot.activeScope;
+}
+
+export function parseStatusConfig(rawConfig: unknown, source = "config.json"): StatusConfig {
+  const config = requireObject(rawConfig, source, "root");
+  const status = requireObject(config.status, source, "status");
+  rejectUnsupportedKeys(status, ["enabled"], source, "status");
+  const enabled = requireBoolean(status.enabled, source, "status.enabled");
+
+  return {
+    enabled,
+    lineLimit: DEFAULT_STATUS_LINE_LIMIT,
+  };
+}
+
+function readStatusConfigFile(configPath: string, examplePath: string): { sourcePath: string; rawConfig: string } {
+  try {
+    return { sourcePath: configPath, rawConfig: readFileSync(configPath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code !== "ENOENT") throw error;
+  }
+
+  try {
+    return { sourcePath: examplePath, rawConfig: readFileSync(examplePath, "utf8") };
+  } catch (error) {
+    const errno = error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        `Missing subagent status config. Expected ${configPath} or ${examplePath}.`,
+      );
+    }
+    throw error;
+  }
+}
+
+export function loadStatusConfig(
+  configPath = DEFAULT_STATUS_CONFIG_PATH,
+  examplePath = STATUS_CONFIG_EXAMPLE_PATH,
+): StatusConfig {
+  const { sourcePath, rawConfig } = readStatusConfigFile(configPath, examplePath);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid JSON in subagent config ${sourcePath}: ${detail}`);
+  }
+
+  return parseStatusConfig(parsed, sourcePath);
+}
+
+export function formatElapsedDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+
+  return `${minutes}m`;
+}
+
+export function createStatusState(params: {
+  source: SubagentStatusSource;
+  startTimeMs: number;
+}): SubagentStatusState {
+  const initialKind = params.source === "claude" ? "running" : "starting";
+  return {
+    source: params.source,
+    startTimeMs: params.startTimeMs,
+    firstObservationAtMs: null,
+    lastActivityAtMs: null,
+    lastActivitySequence: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: null,
+    phase: null,
+    latestEvent: null,
+    activityLabel: null,
+    snapshotState: params.source === "claude" ? "unseen" : "unseen",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    currentKind: initialKind,
+  };
+}
+
+export function observeStatus(
+  state: SubagentStatusState,
+  observation: StatusObservation,
+  now: number,
+): SubagentStatusState {
+  if (state.source === "claude") return state;
+
+  if (observation.snapshot !== "present") {
+    return {
+      ...state,
+      firstObservationAtMs: state.firstObservationAtMs ?? now,
+      snapshotState: observation.snapshot,
+      snapshotProblemSinceMs: state.snapshotProblemSinceMs ?? now,
+      snapshotError: observation.snapshotError ?? null,
+    };
+  }
+
+  const updatedAt = observation.updatedAt;
+  const sequence = observation.sequence;
+  const lastActivityAtMs = state.lastActivityAtMs;
+  const lastActivitySequence = state.lastActivitySequence;
+  const olderThanLastActivity = lastActivityAtMs != null && (
+    updatedAt < lastActivityAtMs ||
+    (updatedAt === lastActivityAtMs && lastActivitySequence != null && sequence < lastActivitySequence)
+  );
+  if (olderThanLastActivity) return state;
+
+  const blockedByLocalOverride = state.localOverrideAtMs != null && (
+    updatedAt < state.localOverrideAtMs ||
+    (updatedAt === state.localOverrideAtMs && state.localOverrideSequence != null && sequence <= state.localOverrideSequence)
+  );
+  if (blockedByLocalOverride) return state;
+
+  const phase = observation.phase;
+  const activeNow = phase === "active" || observation.active === true;
+  const activeSinceMs = activeNow
+    ? observation.activeSince ?? state.activeSinceMs ?? updatedAt
+    : null;
+  const waitingSinceMs = phase === "waiting"
+    ? observation.waitingSince ?? state.waitingSinceMs ?? updatedAt
+    : null;
+
+  return {
+    ...state,
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastActivityAtMs: updatedAt,
+    lastActivitySequence: sequence,
+    activeNow,
+    activeSinceMs,
+    activeScope: activeNow ? observation.activeScope ?? null : null,
+    waitingSinceMs,
+    phase,
+    latestEvent: observation.latestEvent ?? null,
+    activityLabel: observation.activityLabel ?? null,
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    localOverrideAtMs: null,
+    localOverrideSequence: null,
+  };
+}
+
+export function forceStatusAfterInterrupt(state: SubagentStatusState, now: number): SubagentStatusState {
+  if (state.source === "claude") return state;
+
+  return {
+    ...state,
+    firstObservationAtMs: state.firstObservationAtMs ?? now,
+    lastActivityAtMs: now,
+    localOverrideAtMs: now,
+    localOverrideSequence: state.lastActivitySequence,
+    activeNow: false,
+    activeSinceMs: null,
+    activeScope: null,
+    waitingSinceMs: now,
+    phase: "waiting",
+    latestEvent: "interrupt_requested",
+    activityLabel: "interrupted",
+    snapshotState: "present",
+    snapshotProblemSinceMs: null,
+    snapshotError: null,
+    currentKind: "waiting",
+  };
+}
+
+function classifyProblemState(state: SubagentStatusState, now: number): Pick<StatusSnapshot, "kind" | "statusLabel"> {
+  const problemLabel = snapshotProblemLabel(state.snapshotState);
+  const hasValidSnapshot = state.lastActivityAtMs != null;
+
+  if (!hasValidSnapshot) {
+    const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+    const elapsedMs = Math.max(0, now - referenceMs);
+    return elapsedMs >= SNAPSHOT_STALLED_AFTER_MS
+      ? { kind: "stalled", statusLabel: problemLabel }
+      : { kind: "starting", statusLabel: null };
+  }
+
+  const problemSinceMs = state.snapshotProblemSinceMs ?? now;
+  const problemMs = Math.max(0, now - problemSinceMs);
+  if (problemMs >= SNAPSHOT_STALLED_AFTER_MS) return { kind: "stalled", statusLabel: problemLabel };
+
+  const lastHealthyKind = state.activeNow
+    ? "active"
+    : state.waitingSinceMs != null || state.phase === "done"
+      ? "waiting"
+      : state.currentKind === "stalled"
+        ? "starting"
+        : state.currentKind;
+  return { kind: lastHealthyKind, statusLabel: problemLabel };
+}
+
+export function classifyStatus(state: SubagentStatusState, now: number): StatusSnapshot {
+  const elapsedMs = Math.max(0, now - state.startTimeMs);
+  const elapsedText = formatElapsedDuration(elapsedMs);
+
+  if (state.source === "claude") {
+    return {
+      kind: "running",
+      elapsedMs,
+      elapsedText,
+      activeSinceMs: null,
+      activeDurationText: null,
+      activeScope: null,
+      waitingSinceMs: null,
+      waitingDurationText: null,
+      latestEvent: null,
+      activityLabel: null,
+      snapshotState: state.snapshotState,
+      snapshotError: null,
+      snapshotProblemText: null,
+      statusLabel: null,
+    };
+  }
+
+  let kind: SubagentStatusKind;
+  let statusLabel: string | null = null;
+
+  if (state.snapshotState === "present") {
+    if (state.phase === "active" || state.activeNow) {
+      kind = "active";
+    } else if (state.phase === "waiting") {
+      kind = "waiting";
+    } else if (state.phase === "done") {
+      kind = "waiting";
+      statusLabel = "done";
+    } else {
+      const referenceMs = state.firstObservationAtMs ?? state.startTimeMs;
+      const elapsedSinceObservationMs = Math.max(0, now - referenceMs);
+      kind = elapsedSinceObservationMs >= SNAPSHOT_STALLED_AFTER_MS ? "stalled" : "starting";
+      statusLabel = null;
+    }
+  } else {
+    const classified = classifyProblemState(state, now);
+    kind = classified.kind;
+    statusLabel = classified.statusLabel;
+  }
+
+  const activeDurationText = state.activeSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.activeSinceMs);
+  const waitingDurationText = state.waitingSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.waitingSinceMs);
+  const snapshotProblemText = state.snapshotProblemSinceMs == null
+    ? null
+    : formatElapsedDuration(now - state.snapshotProblemSinceMs);
+
+  return {
+    kind,
+    elapsedMs,
+    elapsedText,
+    activeSinceMs: state.activeSinceMs,
+    activeDurationText,
+    activeScope: state.activeScope,
+    waitingSinceMs: state.waitingSinceMs,
+    waitingDurationText,
+    latestEvent: state.latestEvent,
+    activityLabel: state.activityLabel,
+    snapshotState: state.snapshotState,
+    snapshotError: state.snapshotError,
+    snapshotProblemText,
+    statusLabel,
+  };
+}
+
+export function advanceStatusState(
+  state: SubagentStatusState,
+  now: number,
+): {
+  nextState: SubagentStatusState;
+  snapshot: StatusSnapshot;
+  transition: SubagentStatusTransition;
+} {
+  const snapshot = classifyStatus(state, now);
+  const transition =
+    state.currentKind !== "stalled" && snapshot.kind === "stalled"
+      ? "stalled"
+      : state.currentKind === "stalled" && (snapshot.kind === "active" || snapshot.kind === "waiting")
+        ? "recovered"
+        : null;
+
+  return {
+    snapshot,
+    transition,
+    nextState: {
+      ...state,
+      currentKind: snapshot.kind,
+    },
+  };
+}
+
+function formatActiveDetail(snapshot: StatusSnapshot): string {
+  const label = activityLabel(snapshot);
+  if (!label) return "active";
+  const duration = snapshot.activeDurationText ? ` ${snapshot.activeDurationText}` : "";
+  return `active (${label}${duration})`;
+}
+
+function formatWaitingDetail(snapshot: StatusSnapshot): string {
+  const duration = snapshot.waitingDurationText ? ` ${snapshot.waitingDurationText}` : "";
+  return `waiting${duration}`;
+}
+
+function formatStalledDetail(snapshot: StatusSnapshot): string {
+  const detail = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+  const duration = snapshot.snapshotProblemText ? ` ${snapshot.snapshotProblemText}` : "";
+  return `stalled${duration}${detail}`;
+}
+
+export function formatStatusLine(name: string, snapshot: StatusSnapshot): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (snapshot.kind === "starting") {
+    const label = snapshot.statusLabel ? ` (${snapshot.statusLabel})` : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, starting${label}.`);
+  }
+
+  if (snapshot.kind === "running") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}.`);
+  }
+
+  if (snapshot.kind === "active") {
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatActiveDetail(snapshot)}.`);
+  }
+
+  if (snapshot.kind === "waiting") {
+    const problem = snapshot.statusLabel && snapshot.statusLabel !== "done"
+      ? ` (${snapshot.statusLabel})`
+      : snapshot.statusLabel === "done"
+        ? " (done)"
+        : "";
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatWaitingDetail(snapshot)}${problem}.`);
+  }
+
+  return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, ${formatStalledDetail(snapshot)}.`);
+}
+
+export function formatTransitionLine(
+  name: string,
+  snapshot: StatusSnapshot,
+  transition: Exclude<SubagentStatusTransition, null>,
+): string {
+  const boundedName = normalizeStatusName(name);
+
+  if (transition === "recovered") {
+    const detail = snapshot.kind === "waiting" ? formatWaitingDetail(snapshot) : formatActiveDetail(snapshot);
+    return boundStatusLine(`${boundedName} running ${snapshot.elapsedText}, recovered; ${detail}.`);
+  }
+
+  return formatStatusLine(boundedName, snapshot);
+}
+
+export function capStatusLines(lines: string[], lineLimit: number): CappedStatusLines {
+  const visibleLines = lines.slice(0, lineLimit);
+  return {
+    visibleLines,
+    overflow: Math.max(0, lines.length - visibleLines.length),
+  };
+}
+
+export function formatStatusAggregate(lines: string[], lineLimit: number): string {
+  const { visibleLines, overflow } = capStatusLines(lines, lineLimit);
+  const bulletLines = visibleLines.map((line) => `• ${line}`);
+  if (overflow > 0) bulletLines.push(`• +${overflow} more running.`);
+  return `Subagent status:\n${bulletLines.join("\n")}`;
+}

--- a/packages/pi-interactive-subagents/pi-extension/subagents/subagent-done.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/subagent-done.ts
@@ -1,0 +1,431 @@
+/**
+ * Extension loaded into sub-agents.
+ * - Shows agent identity + available tools as a styled widget above the editor (toggle with Ctrl+J)
+ * - Provides a `subagent_done` tool for autonomous agents to self-terminate
+ * - Nudges any agent that forgets to call subagent_done after generating
+ *
+ * auto-exit 历史背景：
+ *   早期设计中 PI_SUBAGENT_AUTO_EXIT=1 会让 agent_end 短路退出 — agent 正常结束
+ *   turn 时直接写 { type: "done" } 到 .exit sidecar，绕过 subagent_done 工具。
+ *   这与 workflow 系统启用 PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA 冲突：LLM 即使
+ *   决定不调 subagent_done 也会被短路退出，workflow 永远拿不到 structuredOutput
+ *   → "Subagent finished without calling structured_output"。
+ *   现在不论 autoExit env 如何，agent 都必须主动调用 subagent_done 或 caller_ping
+ *   才能结束。如果 agent 不调，会被 nudge 提醒。
+ */
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { writeFileSync } from "node:fs";
+import Ajv from "ajv";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import { createSubagentActivityRecorder } from "./activity.ts";
+
+const i18n = createTranslator(loadCatalog(new URL("../../locales/index.json", import.meta.url)));
+
+export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
+  return agentStarted;
+}
+
+export function shouldAutoExitOnAgentEnd(
+  _userTookOver: boolean,
+  messages: any[] | undefined,
+): boolean {
+  // Manual input should not strand an auto-exit subagent. If the latest agent
+  // turn completed normally, close the session. Escape/abort still leaves it
+  // open for inspection or another prompt.
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg?.role === "assistant") {
+        return msg.stopReason !== "aborted";
+      }
+    }
+  }
+
+  return true;
+}
+
+export function parseDeniedTools(rawValue: string | undefined): string[] {
+  return (rawValue ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export default function (pi: ExtensionAPI) {
+  let toolNames: string[] = [];
+  let denied: string[] = [];
+  let expanded = false;
+
+  // Read subagent identity from env vars (set by parent orchestrator)
+  const subagentName = process.env.PI_SUBAGENT_NAME ?? "";
+  const subagentAgent = process.env.PI_SUBAGENT_AGENT ?? "";
+  const deniedToolsValue = process.env.PI_DENY_TOOLS;
+  const autoExit = process.env.PI_SUBAGENT_AUTO_EXIT === "1";
+  const recorder = createSubagentActivityRecorder({
+    runningChildId: process.env.PI_SUBAGENT_ID,
+    activityFile: process.env.PI_SUBAGENT_ACTIVITY_FILE,
+  });
+
+  // ── Agent completion nudge configuration ──
+  /** Delay (ms) before sending a nudge after agent_end. Configurable via env var. */
+  const NUDGE_DELAY_MS = Math.max(
+    1000,
+    parseInt(process.env.PI_SUBAGENT_NUDGE_DELAY_MS ?? "5000", 10) || 5000,
+  );
+  /** Set to "1" to disable the nudge entirely. */
+  const NUDGE_DISABLED = process.env.PI_SUBAGENT_NUDGE_DISABLE === "1";
+
+  let doneCalled = false;
+  let userInputAfterAgentEnd = false;
+  let nudgeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearNudgeTimer(): void {
+    if (nudgeTimer !== null) {
+      clearTimeout(nudgeTimer);
+      nudgeTimer = null;
+    }
+  }
+
+  /**
+   * After a non-auto-exit subagent finishes generating, schedule a nudge
+   * reminding it to call subagent_done if it hasn't already.
+   *
+   * Each call replaces any pending nudge, so repeated agent_end events
+   * (e.g. during multi-turn tool use) automatically reset the timer.
+   * The nudge only fires if no new agent activity or user input arrives
+   * within NUDGE_DELAY_MS.
+   */
+  function scheduleAgentEndNudge(): void {
+    clearNudgeTimer();
+    // 不论 autoExit 是否启用，都必须 nudge — autoExit 已被移除，
+    // agent 结束 turn 后只能靠主动调用 subagent_done 才能真正退出。
+    if (NUDGE_DISABLED || doneCalled) return;
+
+    nudgeTimer = setTimeout(() => {
+      nudgeTimer = null;
+      if (doneCalled || userInputAfterAgentEnd) return;
+
+      pi.sendUserMessage(
+        i18n.t("agentEndNudge"),
+        { deliverAs: "followUp" },
+      );
+    }, NUDGE_DELAY_MS);
+  }
+
+  function renderWidget(ctx: { ui: { setWidget: Function } }, _theme: any) {
+    ctx.ui.setWidget(
+      "subagent-tools",
+      (_tui: any, theme: any) => {
+        const box = new Box(1, 0, (text: string) => theme.bg("toolSuccessBg", text));
+
+        const label = subagentAgent || subagentName;
+        const agentTag = label ? theme.bold(theme.fg("accent", `[${label}]`)) : "";
+
+        if (expanded) {
+          // Expanded: full tool list + denied
+          const countInfo = theme.fg("dim", ` — ${toolNames.length} available`);
+          const hint = theme.fg("muted", "  (Ctrl+J to collapse)");
+
+          const toolList = toolNames
+            .map((name: string) => theme.fg("dim", name))
+            .join(theme.fg("muted", ", "));
+
+          let deniedLine = "";
+          if (denied.length > 0) {
+            const deniedList = denied
+              .map((name: string) => theme.fg("error", name))
+              .join(theme.fg("muted", ", "));
+            deniedLine = "\n" + theme.fg("muted", "denied: ") + deniedList;
+          }
+
+          const content = new Text(
+            `${agentTag}${countInfo}${hint}\n${toolList}${deniedLine}`,
+            0,
+            0,
+          );
+          box.addChild(content);
+        } else {
+          // Collapsed: one-line summary
+          const countInfo = theme.fg("dim", ` — ${toolNames.length} tools`);
+          const deniedInfo =
+            denied.length > 0
+              ? theme.fg("dim", " · ") + theme.fg("error", `${denied.length} denied`)
+              : "";
+          const hint = theme.fg("muted", "  (Ctrl+J to expand)");
+
+          const content = new Text(`${agentTag}${countInfo}${deniedInfo}${hint}`, 0, 0);
+          box.addChild(content);
+        }
+
+        return box;
+      },
+      { placement: "aboveEditor" },
+    );
+  }
+
+  let userTookOver = false;
+  let agentStarted = false;
+
+  // Show widget + status bar on session start
+  pi.on("session_start", (_event, ctx) => {
+    recorder.sessionStart();
+    doneCalled = false;
+    userInputAfterAgentEnd = false;
+    clearNudgeTimer();
+    const tools = pi.getAllTools();
+    toolNames = tools.map((t) => t.name).sort();
+    denied = parseDeniedTools(deniedToolsValue);
+
+    renderWidget(ctx, null);
+  });
+
+  pi.on("input", () => {
+    recorder.input();
+    // User typed something — they are in control, cancel any pending nudge.
+    userInputAfterAgentEnd = true;
+    clearNudgeTimer();
+    // Ignore the initial task message that starts an autonomous subagent.
+    // Only inputs after the first agent run has started count as user takeover.
+    if (!shouldMarkUserTookOver(agentStarted)) return;
+    userTookOver = true;
+  });
+
+  pi.on("before_agent_start", () => {
+    recorder.beforeAgentStart();
+    // Agent is about to generate — clear any pending nudge; the AI is active.
+    clearNudgeTimer();
+  });
+
+  pi.on("agent_start", () => {
+    agentStarted = true;
+    recorder.agentStart();
+    // Agent has started a new generation cycle — clear any pending nudge.
+    userInputAfterAgentEnd = false;
+    clearNudgeTimer();
+  });
+
+  pi.on("agent_end", (event, ctx) => {
+    // auto-exit 已彻底移除：agent 必须主动调用 subagent_done 工具才能结束 session。
+    // 之前的 autoExit 短路会在 agent 正常结束 turn 时直接写 { type: "done" } 到
+    // .exit 文件，绕过 subagent_done 工具。这会让 workflow 系统（启用
+    // PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA 时）拿到 undefined 的 structuredOutput
+    // → "Subagent finished without calling structured_output"。
+    // 现在不论 autoExit env 如何，都不自动退出 — 只能靠 agent 自己调
+    // subagent_done（或 caller_ping）。如果 agent 不调，下面会有 nudge 提醒。
+    recorder.agentEndWaiting();
+
+    // For non-auto-exit agents: schedule a nudge in case the AI forgot to call
+    // subagent_done. This is automatically cleared/reset on any subsequent
+    // agent activity or user input.
+    scheduleAgentEndNudge();
+  });
+
+  pi.on("turn_start", (event) => {
+    recorder.turnStart((event as any).turnIndex);
+  });
+
+  pi.on("turn_end", (event) => {
+    recorder.turnEnd((event as any).turnIndex);
+  });
+
+  pi.on("before_provider_request", () => {
+    recorder.beforeProviderRequest();
+  });
+
+  pi.on("after_provider_response", () => {
+    recorder.afterProviderResponse();
+  });
+
+  pi.on("message_update", (event) => {
+    recorder.messageUpdate((event as any).assistantMessageEvent?.type);
+  });
+
+  pi.on("tool_execution_start", (event) => {
+    recorder.toolExecutionStart((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_call", (event) => {
+    recorder.toolCall((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_update", (event) => {
+    recorder.toolExecutionUpdate((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_result", (event) => {
+    recorder.toolResult((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("tool_execution_end", (event) => {
+    recorder.toolExecutionEnd((event as any).toolCallId, (event as any).toolName);
+  });
+
+  pi.on("session_shutdown", (event) => {
+    clearNudgeTimer();
+    recorder.sessionShutdown((event as any).reason);
+  });
+
+  // Toggle expand/collapse with Ctrl+J
+  pi.registerShortcut("ctrl+j", {
+    description: "Toggle subagent tools widget",
+    handler: (ctx) => {
+      expanded = !expanded;
+      renderWidget(ctx, null);
+    },
+  });
+
+  pi.registerTool({
+    name: "caller_ping",
+    label: "Caller Ping",
+    description:
+      "Send a help request to the parent agent and exit this session. " +
+      "The parent will be notified with your message and can resume this session with a response. " +
+      "Use when you're stuck, need clarification, or need the parent to take action.",
+    parameters: Type.Object({
+      message: Type.String({ description: "What you need help with" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const sessionFile = process.env.PI_SUBAGENT_SESSION;
+      if (!sessionFile) {
+        throw new Error(
+          "caller_ping is only available in subagent contexts. " +
+            "PI_SUBAGENT_SESSION environment variable is not set.",
+        );
+      }
+
+      doneCalled = true;
+      clearNudgeTimer();
+      recorder.callerPing();
+      const exitData = {
+        type: "ping" as const,
+        name: process.env.PI_SUBAGENT_NAME ?? "subagent",
+        message: params.message,
+      };
+      try {
+        writeFileSync(`${sessionFile}.exit`, JSON.stringify(exitData));
+      } catch (writeErr: any) {
+        process.stderr.write(
+          `[subagent-done] caller_ping: .exit 写入失败 file=${sessionFile}.exit err=${writeErr?.message ?? String(writeErr)}\n`,
+        );
+      }
+
+      ctx.shutdown();
+      return {
+        content: [{ type: "text", text: "Ping sent. Session will exit and parent will be notified." }],
+        details: {},
+      };
+    },
+  });
+
+  // ── subagent_done ──
+  // When PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA is set, the `result` parameter
+  // is required and ajv-validated against the JSON Schema before writing to
+  // the .exit sidecar. Otherwise `result` is optional — the subagent's last
+  // assistant message is used as the summary.
+  (() => {
+    let structuredOutputSchema: object | null = null;
+    try {
+      const raw = process.env.PI_SUBAGENT_STRUCTURED_OUTPUT_SCHEMA;
+      if (raw) structuredOutputSchema = JSON.parse(raw);
+    } catch {
+      // Schema parse failure — result will be optional.
+    }
+
+    const hasSchema = !!structuredOutputSchema;
+    let validate: ReturnType<Ajv["compile"]> | null = null;
+    if (hasSchema) {
+      const ajv = new Ajv({ allErrors: true });
+      validate = ajv.compile(structuredOutputSchema!);
+    }
+
+    // result 的类型直接用真实 schema（Type.Unsafe 透传 JSON Schema），让 AI 看到
+    // 完整的 properties/required。旧实现用空 Type.Object 占位 + 把 schema 藏在
+    // description 文本里，导致 AI 不知道要把字段包进 result，直接放到顶层参数。
+    const resultParam = hasSchema
+      ? Type.Unsafe({
+          ...(structuredOutputSchema as object),
+          description:
+            `Required structured result. Must match this JSON Schema:\n` +
+            JSON.stringify(structuredOutputSchema, null, 2),
+        })
+      : Type.Optional(
+          Type.Any({
+            description:
+              "Optional structured result for the parent session. Pass your structured output here.",
+          }),
+        );
+
+    const descriptionBase =
+      "Call this tool when you have completed your task. " +
+      "It will close this session and return your results to the main session.";
+    const description = hasSchema
+      ? `${descriptionBase} You MUST pass your final output as the \`result\` argument — it will be validated against a JSON Schema. If validation fails you will see the errors and can retry.`
+      : `${descriptionBase} Your LAST assistant message before calling this becomes the summary returned to the caller.`;
+
+    pi.registerTool({
+      name: "subagent_done",
+      label: "Subagent Done",
+      description,
+      parameters: Type.Object({ result: resultParam }),
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        const sessionFile = process.env.PI_SUBAGENT_SESSION;
+
+        // Validate structured result if schema is active
+        if (hasSchema) {
+          if (!params.result) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Validation failed — `result` is required for this task. Pass your structured output as the `result` argument.",
+                },
+              ],
+              details: { error: "validation_failed", errors: [{ message: "result is required" }] },
+            };
+          }
+          if (validate && !validate(params.result)) {
+            const errors = (validate.errors ?? [])
+              .map((e) => `  - ${e.instancePath || "/"}: ${e.message}`)
+              .join("\n");
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Validation failed — your \`result\` does not match the required schema:\n${errors}\n\nFix your arguments and call subagent_done again.`,
+                },
+              ],
+              details: { error: "validation_failed", errors: validate.errors },
+            };
+          }
+        }
+
+        doneCalled = true;
+        clearNudgeTimer();
+        recorder.subagentDone();
+
+        if (sessionFile) {
+          const exitFile = `${sessionFile}.exit`;
+          try {
+            if (params.result) {
+              writeFileSync(exitFile, JSON.stringify({ type: "structured_output", value: params.result }));
+            } else {
+              writeFileSync(exitFile, JSON.stringify({ type: "done" }));
+            }
+          } catch (writeErr: any) {
+            process.stderr.write(
+              `[subagent-done] subagent_done: .exit 写入失败 file=${exitFile} err=${writeErr?.message ?? String(writeErr)}\n`,
+            );
+          }
+        }
+
+        ctx.shutdown();
+        return {
+          content: [{ type: "text", text: "Shutting down subagent session." }],
+          details: params.result ?? {},
+        };
+      },
+    });
+  })();
+}

--- a/packages/pi-interactive-subagents/test/integration/agents/test-echo.md
+++ b/packages/pi-interactive-subagents/test/integration/agents/test-echo.md
@@ -1,0 +1,13 @@
+---
+name: test-echo
+description: Integration test agent — completes simple file-writing tasks
+model: anthropic/claude-haiku-4-5
+tools: read, bash, write, edit
+spawning: false
+auto-exit: true
+disable-model-invocation: true
+---
+
+You are a test agent. Complete the task given to you immediately. Be direct and concise.
+When asked to write content to a file, do it right away using the bash tool.
+Do not ask questions. Do not explain. Just execute the task.

--- a/packages/pi-interactive-subagents/test/integration/agents/test-ping.md
+++ b/packages/pi-interactive-subagents/test/integration/agents/test-ping.md
@@ -1,0 +1,11 @@
+---
+name: test-ping
+description: Integration test agent — calls caller_ping instead of completing task
+model: anthropic/claude-haiku-4-5
+tools: read, bash
+spawning: false
+disable-model-invocation: true
+---
+
+You are a test agent. When given ANY task, you must call the caller_ping tool with the message set to "PING: " followed by the task text you received.
+Do NOT complete the task yourself. Do NOT use any other tools. ONLY call caller_ping.

--- a/packages/pi-interactive-subagents/test/integration/harness.ts
+++ b/packages/pi-interactive-subagents/test/integration/harness.ts
@@ -1,0 +1,401 @@
+/**
+ * Integration test harness for pi-interactive-subagents.
+ *
+ * Provides utilities to:
+ * - Detect available mux backends (cmux, tmux, zellij)
+ * - Create isolated test environments with test agent definitions
+ * - Start real pi sessions in mux surfaces
+ * - Poll for file creation and screen output
+ * - Clean up surfaces and temp files after tests
+ */
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  cpSync,
+  readdirSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import {
+  getMuxBackend,
+  createSurface,
+  createSurfaceSplit,
+  sendCommand,
+  sendLongCommand,
+  readScreen,
+  readScreenAsync,
+  closeSurface,
+  sendEscape,
+  shellEscape,
+  parseCmuxFocusedSnapshotFromJson,
+  parseCmuxPaneRefForSurfaceFromJson,
+  type MuxBackend,
+} from "pi-terminal-mux";
+
+// Re-export mux primitives for tests
+export {
+  createSurface,
+  createSurfaceSplit,
+  sendCommand,
+  sendLongCommand,
+  readScreen,
+  readScreenAsync,
+  closeSurface,
+  sendEscape,
+  shellEscape,
+};
+export type { MuxBackend };
+
+// ── Paths ──
+
+const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(HARNESS_DIR, "../..");
+const TEST_AGENTS_SRC = join(HARNESS_DIR, "agents");
+
+/**
+ * Absolute path to the extension source in the working tree.
+ *
+ * Integration tests must exercise the code on the current branch — NOT the
+ * version installed as a pi-package under `~/.pi/agent/git/...` or the project
+ * mirror under `.pi/git/...`, which stays pinned to the last released tag.
+ *
+ * We force-load this file via `pi -ne -e <path>` in startPi() below so local
+ * edits are always the code under test, regardless of what pi-packages are
+ * installed on the host.
+ */
+const EXTENSION_SOURCE = join(PROJECT_ROOT, "pi-extension", "subagents", "index.ts");
+
+// ── Configuration ──
+
+/** Model used for integration tests. Override with PI_TEST_MODEL env var. */
+export const TEST_MODEL = process.env.PI_TEST_MODEL ?? "anthropic/claude-haiku-4-5";
+
+/** Per-test timeout in ms. Override with PI_TEST_TIMEOUT env var. */
+export const PI_TIMEOUT = Number(process.env.PI_TEST_TIMEOUT ?? "120000");
+
+// ── Backend detection ──
+
+/**
+ * Detect which mux backends are actually available in the current environment.
+ * Temporarily sets PI_SUBAGENT_MUX to probe each backend.
+ */
+export function getAvailableBackends(): MuxBackend[] {
+  const backends: MuxBackend[] = [];
+  const orig = process.env.PI_SUBAGENT_MUX;
+
+  for (const backend of ["cmux", "tmux", "zellij", "herdr", "otty"] as MuxBackend[]) {
+    process.env.PI_SUBAGENT_MUX = backend;
+    try {
+      if (getMuxBackend() === backend) backends.push(backend);
+    } catch {}
+  }
+
+  if (orig === undefined) delete process.env.PI_SUBAGENT_MUX;
+  else process.env.PI_SUBAGENT_MUX = orig;
+
+  return backends;
+}
+
+export function setBackend(backend: MuxBackend): string | undefined {
+  const prev = process.env.PI_SUBAGENT_MUX;
+  process.env.PI_SUBAGENT_MUX = backend;
+  return prev;
+}
+
+export function restoreBackend(prev: string | undefined): void {
+  if (prev === undefined) delete process.env.PI_SUBAGENT_MUX;
+  else process.env.PI_SUBAGENT_MUX = prev;
+}
+
+export function focusSurface(backend: MuxBackend, surface: string): void {
+  if (backend === "cmux") {
+    const pane = getSurfacePane(backend, surface);
+    if (pane) execFileSync("cmux", ["focus-pane", "--pane", pane], { encoding: "utf8" });
+    execFileSync("cmux", ["focus-panel", "--panel", surface], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "tmux") {
+    execFileSync("tmux", ["select-pane", "-t", surface], { encoding: "utf8" });
+    return;
+  }
+
+  if (backend === "otty") {
+    execFileSync("otty", ["pane", "focus", surface], { encoding: "utf8" });
+    return;
+  }
+
+  throw new Error(`Focus helpers are not implemented for ${backend}`);
+}
+
+export function getFocusedSurface(backend: MuxBackend): string | null {
+  if (backend === "cmux") {
+    const info = execFileSync("cmux", ["identify", "--json"], { encoding: "utf8" });
+    return parseCmuxFocusedSnapshotFromJson(info)?.surfaceRef ?? null;
+  }
+
+  if (backend === "tmux") {
+    try {
+      const panes = execFileSync("tmux", ["list-panes", "-F", "#{pane_id} #{pane_active}"], {
+        encoding: "utf8",
+      });
+      const activeLine = panes.split("\n").find((line) => line.endsWith(" 1"));
+      return activeLine?.split(" ")[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (backend === "otty") {
+    try {
+      const info = execFileSync("otty", ["panes", "--json", "--timeout", "1000"], {
+        encoding: "utf8",
+      });
+      const parsed = JSON.parse(info);
+      const active = parsed?.data?.find?.((p: { active: boolean }) => p.active);
+      return active?.id ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  throw new Error(`Focus helpers are not implemented for ${backend}`);
+}
+
+export function getSurfacePane(backend: MuxBackend, surface: string): string | null {
+  if (backend === "cmux") {
+    const info = execFileSync("cmux", ["identify", "--surface", surface], { encoding: "utf8" });
+    return parseCmuxPaneRefForSurfaceFromJson(info, surface);
+  }
+
+  if (backend === "tmux") return surface;
+
+  if (backend === "otty") return surface;
+
+  throw new Error(`Pane lookup is not implemented for ${backend}`);
+}
+
+export async function waitForFocusedSurface(
+  backend: MuxBackend,
+  surface: string,
+  timeout: number = PI_TIMEOUT,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (getFocusedSurface(backend) === surface) return;
+    await sleep(200);
+  }
+
+  throw new Error(
+    `Timeout (${timeout}ms) waiting for focused ${backend} surface ${surface}; ` +
+      `current focus is ${getFocusedSurface(backend) ?? "unknown"}`,
+  );
+}
+
+// ── Test environment ──
+
+export interface TestEnv {
+  /** Temp directory serving as the test project root */
+  dir: string;
+  /** Active mux backend for this test run */
+  backend: MuxBackend;
+  /** Surfaces created during the test (cleaned up automatically) */
+  surfaces: string[];
+  /** Temp files to clean up */
+  tempFiles: string[];
+}
+
+/**
+ * Create an isolated test environment with test agent definitions.
+ * The temp dir has `.pi/agents/` containing copies of all test agents.
+ */
+export function createTestEnv(backend: MuxBackend): TestEnv {
+  const dir = mkdtempSync(join(tmpdir(), "pi-integ-"));
+  const agentsDir = join(dir, ".pi", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+
+  // Copy test agent definitions into the project-local agents dir
+  if (existsSync(TEST_AGENTS_SRC)) {
+    for (const file of readdirSync(TEST_AGENTS_SRC)) {
+      if (file.endsWith(".md")) {
+        cpSync(join(TEST_AGENTS_SRC, file), join(agentsDir, file));
+      }
+    }
+  }
+
+  return { dir, backend, surfaces: [], tempFiles: [] };
+}
+
+/**
+ * Clean up all resources created during the test.
+ */
+export function cleanupTestEnv(env: TestEnv): void {
+  for (const surface of env.surfaces) {
+    try {
+      closeSurface(surface);
+    } catch {}
+  }
+  for (const file of env.tempFiles) {
+    try {
+      unlinkSync(file);
+    } catch {}
+  }
+  try {
+    rmSync(env.dir, { recursive: true, force: true });
+  } catch {}
+}
+
+/**
+ * Create a surface and register it for automatic cleanup.
+ */
+export function createTrackedSurface(env: TestEnv, name: string): string {
+  const surface = createSurface(name);
+  env.surfaces.push(surface);
+  return surface;
+}
+
+export function createTrackedSurfaceSplit(
+  env: TestEnv,
+  name: string,
+  direction: "left" | "right" | "up" | "down",
+  fromSurface?: string,
+): string {
+  const surface = createSurfaceSplit(name, direction, fromSurface);
+  env.surfaces.push(surface);
+  return surface;
+}
+
+/**
+ * Remove a surface from tracking (after manual close).
+ */
+export function untrackSurface(env: TestEnv, surface: string): void {
+  env.surfaces = env.surfaces.filter((s) => s !== surface);
+}
+
+// ── Pi session management ──
+
+/**
+ * Start a pi session in a mux surface with the subagents extension loaded.
+ * Returns immediately — the pi process runs asynchronously in the surface.
+ *
+ * The command ends with a sentinel so we can detect when pi exits:
+ *   `pi ...; echo '__TEST_DONE_'$?'__'`
+ */
+export function startPi(
+  surface: string,
+  testDir: string,
+  task: string,
+  opts?: { model?: string; extraArgs?: string },
+): void {
+  const model = opts?.model ?? TEST_MODEL;
+  const extra = opts?.extraArgs ?? "";
+
+  // Force pi to load the working-tree extension (not an installed pi-package
+  // snapshot). `-ne` disables extension auto-discovery, `-e <path>` loads the
+  // current branch's source directly. Without this, the tests silently run
+  // against whatever version is checked out under `~/.pi/agent/git/...`.
+  const cmd = [
+    `cd ${shellEscape(testDir)} &&`,
+    `pi`,
+    `-ne`,
+    `-e ${shellEscape(EXTENSION_SOURCE)}`,
+    `--model ${shellEscape(model)}`,
+    extra,
+    shellEscape(task),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  sendLongCommand(surface, `${cmd}; echo '__TEST_DONE_'$?'__'`, {
+    scriptPath: join(testDir, `test-launch-${Date.now()}.sh`),
+  });
+}
+
+// ── Polling helpers ──
+
+/**
+ * Poll until a regex pattern appears in the surface's screen output.
+ * Throws on timeout with the last screen contents for debugging.
+ */
+export async function waitForScreen(
+  surface: string,
+  pattern: RegExp,
+  timeout: number = PI_TIMEOUT,
+  lines: number = 200,
+): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const screen = await readScreenAsync(surface, lines);
+      if (pattern.test(screen)) return screen;
+    } catch {}
+    await sleep(2000);
+  }
+
+  let finalScreen = "";
+  try {
+    finalScreen = readScreen(surface, lines);
+  } catch {}
+  throw new Error(
+    `Timeout (${timeout}ms) waiting for pattern ${pattern}.\nLast screen:\n${finalScreen.slice(-1000)}`,
+  );
+}
+
+/**
+ * Poll until a file exists and optionally matches a content pattern.
+ * Returns the file content on success.
+ */
+export async function waitForFile(
+  path: string,
+  timeout: number = PI_TIMEOUT,
+  contentPattern?: RegExp,
+): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (existsSync(path)) {
+      const content = readFileSync(path, "utf8");
+      if (!contentPattern || contentPattern.test(content)) return content;
+    }
+    await sleep(2000);
+  }
+  throw new Error(
+    `Timeout (${timeout}ms) waiting for file: ${path}` +
+      (contentPattern ? ` matching ${contentPattern}` : ""),
+  );
+}
+
+/**
+ * Wait for the pi process in a surface to exit (sentinel detection).
+ * Returns the exit code.
+ */
+export async function waitForPiExit(
+  surface: string,
+  timeout: number = PI_TIMEOUT,
+): Promise<number> {
+  const screen = await waitForScreen(surface, /__TEST_DONE_(\d+)__/, timeout);
+  const match = screen.match(/__TEST_DONE_(\d+)__/);
+  return match ? parseInt(match[1], 10) : -1;
+}
+
+// ── Utilities ──
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function uniqueId(): string {
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+/**
+ * Register a temp file for cleanup.
+ */
+export function trackTempFile(env: TestEnv, path: string): void {
+  env.tempFiles.push(path);
+}

--- a/packages/pi-interactive-subagents/test/integration/mux-surface.test.ts
+++ b/packages/pi-interactive-subagents/test/integration/mux-surface.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Integration tests for the multiplexer surface layer.
+ *
+ * These tests exercise real mux operations: creating panes,
+ * sending commands, reading screen output, and closing surfaces.
+ * No LLM calls — fast and free.
+ *
+ * Run inside a supported multiplexer:
+ *   cmux bash -c 'npm run test:integration'
+ *   tmux new 'npm run test:integration'
+ *   zellij --session pi  # then run: npm run test:integration
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { unlinkSync } from "node:fs";
+import {
+  getAvailableBackends,
+  setBackend,
+  restoreBackend,
+  createTestEnv,
+  cleanupTestEnv,
+  createTrackedSurface,
+  createTrackedSurfaceSplit,
+  focusSurface,
+  getFocusedSurface,
+  getSurfacePane,
+  waitForFocusedSurface,
+  untrackSurface,
+  sendCommand,
+  sendLongCommand,
+  readScreen,
+  readScreenAsync,
+  closeSurface,
+  sendEscape,
+  sleep,
+  uniqueId,
+  trackTempFile,
+  waitForFile,
+  waitForScreen,
+  type TestEnv,
+} from "./harness.ts";
+
+const backends = getAvailableBackends();
+const FOCUS_TEST_SHELL_READY_DELAY_MS = Number(process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS ?? "2500");
+
+if (backends.length === 0) {
+  console.log("⚠️  No mux backend available — skipping mux-surface integration tests");
+  console.log("   Run inside cmux or tmux to enable these tests.");
+}
+
+for (const backend of backends) {
+  describe(`mux-surface [${backend}]`, { timeout: 60_000 }, () => {
+    let prevMux: string | undefined;
+    let env: TestEnv;
+
+    before(() => {
+      prevMux = setBackend(backend);
+      env = createTestEnv(backend);
+    });
+
+    after(() => {
+      cleanupTestEnv(env);
+      restoreBackend(prevMux);
+    });
+
+    it("keeps focus on the active surface while creating and targeting subagent surfaces", async () => {
+      const anchor = createTrackedSurfaceSplit(env, "focus-anchor", "right");
+      await sleep(1000);
+
+      focusSurface(backend, anchor);
+      await waitForFocusedSurface(backend, anchor, 10_000);
+
+      const childA = createTrackedSurface(env, "focus-child-a");
+      await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
+      assert.equal(getFocusedSurface(backend), anchor);
+
+      const childB = createTrackedSurface(env, "focus-child-b");
+      await sleep(FOCUS_TEST_SHELL_READY_DELAY_MS);
+      assert.equal(getFocusedSurface(backend), anchor);
+
+      if (backend === "cmux") {
+        const paneA = getSurfacePane(backend, childA);
+        const paneB = getSurfacePane(backend, childB);
+        assert.ok(paneA, `Expected pane ref for ${childA}`);
+        assert.ok(paneB, `Expected pane ref for ${childB}`);
+        assert.equal(paneB, paneA);
+      }
+
+      const markerA = uniqueId();
+      const markerB = uniqueId();
+      sendCommand(childA, `echo "FOCUS_A_${markerA}"`);
+      sendCommand(childB, `echo "FOCUS_B_${markerB}"`);
+
+      await Promise.all([
+        waitForScreen(childA, new RegExp(`FOCUS_A_${markerA}`), 20_000, 50),
+        waitForScreen(childB, new RegExp(`FOCUS_B_${markerB}`), 20_000, 50),
+      ]);
+      assert.equal(getFocusedSurface(backend), anchor);
+    });
+
+    it("creates a surface, sends a command, reads output, and closes it", async () => {
+      const surface = createTrackedSurface(env, "echo-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      sendCommand(surface, `echo "MARKER_${marker}"`);
+      await sleep(1500);
+
+      const screen = readScreen(surface, 50);
+      assert.ok(
+        screen.includes(`MARKER_${marker}`),
+        `Expected screen to contain MARKER_${marker}. Got:\n${screen}`,
+      );
+
+      closeSurface(surface);
+      untrackSurface(env, surface);
+    });
+
+    it("preserves shell special characters in echo output", async () => {
+      const surface = createTrackedSurface(env, "escape-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      // Single-quoted string — $ and " are literal inside single quotes
+      sendCommand(surface, `echo 'SPEC_${marker}_$HOME_"quotes"_done'`);
+      await sleep(1500);
+
+      const screen = readScreen(surface, 50);
+      assert.ok(
+        screen.includes(`SPEC_${marker}`),
+        `Expected special-char output. Got:\n${screen}`,
+      );
+      // $ should be literal inside single quotes
+      assert.ok(
+        screen.includes("$HOME"),
+        `Expected literal $HOME in output. Got:\n${screen}`,
+      );
+    });
+
+    it("sends a long command via script file without truncation", async () => {
+      const surface = createTrackedSurface(env, "long-cmd-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      const longValue = "X".repeat(500);
+      const command = `echo "LONG_${marker}_${longValue}_END"`;
+
+      sendLongCommand(surface, command);
+      await sleep(2000);
+
+      const screen = readScreen(surface, 50);
+      assert.ok(
+        screen.includes(`LONG_${marker}`),
+        `Expected long command output. Got:\n${screen.slice(0, 300)}...`,
+      );
+      assert.ok(
+        screen.includes("_END"),
+        `Expected full output (not truncated). Got:\n${screen.slice(-300)}`,
+      );
+    });
+
+    it("reads screen asynchronously", async () => {
+      const surface = createTrackedSurface(env, "async-read-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      sendCommand(surface, `echo "ASYNC_${marker}"`);
+      await sleep(1500);
+
+      const screen = await readScreenAsync(surface, 50);
+      assert.ok(
+        screen.includes(`ASYNC_${marker}`),
+        `Async read should find marker. Got:\n${screen}`,
+      );
+    });
+
+    it("manages multiple surfaces concurrently", async () => {
+      const s1 = createTrackedSurface(env, "multi-1");
+      const s2 = createTrackedSurface(env, "multi-2");
+      await sleep(1500);
+
+      const m1 = uniqueId();
+      const m2 = uniqueId();
+      sendCommand(s1, `echo "S1_${m1}"`);
+      sendCommand(s2, `echo "S2_${m2}"`);
+      await sleep(1500);
+
+      const screen1 = readScreen(s1, 50);
+      const screen2 = readScreen(s2, 50);
+
+      assert.ok(screen1.includes(`S1_${m1}`), `Surface 1 missing marker. Got:\n${screen1}`);
+      assert.ok(screen2.includes(`S2_${m2}`), `Surface 2 missing marker. Got:\n${screen2}`);
+    });
+
+    it("writes output to a file and verifies via surface", async () => {
+      const surface = createTrackedSurface(env, "file-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      const filePath = `/tmp/pi-mux-test-${marker}.txt`;
+
+      sendCommand(surface, `echo "FILE_${marker}" > ${filePath} && echo "WRITTEN_${marker}"`);
+
+      await waitForScreen(surface, new RegExp(`WRITTEN_${marker}`), 10_000, 50);
+      const content = await waitForFile(filePath, 10_000, new RegExp(`FILE_${marker}`));
+      assert.ok(content.includes(`FILE_${marker}`), `File content wrong. Got: ${content}`);
+
+      // Clean up
+      try {
+        unlinkSync(filePath);
+      } catch {}
+    });
+
+    it("delivers Escape as byte 27 to the target surface", async () => {
+      const surface = createTrackedSurface(env, "escape-byte-test");
+      await sleep(1000);
+
+      const marker = uniqueId();
+      const byteFile = `/tmp/pi-mux-escape-${marker}.txt`;
+      trackTempFile(env, byteFile);
+
+      const nodeProgram =
+        "const fs = require('node:fs');" +
+        "if (!process.stdin.isTTY) throw new Error('stdin is not a TTY');" +
+        "process.stdin.setRawMode(true);" +
+        "process.stdin.resume();" +
+        "process.stdout.write('ESC_READY\\n');" +
+        "process.stdin.once('data', (chunk) => {" +
+        `fs.writeFileSync(${JSON.stringify(byteFile)}, Array.from(chunk).join(','));` +
+        "process.exit(0);" +
+        "});";
+      const command = `node -e ${JSON.stringify(nodeProgram)}`;
+
+      sendLongCommand(surface, command);
+      await waitForScreen(surface, /ESC_READY/, 15_000, 50);
+
+      sendEscape(surface);
+
+      const content = await waitForFile(byteFile, 15_000, /^27$/);
+      assert.equal(content.trim(), "27");
+    });
+  });
+}

--- a/packages/pi-interactive-subagents/test/integration/subagent-lifecycle.test.ts
+++ b/packages/pi-interactive-subagents/test/integration/subagent-lifecycle.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Integration tests for the full subagent lifecycle.
+ *
+ * These tests spawn REAL pi sessions with REAL LLM calls (haiku by default).
+ * Each test creates a mux surface, runs pi with a task that uses the subagent
+ * tool, and verifies the outcome via marker files and screen output.
+ *
+ * Costs: ~$0.01-0.05 per test run (haiku).
+ * Duration: ~30-90s per test.
+ *
+ * Run inside a supported multiplexer:
+ *   cmux bash -c 'npm run test:integration'
+ *   tmux new 'npm run test:integration'
+ *
+ * Configuration:
+ *   PI_TEST_MODEL     — model for all pi sessions (default: anthropic/claude-haiku-4-5)
+ *   PI_TEST_TIMEOUT   — per-test timeout in ms (default: 120000)
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import {
+  getAvailableBackends,
+  setBackend,
+  restoreBackend,
+  createTestEnv,
+  cleanupTestEnv,
+  createTrackedSurface,
+  startPi,
+  waitForScreen,
+  waitForFile,
+  sleep,
+  uniqueId,
+  trackTempFile,
+  readScreen,
+  PI_TIMEOUT,
+  type TestEnv,
+} from "./harness.ts";
+
+const backends = getAvailableBackends();
+
+if (backends.length === 0) {
+  console.log("⚠️  No mux backend available — skipping subagent lifecycle integration tests");
+  console.log("   Run inside cmux or tmux to enable these tests.");
+}
+
+for (const backend of backends) {
+  describe(`subagent-lifecycle [${backend}]`, { timeout: PI_TIMEOUT * 3 }, () => {
+    let prevMux: string | undefined;
+    let env: TestEnv;
+
+    before(() => {
+      prevMux = setBackend(backend);
+      env = createTestEnv(backend);
+    });
+
+    after(() => {
+      cleanupTestEnv(env);
+      restoreBackend(prevMux);
+    });
+
+    // ── Basic spawn + completion ──
+
+    it("spawns a subagent that writes a file and verifies the session", async () => {
+      const id = uniqueId();
+      const markerFile = `/tmp/pi-integ-echo-${id}.txt`;
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `echo-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these EXACT parameters:`,
+        `  name: "Echo-${id}"`,
+        `  agent: "test-echo"`,
+        `  task: "Run this bash command: echo 'PASS_${id}' > '${markerFile}'"`,
+        `Do not do anything else. Just call the subagent tool once.`,
+        `After you receive the subagent result, say INTEGRATION_COMPLETE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      // Verify: subagent created the marker file
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /PASS/);
+      assert.ok(
+        content.includes(`PASS_${id}`),
+        `Marker file should contain PASS_${id}. Got: ${content.trim()}`,
+      );
+
+      // Verify: outer pi received the subagent result
+      const screen = await waitForScreen(
+        surface,
+        /INTEGRATION_COMPLETE|completed|Sub-agent.*"Echo/i,
+        PI_TIMEOUT,
+      );
+
+      // Verify: session file was created (shown in steer result)
+      const sessionMatch = screen.match(/Session:\s*(\S+\.jsonl)/);
+      if (sessionMatch) {
+        const sessionFile = sessionMatch[1];
+        assert.ok(existsSync(sessionFile), `Subagent session file should exist: ${sessionFile}`);
+
+        const lines = readFileSync(sessionFile, "utf8").trim().split("\n");
+        assert.ok(lines.length >= 2, `Session should have ≥2 entries, got ${lines.length}`);
+
+        const header = JSON.parse(lines[0]);
+        assert.equal(header.type, "session", "First entry should be session header");
+        assert.ok(header.id, "Session header should have an id");
+      }
+    });
+
+    // ── In-progress activity snapshots ──
+
+    it("keeps a long active tool call from surfacing false stalled status", async () => {
+      const id = uniqueId();
+      const startFile = `/tmp/pi-integ-status-start-${id}.txt`;
+      const markerFile = `/tmp/pi-integ-status-${id}.txt`;
+      trackTempFile(env, startFile);
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `status-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these EXACT parameters:`,
+        `  name: "Status-${id}"`,
+        `  agent: "test-echo"`,
+        `  task: "Run this bash command: echo 'START_${id}' > '${startFile}'; sleep 90; echo 'STATUS_${id}' > '${markerFile}'"`,
+        `Do not do anything else. Just call the subagent tool once.`,
+        `After you receive the subagent result, say STATUS_TEST_DONE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      const activeScreen = await waitForScreen(surface, /active[\s\S]*bash|bash[\s\S]*active/i, PI_TIMEOUT, 300);
+      assert.doesNotMatch(activeScreen, /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i);
+
+      await waitForFile(startFile, PI_TIMEOUT, /START_/);
+      assert.equal(existsSync(markerFile), false, "Completion marker should not exist before the long sleep");
+      await sleep(65_000);
+      assert.equal(existsSync(markerFile), false, "Completion marker should not exist before the watchdog assertion");
+      const watchdogScreen = readScreen(surface, 300);
+      assert.doesNotMatch(watchdogScreen, /Subagent status[\s\S]*stalled|stalled[\s\S]*Subagent status/i);
+
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /STATUS_/);
+      assert.ok(content.includes(`STATUS_${id}`), `Marker file should contain STATUS_${id}`);
+
+      const completionScreen = await waitForScreen(
+        surface,
+        /STATUS_TEST_DONE|completed|Sub-agent.*"Status-/i,
+        PI_TIMEOUT,
+        300,
+      );
+      assert.ok(/STATUS_TEST_DONE|completed/i.test(completionScreen));
+    });
+
+    // ── Parallel subagent spawn ──
+
+    it("spawns two subagents in parallel and both complete", async () => {
+      const id = uniqueId();
+      const fileA = `/tmp/pi-integ-para-${id}-a.txt`;
+      const fileB = `/tmp/pi-integ-para-${id}-b.txt`;
+      trackTempFile(env, fileA);
+      trackTempFile(env, fileB);
+
+      const surface = createTrackedSurface(env, `parallel-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `You must call the subagent tool TWICE. Make both calls before waiting for results.`,
+        ``,
+        `First call:`,
+        `  name: "ParaA-${id}"`,
+        `  agent: "test-echo"`,
+        `  task: "Run: echo 'DONE_A_${id}' > '${fileA}'"`,
+        ``,
+        `Second call:`,
+        `  name: "ParaB-${id}"`,
+        `  agent: "test-echo"`,
+        `  task: "Run: echo 'DONE_B_${id}' > '${fileB}'"`,
+        ``,
+        `Call both subagent tools NOW, do not wait between them.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      // Both marker files should appear
+      const [contentA, contentB] = await Promise.all([
+        waitForFile(fileA, PI_TIMEOUT, /DONE_A/),
+        waitForFile(fileB, PI_TIMEOUT, /DONE_B/),
+      ]);
+
+      assert.ok(contentA.includes(`DONE_A_${id}`), `File A should contain marker`);
+      assert.ok(contentB.includes(`DONE_B_${id}`), `File B should contain marker`);
+    });
+
+    // ── Fork mode ──
+
+    it("fork mode creates a child session linked to the parent", async () => {
+      const id = uniqueId();
+      const markerFile = `/tmp/pi-integ-fork-${id}.txt`;
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `fork-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these EXACT parameters:`,
+        `  name: "Fork-${id}"`,
+        `  fork: true`,
+        `  task: "Run this bash command: echo 'FORK_OK_${id}' > '${markerFile}'"`,
+        `Do not set the agent parameter. Just set name, fork, and task.`,
+        `After you receive the result, say FORK_COMPLETE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      // Verify: forked subagent created the file
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /FORK_OK/);
+      assert.ok(content.includes(`FORK_OK_${id}`), `Fork marker file should exist with content`);
+
+      // Wait for the outer pi to show the result
+      const screen = await waitForScreen(
+        surface,
+        /FORK_COMPLETE|completed|Sub-agent.*"Fork/i,
+        PI_TIMEOUT,
+      );
+
+      // Verify: the forked session has a parent link
+      const sessionMatch = screen.match(/Session:\s*(\S+\.jsonl)/);
+      if (sessionMatch) {
+        const sessionFile = sessionMatch[1];
+        assert.ok(existsSync(sessionFile), `Fork session file should exist: ${sessionFile}`);
+
+        const entries = readFileSync(sessionFile, "utf8")
+          .trim()
+          .split("\n")
+          .map((l) => JSON.parse(l));
+        const header = entries[0];
+        assert.equal(header.type, "session", "First entry should be session header");
+        assert.ok(header.parentSession, "Fork session should have parentSession field");
+        // Fork sessions include parent context (model_change entries etc.)
+        assert.ok(entries.length >= 2, "Fork session should have context entries beyond header");
+      }
+    });
+
+    // ── caller_ping ──
+
+    it("subagent caller_ping sends notification back to the parent", async () => {
+      const id = uniqueId();
+
+      const surface = createTrackedSurface(env, `ping-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these EXACT parameters:`,
+        `  name: "Ping-${id}"`,
+        `  agent: "test-ping"`,
+        `  task: "PING_TEST_${id}"`,
+        `Just call the subagent tool once. Do not do anything else before calling it.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      // The test-ping agent calls caller_ping, which steers a "needs help" message
+      // back to the outer pi. Look for it on screen.
+      const screen = await waitForScreen(
+        surface,
+        /needs help|PING|caller_ping|ping/i,
+        PI_TIMEOUT,
+      );
+
+      assert.ok(
+        /needs help|PING/i.test(screen),
+        `Screen should show ping notification. Got:\n${screen.slice(-800)}`,
+      );
+    });
+
+    // ── Agent discovery ──
+
+    it("subagent discovers project-local test agents", async () => {
+      const id = uniqueId();
+      const markerFile = `/tmp/pi-integ-discovery-${id}.txt`;
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `discovery-${id}`);
+      await sleep(1000);
+
+      // Use subagents_list to verify test agents are discoverable,
+      // then spawn one to prove it works end-to-end.
+      const task = [
+        `First, call the subagents_list tool to see available agents.`,
+        `Then call the subagent tool:`,
+        `  name: "Disco-${id}"`,
+        `  agent: "test-echo"`,
+        `  task: "Run: echo 'DISCO_${id}' > '${markerFile}'"`,
+        `After you receive the subagent result, say DISCOVERY_DONE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      // The test-echo agent (discovered from project .pi/agents/) should work
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /DISCO/);
+      assert.ok(content.includes(`DISCO_${id}`), `Discovery test marker should exist`);
+    });
+
+    // ── Subagent with custom system prompt ──
+
+    it("passes systemPrompt to subagent", async () => {
+      const id = uniqueId();
+      const markerFile = `/tmp/pi-integ-sysprompt-${id}.txt`;
+      trackTempFile(env, markerFile);
+
+      const surface = createTrackedSurface(env, `sysprompt-${id}`);
+      await sleep(1000);
+
+      const task = [
+        `Call the subagent tool with these parameters:`,
+        `  name: "SysP-${id}"`,
+        `  agent: "test-echo"`,
+        `  systemPrompt: "Always start your response with CUSTOM_PROMPT_ACTIVE."`,
+        `  task: "Write 'SYSPROMPT_${id}' to ${markerFile} using bash: echo 'SYSPROMPT_${id}' > '${markerFile}'"`,
+        `After the subagent completes, say SYSPROMPT_TEST_DONE.`,
+      ].join("\n");
+
+      startPi(surface, env.dir, task);
+
+      const content = await waitForFile(markerFile, PI_TIMEOUT, /SYSPROMPT/);
+      assert.ok(content.includes(`SYSPROMPT_${id}`), `System prompt test marker should exist`);
+    });
+  });
+}

--- a/packages/pi-interactive-subagents/test/otty-smoke.test.ts
+++ b/packages/pi-interactive-subagents/test/otty-smoke.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Otty backend smoke test.
+ *
+ * 直接调用 otty.ts 的导出函数，验证：
+ *   1. isOttyRuntimeAvailable 检测 TERM_PROGRAM=otty + otty CLI
+ *   2. isOttySendKeysEnabled 检测 ipc-allow-send-keys 配置
+ *   3. readOttyPanes / getTabIdForPane / readOttyScreen 解析正确
+ *   4. createOttySurface 创建新 pane 并通过 diffNewPane 推断 id
+ *   5. closeOttySurface 清理（best-effort）+ state marker 同步
+ *
+ * 不在 pi pane 上跑（避免误触 TUI），全程在 herdr pane 上测试。
+ *
+ * 运行：
+ *   cd pi-interactive-subagents && NODE_PATH=/opt/homebrew/lib/node_modules npx tsx test/otty-smoke.test.ts
+ */
+
+import { execSync } from "node:child_process";
+import { rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isOttyRuntimeAvailable,
+  isOttySendKeysEnabled,
+  readOttyPanes,
+  getTabIdForPane,
+  readOttyScreen,
+  createOttySurface,
+  closeOttySurface,
+  AGENT_OTTY_PANE_ID,
+} from "pi-terminal-mux";
+
+let passed = 0;
+let failed = 0;
+
+function ok(cond: boolean, msg: string): void {
+  if (cond) {
+    console.log(`  ✅ ${msg}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${msg}`);
+    failed++;
+  }
+}
+
+function section(name: string): void {
+  console.log(`\n${name}`);
+}
+
+function sleep(ms: number): void {
+  try {
+    execSync(`sleep ${(ms / 1000).toFixed(2)}`, { stdio: "ignore" });
+  } catch {
+    /* ignore */
+  }
+}
+
+console.log("═══════════════════════════════════════");
+console.log(" Otty backend smoke test");
+console.log("═══════════════════════════════════════");
+
+// ── 环境检测 ──
+section("1. Environment detection");
+const available = isOttyRuntimeAvailable();
+ok(
+  available,
+  "isOttyRuntimeAvailable() returns true (TERM_PROGRAM=otty + otty CLI in PATH + app running)",
+);
+ok(
+  typeof AGENT_OTTY_PANE_ID === "string" || AGENT_OTTY_PANE_ID === null,
+  `AGENT_OTTY_PANE_ID captured at module load: ${AGENT_OTTY_PANE_ID ?? "null"}`,
+);
+
+if (!available) {
+  console.log("\n⚠️  Otty not available — skipping remaining tests");
+  console.log("   Run this inside Otty terminal: `otty` should be in PATH and TERM_PROGRAM=otty");
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+// ── send-keys 开关检测 ──
+section("2. send-keys enablement");
+const sendKeys = isOttySendKeysEnabled();
+ok(typeof sendKeys === "boolean", `isOttySendKeysEnabled() returned ${sendKeys}`);
+if (!sendKeys) {
+  console.log("  ℹ️  send-keys disabled — 测试 send-command/send-escape 时会 noop");
+  console.log("     在 ~/.config/otty/config.toml 中设置 ipc-allow-send-keys = true");
+}
+
+// ── panes 读取 ──
+section("3. readOttyPanes");
+const panes = readOttyPanes();
+ok(panes.length > 0, `panes.length = ${panes.length} (>0)`);
+ok(
+  panes.some((p) => typeof p.id === "string" && p.id.startsWith("p_")),
+  "at least one pane id starts with 'p_' (otty format)",
+);
+ok(
+  typeof panes[0]?.tab_id === "string",
+  `first pane has tab_id (${panes[0]?.tab_id ?? "?"})`,
+);
+const activeCount = panes.filter((p) => p.active).length;
+ok(activeCount >= 1, `${activeCount} pane(s) marked active`);
+
+// ── tab id 解析 ──
+section("4. getTabIdForPane");
+const samplePane = panes[0]!;
+const tabId = getTabIdForPane(samplePane.id);
+ok(
+  tabId === samplePane.tab_id,
+  `getTabIdForPane(${samplePane.id}) -> ${tabId ?? "null"} (expected ${samplePane.tab_id})`,
+);
+
+// ── readOttyScreen ──
+section("5. readOttyScreen");
+const screen = readOttyScreen(samplePane.id, 20);
+ok(typeof screen === "string", `readOttyScreen returned ${screen.length} chars`);
+
+// ── createSurface + state marker ──
+section("6. createOttySurface");
+const stateFile = join(
+  tmpdir(),
+  `otty-subagent-pane-${(AGENT_OTTY_PANE_ID ?? "default").replace(/[^a-zA-Z0-9_-]/g, "_")}.json`,
+);
+try {
+  rmSync(stateFile);
+} catch {
+  /* ignore */
+}
+
+const beforePanes = readOttyPanes();
+const newPaneId = createOttySurface("smoke-test-1");
+const afterPanes = readOttyPanes();
+
+ok(typeof newPaneId === "string" && newPaneId.length > 0, `createOttySurface returned "${newPaneId}"`);
+if (newPaneId) {
+  ok(newPaneId.startsWith("p_"), `new pane id has otty format: ${newPaneId}`);
+  ok(
+    !beforePanes.some((p) => p.id === newPaneId),
+    "new pane was not in pane list before createSurface",
+  );
+  ok(
+    afterPanes.some((p) => p.id === newPaneId),
+    "new pane appears in pane list after createSurface",
+  );
+
+  // 验证 state marker
+  ok(existsSync(stateFile), `state marker written: ${stateFile}`);
+
+  // 验证 readScreen 在新 pane 上能用
+  const newScreen = readOttyScreen(newPaneId, 5);
+  ok(typeof newScreen === "string", `readOttyScreen on new pane works (${newScreen.length} chars)`);
+
+  // ── closeSurface 清理 ──
+  section("7. closeOttySurface");
+  closeOttySurface(newPaneId);
+  sleep(300);
+  const finalPanes = readOttyPanes();
+  // Otty 1.0.4 已知问题：`otty pane close` 命令返回成功但不实际删除 pane。
+  // 后端能做的只是清理 state marker、避免脏数据。验证 cleanup 逻辑正确即可。
+  let stateAfter: { panes?: string[] } | null = null;
+  try {
+    stateAfter = JSON.parse(readFileSync(stateFile, "utf8"));
+  } catch {
+    stateAfter = null;
+  }
+  ok(
+    stateAfter === null || !stateAfter.panes?.includes(newPaneId),
+    "state marker cleaned up (pane removed from state.panes)",
+  );
+  // pane 实际是否被关掉由 Otty CLI 决定，不作为硬性断言。
+  const paneStillThere = finalPanes.some((p) => p.id === newPaneId);
+  if (paneStillThere) {
+    console.log(
+      `  ℹ️  pane ${newPaneId} still in pane list (Otty 1.0.4 pane close limitation, state marker still cleaned)`,
+    );
+  } else {
+    ok(true, `pane ${newPaneId} no longer in pane list`);
+  }
+}
+
+// ── 二次 createSurface 验证广度优先 ──
+section("8. createSurface #2 (breadth-first)");
+const secondId = createOttySurface("smoke-test-2");
+if (secondId && newPaneId) {
+  ok(secondId !== newPaneId, `second surface id differs from first (${secondId} vs ${newPaneId})`);
+  closeOttySurface(secondId);
+  sleep(300);
+}
+
+console.log("\n═══════════════════════════════════════");
+console.log(`  通过: ${passed}  |  失败: ${failed}`);
+console.log("═══════════════════════════════════════");
+
+process.exit(failed > 0 ? 1 : 0);

--- a/packages/pi-interactive-subagents/test/system-prompt-mode.test.ts
+++ b/packages/pi-interactive-subagents/test/system-prompt-mode.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Smoke tests for the systemPromptMode feature.
+ * Tests: frontmatter parsing, identity routing, CLI flag generation.
+ */
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, msg: string) {
+  if (condition) {
+    console.log(`  ✅ ${msg}`);
+    passed++;
+  } else {
+    console.log(`  ❌ ${msg}`);
+    failed++;
+  }
+}
+
+// --- Extracted logic under test ---
+
+function parseFrontmatter(content: string) {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const frontmatter = match[1];
+  const get = (key: string) => {
+    const m = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+    return m ? m[1].trim() : undefined;
+  };
+  const body = content.replace(/^---\n[\s\S]*?\n---\n*/, "").trim();
+  const spm = get("system-prompt");
+  return {
+    systemPromptMode: spm === "replace" ? "replace" : spm === "append" ? "append" : undefined,
+    body: body || undefined,
+  };
+}
+
+function simulateRouting(
+  agentBody: string | undefined,
+  systemPromptMode: "append" | "replace" | undefined,
+  paramSystemPrompt: string | undefined,
+) {
+  const identity = agentBody ?? paramSystemPrompt ?? null;
+  const identityInSystemPrompt = systemPromptMode && identity;
+  const roleBlock = identity && !identityInSystemPrompt ? `\n\n${identity}` : "";
+
+  let cliFlag: string | null = null;
+  if (identityInSystemPrompt && identity) {
+    cliFlag = systemPromptMode === "replace" ? "--system-prompt" : "--append-system-prompt";
+  }
+
+  return { roleBlock, cliFlag, identityInSystemPrompt: !!identityInSystemPrompt };
+}
+
+// --- Fixtures ---
+
+const AGENT_REPLACE = `---
+model: anthropic/claude-sonnet-4-20250514
+system-prompt: replace
+auto-exit: true
+---
+
+You are a specialized agent.`;
+
+const AGENT_APPEND = `---
+model: anthropic/claude-sonnet-4-20250514
+system-prompt: append
+---
+
+You are an appended identity.`;
+
+const AGENT_DEFAULT = `---
+model: anthropic/claude-sonnet-4-20250514
+---
+
+You are a default agent.`;
+
+const AGENT_INVALID = `---
+model: anthropic/claude-sonnet-4-20250514
+system-prompt: foobar
+---
+
+Body here.`;
+
+// --- Test 1: Frontmatter parsing ---
+console.log("\n🧪 Frontmatter parsing of system-prompt field");
+
+const r1 = parseFrontmatter(AGENT_REPLACE)!;
+assert(r1.systemPromptMode === "replace", "system-prompt: replace → mode is 'replace'");
+assert(r1.body === "You are a specialized agent.", "body extracted correctly");
+
+const r2 = parseFrontmatter(AGENT_APPEND)!;
+assert(r2.systemPromptMode === "append", "system-prompt: append → mode is 'append'");
+
+const r3 = parseFrontmatter(AGENT_DEFAULT)!;
+assert(r3.systemPromptMode === undefined, "no system-prompt field → mode is undefined");
+
+const r4 = parseFrontmatter(AGENT_INVALID)!;
+assert(r4.systemPromptMode === undefined, "system-prompt: foobar → mode is undefined (ignored)");
+
+// --- Test 2: Identity routing ---
+console.log("\n🧪 Identity routing (system prompt vs user message)");
+
+const s1 = simulateRouting("You are X.", "replace", undefined);
+assert(s1.roleBlock === "", "replace mode: roleBlock empty (not in task)");
+assert(s1.cliFlag === "--system-prompt", "replace mode: uses --system-prompt flag");
+
+const s2 = simulateRouting("You are X.", "append", undefined);
+assert(s2.roleBlock === "", "append mode: roleBlock empty (not in task)");
+assert(s2.cliFlag === "--append-system-prompt", "append mode: uses --append-system-prompt flag");
+
+const s3 = simulateRouting("You are X.", undefined, undefined);
+assert(s3.roleBlock === "\n\nYou are X.", "no mode: roleBlock contains identity");
+assert(s3.cliFlag === null, "no mode: no CLI flag");
+
+const s4 = simulateRouting(undefined, undefined, undefined);
+assert(s4.roleBlock === "", "no identity: roleBlock empty");
+assert(s4.cliFlag === null, "no identity: no CLI flag");
+
+const s5 = simulateRouting(undefined, "replace", undefined);
+assert(s5.roleBlock === "", "mode set but no body: roleBlock empty");
+assert(s5.cliFlag === null, "mode set but no body: no CLI flag");
+
+const s6 = simulateRouting(undefined, "replace", "Param identity");
+assert(s6.cliFlag === "--system-prompt", "mode + param systemPrompt: uses CLI flag");
+assert(s6.roleBlock === "", "mode + param systemPrompt: roleBlock empty");
+
+// --- Test 3: End-to-end with temp agent files ---
+console.log("\n🧪 End-to-end with temp agent files");
+
+const tmpDir = mkdtempSync(join(tmpdir(), "pi-test-spm-"));
+const agentsDir = join(tmpDir, ".pi", "agents");
+mkdirSync(agentsDir, { recursive: true });
+
+writeFileSync(join(agentsDir, "test-replace.md"), AGENT_REPLACE);
+writeFileSync(join(agentsDir, "test-append.md"), AGENT_APPEND);
+writeFileSync(join(agentsDir, "test-default.md"), AGENT_DEFAULT);
+
+function loadFromDir(name: string) {
+  const p = join(agentsDir, `${name}.md`);
+  if (!existsSync(p)) return null;
+  return parseFrontmatter(readFileSync(p, "utf8"));
+}
+
+const t1 = loadFromDir("test-replace")!;
+assert(t1.systemPromptMode === "replace", "file test-replace.md → replace mode");
+assert(t1.body === "You are a specialized agent.", "file test-replace.md → body correct");
+
+const t2 = loadFromDir("test-append")!;
+assert(t2.systemPromptMode === "append", "file test-append.md → append mode");
+
+const t3 = loadFromDir("test-default")!;
+assert(t3.systemPromptMode === undefined, "file test-default.md → no mode");
+
+rmSync(tmpDir, { recursive: true });
+
+// --- Summary ---
+console.log(`\n${"=".repeat(40)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);
+console.log("All tests passed! ✅\n");

--- a/packages/pi-interactive-subagents/test/test.ts
+++ b/packages/pi-interactive-subagents/test/test.ts
@@ -1,0 +1,2393 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import * as subagentsModule from "../pi-extension/subagents/index.ts";
+
+import {
+  getLeafId,
+  getNewEntries,
+  findLastAssistantMessage,
+  appendBranchSummary,
+  copySessionFile,
+  mergeNewEntries,
+  seedSubagentSessionFile,
+} from "../pi-extension/subagents/session.ts";
+
+import {
+  shellEscape,
+  isCmuxAvailable,
+  isWezTermAvailable,
+  parseCmuxFocusedSnapshot,
+  parseCmuxFocusedSnapshotFromJson,
+  parseCmuxJson,
+  parseCmuxPaneRefForSurface,
+  parseCmuxPaneRefForSurfaceFromJson,
+  canSplitZellijPane,
+  predictZellijSplitDirection,
+  selectZellijPlacement,
+  selectZellijStackPlacement,
+} from "pi-terminal-mux";
+import {
+  advanceStatusState,
+  capStatusLines,
+  classifyStatus,
+  createStatusState,
+  forceStatusAfterInterrupt,
+  formatStatusAggregate,
+  formatStatusLine,
+  formatTransitionLine,
+  observeStatus,
+  loadStatusConfig,
+  parseStatusConfig,
+} from "../pi-extension/subagents/status.ts";
+import {
+  createSubagentActivityRecorder,
+  getSubagentActivityFile,
+  readSubagentActivityFile,
+} from "../pi-extension/subagents/activity.ts";
+import {
+  shouldMarkUserTookOver,
+  shouldAutoExitOnAgentEnd,
+} from "../pi-extension/subagents/subagent-done.ts";
+
+// --- Helpers ---
+
+function createTestDir(): string {
+  return mkdtempSync(join(tmpdir(), "subagents-test-"));
+}
+
+function createSessionFile(dir: string, entries: object[]): string {
+  const file = join(dir, "test-session.jsonl");
+  const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(file, content);
+  return file;
+}
+
+function withTempDir(run: (dir: string) => void) {
+  const dir = createTestDir();
+  try {
+    run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function createMockExtensionApi() {
+  const registeredTools: Array<any> = [];
+  const registeredCommands: Array<any> = [];
+  const registeredMessageRenderers: Array<any> = [];
+  const sentUserMessages: string[] = [];
+  const sentMessages: Array<any> = [];
+  return {
+    registeredTools,
+    registeredCommands,
+    registeredMessageRenderers,
+    sentUserMessages,
+    sentMessages,
+    api: {
+      on() {},
+      registerTool(tool: any) {
+        registeredTools.push(tool);
+      },
+      registerCommand(name: string, command: any) {
+        registeredCommands.push({ name, ...command });
+      },
+      registerMessageRenderer(name: string, renderer: any) {
+        registeredMessageRenderers.push({ name, renderer });
+      },
+      registerShortcut() {},
+      sendUserMessage(message: string) {
+        sentUserMessages.push(message);
+      },
+      sendMessage(message: any, options?: any) {
+        sentMessages.push({ message, options });
+      },
+      getAllTools() {
+        return [];
+      },
+    } as any,
+  };
+}
+
+function restoreEnvVar(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function withMockedNow<T>(now: number, fn: () => T): T {
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    return fn();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+function writeAgentFile(
+  agentsDir: string,
+  name: string,
+  frontmatter: string,
+  body = "You are a test agent.",
+) {
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(join(agentsDir, `${name}.md`), `---\n${frontmatter}\n---\n\n${body}\n`);
+}
+
+async function withIsolatedAgentEnv(
+  fn: (paths: {
+    projectDir: string;
+    projectAgentsDir: string;
+    globalDir: string;
+    globalAgentsDir: string;
+  }) => Promise<void> | void,
+) {
+  const root = createTestDir();
+  const previousCwd = process.cwd();
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const projectDir = join(root, "project");
+  const projectAgentsDir = join(projectDir, ".pi", "agents");
+  const globalDir = join(root, "global");
+  const globalAgentsDir = join(globalDir, "agents");
+
+  mkdirSync(projectAgentsDir, { recursive: true });
+  mkdirSync(globalAgentsDir, { recursive: true });
+  process.chdir(projectDir);
+  process.env.PI_CODING_AGENT_DIR = globalDir;
+
+  try {
+    await fn({ projectDir, projectAgentsDir, globalDir, globalAgentsDir });
+  } finally {
+    process.chdir(previousCwd);
+    restoreEnvVar("PI_CODING_AGENT_DIR", previousAgentDir);
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+const SESSION_HEADER = { type: "session", id: "sess-001", version: 3 };
+const MODEL_CHANGE = { type: "model_change", id: "mc-001", parentId: null };
+const USER_MSG = {
+  type: "message",
+  id: "user-001",
+  parentId: "mc-001",
+  message: {
+    role: "user",
+    content: [{ type: "text", text: "Hello, plan something" }],
+  },
+};
+const ASSISTANT_MSG = {
+  type: "message",
+  id: "asst-001",
+  parentId: "user-001",
+  message: {
+    role: "assistant",
+    content: [{ type: "text", text: "Here is my plan..." }],
+  },
+};
+const ASSISTANT_MSG_2 = {
+  type: "message",
+  id: "asst-002",
+  parentId: "asst-001",
+  message: {
+    role: "assistant",
+    content: [
+      { type: "thinking", thinking: "Let me think..." },
+      { type: "text", text: "Updated plan with details." },
+    ],
+  },
+};
+const TOOL_RESULT = {
+  type: "message",
+  id: "tool-001",
+  parentId: "asst-001",
+  message: {
+    role: "toolResult",
+    toolCallId: "tc-001",
+    toolName: "bash",
+    content: [{ type: "text", text: "output here" }],
+  },
+};
+
+// --- Tests ---
+
+describe("session.ts", () => {
+  let dir: string;
+
+  before(() => {
+    dir = createTestDir();
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("getLeafId", () => {
+    it("returns last entry id", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      assert.equal(getLeafId(file), "asst-001");
+    });
+
+    it("returns null for empty file", () => {
+      const file = join(dir, "empty.jsonl");
+      writeFileSync(file, "");
+      assert.equal(getLeafId(file), null);
+    });
+  });
+
+  describe("getNewEntries", () => {
+    it("returns entries after a given line", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      const entries = getNewEntries(file, 2);
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].id, "user-001");
+      assert.equal(entries[1].id, "asst-001");
+    });
+
+    it("returns empty array when no new entries", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE]);
+      const entries = getNewEntries(file, 2);
+      assert.equal(entries.length, 0);
+    });
+  });
+
+  describe("findLastAssistantMessage", () => {
+    it("finds last assistant text", () => {
+      const entries = [USER_MSG, ASSISTANT_MSG, ASSISTANT_MSG_2] as any[];
+      const text = findLastAssistantMessage(entries);
+      assert.equal(text, "Updated plan with details.");
+    });
+
+    it("skips thinking blocks, gets text only", () => {
+      const entries = [ASSISTANT_MSG_2] as any[];
+      const text = findLastAssistantMessage(entries);
+      assert.equal(text, "Updated plan with details.");
+    });
+
+    it("skips tool results", () => {
+      const entries = [ASSISTANT_MSG, TOOL_RESULT] as any[];
+      const text = findLastAssistantMessage(entries);
+      assert.equal(text, "Here is my plan...");
+    });
+
+    it("returns null when no assistant messages", () => {
+      const entries = [USER_MSG] as any[];
+      assert.equal(findLastAssistantMessage(entries), null);
+    });
+
+    it("returns null for empty array", () => {
+      assert.equal(findLastAssistantMessage([]), null);
+    });
+
+    it("skips empty assistant messages and returns real content above", () => {
+      const realMsg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Real summary content." }],
+        },
+      };
+      const emptyMsg = {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+        },
+      };
+      const entries = [realMsg, emptyMsg] as any[];
+      assert.equal(findLastAssistantMessage(entries), "Real summary content.");
+    });
+  });
+
+  describe("appendBranchSummary", () => {
+    it("appends valid branch_summary entry", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER, USER_MSG, ASSISTANT_MSG]);
+      const id = appendBranchSummary(file, "user-001", "asst-001", "The plan was created.");
+
+      assert.ok(id, "should return an id");
+      assert.equal(typeof id, "string");
+
+      // Read back and verify
+      const lines = readFileSync(file, "utf8").trim().split("\n");
+      assert.equal(lines.length, 4); // 3 original + 1 summary
+
+      const summary = JSON.parse(lines[3]);
+      assert.equal(summary.type, "branch_summary");
+      assert.equal(summary.id, id);
+      assert.equal(summary.parentId, "user-001");
+      assert.equal(summary.fromId, "asst-001");
+      assert.equal(summary.summary, "The plan was created.");
+      assert.ok(summary.timestamp);
+    });
+
+    it("uses branchPointId as fromId fallback", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER]);
+      appendBranchSummary(file, "branch-pt", null, "summary");
+
+      const lines = readFileSync(file, "utf8").trim().split("\n");
+      const summary = JSON.parse(lines[1]);
+      assert.equal(summary.fromId, "branch-pt");
+    });
+  });
+
+  describe("copySessionFile", () => {
+    it("creates a copy with different path", () => {
+      const file = createSessionFile(dir, [SESSION_HEADER, USER_MSG]);
+      const copyDir = join(dir, "copies");
+      mkdirSync(copyDir, { recursive: true });
+      const copy = copySessionFile(file, copyDir);
+
+      assert.notEqual(copy, file);
+      assert.ok(copy.endsWith(".jsonl"));
+      assert.equal(readFileSync(copy, "utf8"), readFileSync(file, "utf8"));
+    });
+  });
+
+  describe("seedSubagentSessionFile", () => {
+    it("creates a lineage-only child session with parent linkage and no copied turns", () => {
+      const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      const childFile = join(dir, "lineage-child.jsonl");
+
+      seedSubagentSessionFile({
+        mode: "lineage-only",
+        parentSessionFile: parentFile,
+        childSessionFile: childFile,
+        childCwd: "/tmp/child-cwd",
+      });
+
+      const lines = readFileSync(childFile, "utf8").trim().split("\n");
+      assert.equal(lines.length, 1);
+
+      const header = JSON.parse(lines[0]);
+      assert.equal(header.type, "session");
+      assert.equal(header.parentSession, parentFile);
+      assert.equal(header.cwd, "/tmp/child-cwd");
+    });
+
+    it("creates a forked child session with copied context before the triggering user turn", () => {
+      const parentFile = createSessionFile(dir, [SESSION_HEADER, MODEL_CHANGE, USER_MSG, ASSISTANT_MSG]);
+      const childFile = join(dir, "fork-child.jsonl");
+
+      seedSubagentSessionFile({
+        mode: "fork",
+        parentSessionFile: parentFile,
+        childSessionFile: childFile,
+        childCwd: "/tmp/fork-child-cwd",
+      });
+
+      const entries = readFileSync(childFile, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      assert.equal(entries.length, 2);
+      assert.equal(entries[0].type, "session");
+      assert.equal(entries[0].parentSession, parentFile);
+      assert.equal(entries[0].cwd, "/tmp/fork-child-cwd");
+      assert.equal(entries[1].type, "model_change");
+      assert.equal(entries.some((entry) => entry.type === "session" && entry.parentSession !== parentFile), false);
+      assert.equal(entries.some((entry) => entry.type === "message"), false);
+    });
+  });
+
+  describe("mergeNewEntries", () => {
+    it("appends new entries from source to target", () => {
+      // Source starts with same base (2 entries), then has 1 new entry
+      const sourceFile = join(dir, "merge-source.jsonl");
+      const targetFile = join(dir, "merge-target.jsonl");
+      writeFileSync(
+        sourceFile,
+        [SESSION_HEADER, USER_MSG, ASSISTANT_MSG].map((e) => JSON.stringify(e)).join("\n") + "\n",
+      );
+      writeFileSync(
+        targetFile,
+        [SESSION_HEADER, USER_MSG].map((e) => JSON.stringify(e)).join("\n") + "\n",
+      );
+
+      // Merge entries after line 2 (the shared base)
+      const merged = mergeNewEntries(sourceFile, targetFile, 2);
+      assert.equal(merged.length, 1);
+      assert.equal(merged[0].id, "asst-001");
+
+      // Target should now have 3 entries
+      const targetLines = readFileSync(targetFile, "utf8").trim().split("\n");
+      assert.equal(targetLines.length, 3);
+    });
+  });
+});
+
+describe("status.ts", () => {
+  it("parses strict config objects", () => {
+    const disabled = parseStatusConfig({ status: { enabled: false } });
+
+    assert.deepEqual(disabled, {
+      enabled: false,
+      lineLimit: 4,
+    });
+  });
+
+  it("loads a valid config file", () => {
+    const examplePath = fileURLToPath(new URL("../config.json.example", import.meta.url));
+    const config = loadStatusConfig(examplePath);
+
+    assert.deepEqual(config, {
+      enabled: true,
+      lineLimit: 4,
+    });
+  });
+
+  it("loads the shared example when local config is absent", () => {
+    withTempDir((dir) => {
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(
+        examplePath,
+        JSON.stringify({ status: { enabled: true } }, null, 2) + "\n",
+      );
+
+      const config = loadStatusConfig(join(dir, "config.json"), examplePath);
+
+      assert.deepEqual(config, {
+        enabled: true,
+        lineLimit: 4,
+      });
+    });
+  });
+
+  it("fails fast for invalid config shapes", () => {
+    assert.throws(
+      () => parseStatusConfig({ status: { enabled: "false" } }),
+      /status\.enabled must be a boolean/,
+    );
+    assert.throws(
+      () => parseStatusConfig({ status: { enabled: true, defaultCadenceSeconds: 60 } }),
+      /status has unsupported key\(s\): defaultCadenceSeconds/,
+    );
+  });
+
+  it("reports when neither local nor shared config exists", () => {
+    withTempDir((dir) => {
+      assert.throws(
+        () => loadStatusConfig(join(dir, "config.json"), join(dir, "config.json.example")),
+        /Missing subagent status config\. Expected .*config\.json.*or.*config\.json\.example/,
+      );
+    });
+  });
+
+  it("reports invalid JSON from the shared example path", () => {
+    withTempDir((dir) => {
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(examplePath, "{\n");
+
+      assert.throws(
+        () => loadStatusConfig(join(dir, "config.json"), examplePath),
+        /Invalid JSON in subagent config .*config\.json\.example/,
+      );
+    });
+  });
+
+  it("fails on invalid local config instead of falling back to the shared example", () => {
+    withTempDir((dir) => {
+      const configPath = join(dir, "config.json");
+      const examplePath = join(dir, "config.json.example");
+      writeFileSync(configPath, "{\n");
+      writeFileSync(
+        examplePath,
+        JSON.stringify({ status: { enabled: true } }, null, 2) + "\n",
+      );
+
+      assert.throws(
+        () => loadStatusConfig(configPath, examplePath),
+        /Invalid JSON in subagent config .*config\.json/,
+      );
+    });
+  });
+
+  it("keeps a missing snapshot as starting until the fixed watchdog threshold", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, { snapshot: "missing" }, 1_000);
+
+    assert.equal(classifyStatus(state, 60_999).kind, "starting");
+    const stalled = classifyStatus(state, 61_000);
+    assert.equal(stalled.kind, "stalled");
+    assert.equal(stalled.statusLabel, null);
+  });
+
+  it("classifies active snapshots without aging into stalled", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+      latestEvent: "tool_execution_start",
+    }, 5_000);
+
+    const snapshot = classifyStatus(state, 240_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.activityLabel, "bash");
+    assert.equal(snapshot.activeDurationText, "3m");
+  });
+
+  it("classifies waiting snapshots as healthy idle without becoming stalled", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 1,
+      phase: "waiting",
+      waitingSince: 10_000,
+      latestEvent: "agent_end",
+    }, 10_000);
+
+    const snapshot = classifyStatus(state, 240_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.waitingDurationText, "3m");
+  });
+
+  it("uses elapsed-only fallback for claude-backed subagents", () => {
+    const state = createStatusState({ source: "claude", startTimeMs: 0 });
+    const snapshot = classifyStatus(state, 125_000);
+
+    assert.equal(snapshot.kind, "running");
+    assert.equal(snapshot.elapsedText, "2m");
+  });
+
+  it("detects stalled transitions and recovery", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, { snapshot: "missing" }, 1_000);
+
+    let advanced = advanceStatusState(state, 95_000);
+    assert.equal(advanced.transition, "stalled");
+    assert.equal(advanced.snapshot.kind, "stalled");
+
+    state = observeStatus(advanced.nextState, {
+      snapshot: "present",
+      updatedAt: 96_000,
+      sequence: 1,
+      phase: "waiting",
+      waitingSince: 96_000,
+      latestEvent: "agent_end",
+    }, 96_000);
+    advanced = advanceStatusState(state, 97_000);
+    assert.equal(advanced.transition, "recovered");
+    assert.equal(advanced.snapshot.kind, "waiting");
+  });
+
+  it("keeps the last healthy kind during transient snapshot loss", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "streaming",
+      activeSince: 5_000,
+    }, 5_000);
+    state = advanceStatusState(state, 6_000).nextState;
+    state = observeStatus(state, { snapshot: "missing" }, 10_000);
+
+    const snapshot = classifyStatus(state, 20_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.statusLabel, null);
+  });
+
+  it("forces an active state to waiting after interrupt", () => {
+    const now = 20_000;
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
+
+    assert.equal(classifyStatus(state, now).kind, "active");
+
+    const forced = forceStatusAfterInterrupt(state, now);
+    const snapshot = classifyStatus(forced, now);
+
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
+    assert.equal(snapshot.waitingDurationText, "0s");
+    assert.equal(forced.activeNow, false);
+  });
+
+  it("orders same-millisecond snapshots by sequence", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 10_000,
+      activityLabel: "bash",
+    }, 10_000);
+
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 10_000,
+      sequence: 3,
+      phase: "waiting",
+      waitingSince: 10_000,
+      latestEvent: "agent_end",
+    }, 10_001);
+
+    const snapshot = classifyStatus(state, 11_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.latestEvent, "agent_end");
+  });
+
+  it("recovers from a transient snapshot read failure with the same valid snapshot", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
+    state = observeStatus(state, { snapshot: "missing" }, 10_000);
+    assert.equal(classifyStatus(state, 10_000).statusLabel, null);
+
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 2,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 11_000);
+
+    const snapshot = classifyStatus(state, 11_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(snapshot.statusLabel, null);
+  });
+
+  it("ignores stale and exact old snapshots after interrupt and accepts newer snapshots", () => {
+    let state = createStatusState({ source: "pi", startTimeMs: 0 });
+    state = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 5_000);
+    state = forceStatusAfterInterrupt(state, 20_000);
+
+    const stale = observeStatus(state, {
+      snapshot: "present",
+      updatedAt: 5_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 5_000,
+      activityLabel: "bash",
+    }, 21_000);
+    let snapshot = classifyStatus(stale, 21_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
+
+    const sameTimestamp = observeStatus(stale, {
+      snapshot: "present",
+      updatedAt: 20_000,
+      sequence: 1,
+      phase: "active",
+      active: true,
+      activeScope: "tool",
+      activeSince: 20_000,
+      activityLabel: "bash",
+    }, 22_000);
+    snapshot = classifyStatus(sameTimestamp, 22_000);
+    assert.equal(snapshot.kind, "waiting");
+    assert.equal(snapshot.activityLabel, "interrupted");
+
+    const resumed = observeStatus(sameTimestamp, {
+      snapshot: "present",
+      sequence: 2,
+      updatedAt: 25_000,
+      phase: "active",
+      active: true,
+      activeScope: "streaming",
+      activeSince: 25_000,
+      activityLabel: "streaming",
+    }, 25_000);
+    snapshot = classifyStatus(resumed, 25_000);
+    assert.equal(snapshot.kind, "active");
+    assert.equal(resumed.activeScope, "streaming");
+  });
+
+  it("normalizes and truncates long newline-heavy names", () => {
+    const longName = `Worker\n\n${"very-long-name-".repeat(12)}`;
+    const stalledState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      { snapshot: "missing" },
+      1_000,
+    );
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 299_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 299_000,
+        activityLabel: "write",
+      },
+      299_000,
+    );
+    const line = formatStatusLine(longName, classifyStatus(stalledState, 240_000));
+    const recovered = formatTransitionLine(longName, classifyStatus(activeState, 300_000), "recovered");
+
+    assert.doesNotMatch(line, /\n/);
+    assert.doesNotMatch(recovered, /\n/);
+    assert.ok(line.length <= 120, `expected bounded line length, got ${line.length}`);
+    assert.ok(recovered.length <= 120, `expected bounded line length, got ${recovered.length}`);
+  });
+
+  it("caps visible status lines and reports overflow consistently", () => {
+    const waitingState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      { snapshot: "present", updatedAt: 180_000, sequence: 1, phase: "waiting", waitingSince: 180_000 },
+      180_000,
+    );
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 419_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 419_000,
+        activityLabel: "bash",
+      },
+      419_000,
+    );
+    const waitingLine = formatStatusLine("Worker", classifyStatus(waitingState, 300_000));
+    const recoveredLine = formatTransitionLine("Worker", classifyStatus(activeState, 420_000), "recovered");
+    const lines = [waitingLine, recoveredLine, "Scout running 2m.", "Reviewer running 4m.", "Planner running 6m."];
+    const capped = capStatusLines(lines, 3);
+    const aggregate = formatStatusAggregate(lines, 3);
+
+    assert.equal(waitingLine, "Worker running 5m, waiting 2m.");
+    assert.equal(recoveredLine, "Worker running 7m, recovered; active (bash 1s).");
+    assert.deepEqual(capped.visibleLines, [waitingLine, recoveredLine, "Scout running 2m."]);
+    assert.equal(capped.overflow, 2);
+    assert.match(aggregate, /^Subagent status:/);
+    assert.match(aggregate, /\+2 more running\./);
+    assert.doesNotMatch(aggregate, /\/tmp|\.jsonl/);
+  });
+});
+
+describe("subagent discovery", () => {
+  const testApi = (subagentsModule as any).__test__;
+
+  it("loads session-mode from frontmatter", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "lineage-mode-test-agent",
+        [
+          "name: lineage-mode-test-agent",
+          "model: anthropic/test-lineage",
+          "session-mode: lineage-only",
+        ].join("\n"),
+      );
+
+      const loaded = testApi.loadAgentDefaults("lineage-mode-test-agent");
+      assert.ok(loaded, "expected agent to load");
+      assert.equal(loaded.sessionMode, "lineage-only");
+    });
+  });
+
+  it("loads explicit interactive flag from frontmatter", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "interactive-true-test-agent",
+        [
+          "name: interactive-true-test-agent",
+          "model: anthropic/test-interactive-true",
+          "interactive: true",
+        ].join("\n"),
+      );
+      writeAgentFile(
+        projectAgentsDir,
+        "interactive-false-test-agent",
+        [
+          "name: interactive-false-test-agent",
+          "model: anthropic/test-interactive-false",
+          "interactive: false",
+        ].join("\n"),
+      );
+
+      const loadedTrue = testApi.loadAgentDefaults("interactive-true-test-agent");
+      assert.equal(loadedTrue?.interactive, true);
+
+      const loadedFalse = testApi.loadAgentDefaults("interactive-false-test-agent");
+      assert.equal(loadedFalse?.interactive, false);
+    });
+  });
+
+  it("leaves interactive undefined when not set in frontmatter", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "interactive-unset-test-agent",
+        [
+          "name: interactive-unset-test-agent",
+          "model: anthropic/test-interactive-unset",
+        ].join("\n"),
+      );
+
+      const loaded = testApi.loadAgentDefaults("interactive-unset-test-agent");
+      assert.equal(loaded?.interactive, undefined);
+    });
+  });
+
+  it("resolveEffectiveInteractive defaults to the inverse of auto-exit", () => {
+    // Autonomous agents (auto-exit: true) are NOT interactive — parent gets stall pings.
+    assert.equal(
+      testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, { autoExit: true }),
+      false,
+    );
+    // Agents without auto-exit ARE interactive — parent does not receive status transition pings.
+    assert.equal(
+      testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, { autoExit: false }),
+      true,
+    );
+    assert.equal(
+      testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, {}),
+      true,
+    );
+    // Bare spawn with no agent defs (e.g. /iterate fork) is interactive by default.
+    assert.equal(
+      testApi.resolveEffectiveInteractive({ name: "A", task: "T" }, null),
+      true,
+    );
+  });
+
+  it("resolveEffectiveInteractive honors explicit frontmatter over the auto-exit default", () => {
+    // Autonomous agent that still wants to be treated as interactive.
+    assert.equal(
+      testApi.resolveEffectiveInteractive(
+        { name: "A", task: "T" },
+        { autoExit: true, interactive: true },
+      ),
+      true,
+    );
+    // Non-auto-exit agent that opts back into stall pings.
+    assert.equal(
+      testApi.resolveEffectiveInteractive(
+        { name: "A", task: "T" },
+        { interactive: false },
+      ),
+      false,
+    );
+  });
+
+  it("resolveEffectiveInteractive honors the explicit tool parameter over all else", () => {
+    assert.equal(
+      testApi.resolveEffectiveInteractive(
+        { name: "A", task: "T", interactive: false },
+        { autoExit: false, interactive: true },
+      ),
+      false,
+    );
+    assert.equal(
+      testApi.resolveEffectiveInteractive(
+        { name: "A", task: "T", interactive: true },
+        { autoExit: true, interactive: false },
+      ),
+      true,
+    );
+  });
+
+  it("bundled scout/worker/reviewer agents resolve as non-interactive; planner resolves as interactive", () => {
+    for (const name of ["scout", "worker", "reviewer"]) {
+      const defs = testApi.loadAgentDefaults(name);
+      assert.ok(defs, `expected bundled agent ${name} to be discoverable`);
+      assert.equal(
+        testApi.resolveEffectiveInteractive({ name, task: "" }, defs),
+        false,
+        `${name} should resolve as non-interactive (autonomous)`,
+      );
+    }
+
+    const planner = testApi.loadAgentDefaults("planner");
+    assert.ok(planner, "expected bundled planner to be discoverable");
+    assert.equal(
+      testApi.resolveEffectiveInteractive({ name: "planner", task: "" }, planner),
+      true,
+      "planner should resolve as interactive (no auto-exit)",
+    );
+  });
+
+  it("ignores invalid session-mode values", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "invalid-mode-test-agent",
+        [
+          "name: invalid-mode-test-agent",
+          "model: anthropic/test-invalid",
+          "session-mode: sideways",
+        ].join("\n"),
+      );
+
+      const loaded = testApi.loadAgentDefaults("invalid-mode-test-agent");
+      assert.ok(loaded, "expected agent to load");
+      assert.equal(loaded.sessionMode, undefined);
+    });
+  });
+
+  it("resolves session mode with fork override precedence", () => {
+    assert.equal(testApi.resolveEffectiveSessionMode({ name: "A", task: "T" }, null), "standalone");
+    assert.equal(
+      testApi.resolveEffectiveSessionMode({ name: "A", task: "T" }, { sessionMode: "lineage-only" }),
+      "lineage-only",
+    );
+    assert.equal(
+      testApi.resolveEffectiveSessionMode(
+        { name: "A", task: "T", fork: true },
+        { sessionMode: "lineage-only" },
+      ),
+      "fork",
+    );
+  });
+
+  it("resolves launch behavior for standalone, lineage-only, and fork modes", () => {
+    assert.deepEqual(testApi.resolveLaunchBehavior({ name: "A", task: "T" }, null), {
+      sessionMode: "standalone",
+      seededSessionMode: null,
+      inheritsConversationContext: false,
+      taskDelivery: "artifact",
+    });
+    assert.deepEqual(
+      testApi.resolveLaunchBehavior({ name: "A", task: "T" }, { sessionMode: "lineage-only" }),
+      {
+        sessionMode: "lineage-only",
+        seededSessionMode: "lineage-only",
+        inheritsConversationContext: false,
+        taskDelivery: "artifact",
+      },
+    );
+    assert.deepEqual(
+      testApi.resolveLaunchBehavior({ name: "A", task: "T" }, { sessionMode: "fork" }),
+      {
+        sessionMode: "fork",
+        seededSessionMode: "fork",
+        inheritsConversationContext: true,
+        taskDelivery: "direct",
+      },
+    );
+    assert.deepEqual(
+      testApi.resolveLaunchBehavior(
+        { name: "A", task: "T", fork: true },
+        { sessionMode: "lineage-only" },
+      ),
+      {
+        sessionMode: "fork",
+        seededSessionMode: "fork",
+        inheritsConversationContext: true,
+        taskDelivery: "direct",
+      },
+    );
+  });
+
+  it("buildSubagentToolAllowlist preserves requested tools and adds child control tools", () => {
+    assert.equal(
+      testApi.buildSubagentToolAllowlist("read,bash,web_search"),
+      "read,bash,web_search,caller_ping,subagent_done",
+    );
+  });
+
+  it("buildSubagentToolAllowlist returns null without an explicit tool restriction", () => {
+    assert.equal(testApi.buildSubagentToolAllowlist(undefined), null);
+    assert.equal(testApi.buildSubagentToolAllowlist(""), null);
+  });
+
+  it("buildPiPromptArgs inserts separator for artifact-backed launches with skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: "review,lint", taskDelivery: "artifact", taskArg: "@artifact.md" }),
+      ["", "/skill:review", "/skill:lint", "@artifact.md"],
+    );
+  });
+
+  it("buildPiPromptArgs omits separator for artifact-backed launches without skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: undefined, taskDelivery: "artifact", taskArg: "@artifact.md" }),
+      ["@artifact.md"],
+    );
+  });
+
+  it("buildPiPromptArgs omits separator for direct launches with skills", () => {
+    assert.deepEqual(
+      testApi.buildPiPromptArgs({ effectiveSkills: "review", taskDelivery: "direct", taskArg: "do the task" }),
+      ["/skill:review", "do the task"],
+    );
+  });
+
+  it("lists visible agents from discovery", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "visible-discovery-test-agent",
+        [
+          "name: visible-discovery-test-agent",
+          "description: Visible test agent",
+          "model: anthropic/test-visible",
+        ].join("\n"),
+      );
+
+      const { api, registeredTools } = createMockExtensionApi();
+      (subagentsModule as any).default(api);
+
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
+      assert.ok(tool, "expected subagents_list to be registered");
+
+      const result = await tool.execute();
+      const agents = result.details?.agents ?? [];
+
+      assert.ok(agents.some((agent: any) => agent.name === "visible-discovery-test-agent"));
+      assert.match(result.content[0].text, /visible-discovery-test-agent/);
+    });
+  });
+
+  it("hides disable-model-invocation agents from listings but keeps direct loading", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {
+      writeAgentFile(
+        projectAgentsDir,
+        "hidden-discovery-test-agent",
+        [
+          "name: hidden-discovery-test-agent",
+          "description: Hidden test agent",
+          "model: anthropic/test-hidden",
+          "disable-model-invocation: true",
+        ].join("\n"),
+        "You are the hidden agent.",
+      );
+
+      const { api, registeredTools } = createMockExtensionApi();
+      (subagentsModule as any).default(api);
+
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
+      assert.ok(tool, "expected subagents_list to be registered");
+
+      const result = await tool.execute();
+      const agents = result.details?.agents ?? [];
+
+      assert.equal(agents.some((agent: any) => agent.name === "hidden-discovery-test-agent"), false);
+      assert.doesNotMatch(result.content[0].text, /hidden-discovery-test-agent/);
+
+      const loaded = testApi.loadAgentDefaults("hidden-discovery-test-agent");
+      assert.ok(loaded, "expected hidden agent to remain directly loadable");
+      assert.equal(loaded.model, "anthropic/test-hidden");
+      assert.equal(loaded.body, "You are the hidden agent.");
+      assert.equal(loaded.disableModelInvocation, true);
+    });
+  });
+
+  it("lets a hidden project agent shadow a visible global agent", async () => {
+    await withIsolatedAgentEnv(async ({ projectAgentsDir, globalAgentsDir }) => {
+      writeAgentFile(
+        globalAgentsDir,
+        "shadowed-discovery-test-agent",
+        [
+          "name: shadowed-discovery-test-agent",
+          "description: Global visible agent",
+          "model: anthropic/test-global",
+        ].join("\n"),
+        "You are the global visible agent.",
+      );
+      writeAgentFile(
+        projectAgentsDir,
+        "shadowed-discovery-test-agent",
+        [
+          "name: shadowed-discovery-test-agent",
+          "description: Project hidden agent",
+          "model: anthropic/test-project",
+          "disable-model-invocation: true",
+        ].join("\n"),
+        "You are the project hidden agent.",
+      );
+
+      const { api, registeredTools } = createMockExtensionApi();
+      (subagentsModule as any).default(api);
+
+      const tool = registeredTools.find((tool) => tool.name === "subagents_list");
+      assert.ok(tool, "expected subagents_list to be registered");
+
+      const result = await tool.execute();
+      const agents = result.details?.agents ?? [];
+
+      assert.equal(agents.some((agent: any) => agent.name === "shadowed-discovery-test-agent"), false);
+      assert.doesNotMatch(result.content[0].text, /shadowed-discovery-test-agent/);
+
+      const loaded = testApi.loadAgentDefaults("shadowed-discovery-test-agent");
+      assert.ok(loaded, "expected project override to remain directly loadable");
+      assert.equal(loaded.model, "anthropic/test-project");
+      assert.equal(loaded.body, "You are the project hidden agent.");
+      assert.equal(loaded.disableModelInvocation, true);
+    });
+  });
+});
+describe("subagent-done.ts", () => {
+  describe("shouldMarkUserTookOver", () => {
+    it("ignores the initial injected task before the first agent run", () => {
+      assert.equal(shouldMarkUserTookOver(false), false);
+    });
+
+    it("treats later input as manual takeover", () => {
+      assert.equal(shouldMarkUserTookOver(true), true);
+    });
+  });
+
+  describe("shouldAutoExitOnAgentEnd", () => {
+    it("auto-exits after normal completion when there was no takeover", () => {
+      const messages = [{ role: "assistant", stopReason: "stop" }];
+      assert.equal(shouldAutoExitOnAgentEnd(false, messages), true);
+    });
+
+    it("auto-exits after normal completion even when the user sent the prompt", () => {
+      const messages = [{ role: "assistant", stopReason: "stop" }];
+      assert.equal(shouldAutoExitOnAgentEnd(true, messages), true);
+    });
+
+    it("stays open after Escape aborts the run", () => {
+      const messages = [{ role: "assistant", stopReason: "aborted" }];
+      assert.equal(shouldAutoExitOnAgentEnd(false, messages), false);
+    });
+  });
+
+  describe("agent_end handler", () => {
+    /**
+     * Build a mock ExtensionAPI that captures event handlers so we can drive
+     * the agent_end handler directly and inspect its side effects.
+     *
+     * Bug being guarded against: previously, when PI_SUBAGENT_AUTO_EXIT=1, the
+     * agent_end handler wrote { type: "done" } to the .exit sidecar and called
+     * ctx.shutdown(). This short-circuited the subagent_done tool and broke
+     * any caller relying on structured_output (e.g. workflow tool with a
+     * structuredOutputSchema). The fix removes that short-circuit: the agent
+     * must always call subagent_done itself to terminate.
+     */
+    function createHandlerCapturingMockApi() {
+      const handlers: Record<string, Array<(event: any, ctx: any) => void>> = {};
+      const registeredTools: Array<any> = [];
+      const sentUserMessages: string[] = [];
+      const ctxShutdowns: Array<unknown> = [];
+      const ctx: any = {
+        shutdown(reason?: unknown) {
+          ctxShutdowns.push(reason);
+        },
+        ui: {
+          setWidget() {},
+          hasUI: false,
+        },
+      };
+      return {
+        handlers,
+        registeredTools,
+        sentUserMessages,
+        ctxShutdowns,
+        ctx,
+        api: {
+          on(event: string, handler: (event: any, ctx: any) => void) {
+            (handlers[event] ??= []).push(handler);
+          },
+          registerTool(tool: any) {
+            registeredTools.push(tool);
+          },
+          registerShortcut() {},
+          sendUserMessage(message: string) {
+            sentUserMessages.push(message);
+          },
+          sendMessage() {},
+          getAllTools() {
+            return [];
+          },
+        } as any,
+      };
+    }
+
+    /**
+     * Set up env, dynamically import subagent-done with a cache-busting query
+     * string so each test gets a fresh module instance (module-level state like
+     * `doneCalled`, `autoExit`, and `NUDGE_DELAY_MS` is reset).
+     *
+     * IMPORTANT: env must be set BEFORE the import. Module-level `const`s in
+     * subagent-done.ts are evaluated at load time and won't see later changes.
+     *
+     * Returns the imported module and a `restore` function the caller must
+     * invoke in a finally block to restore the original env.
+     */
+    async function loadSubagentDoneDefaultWithEnv(envOverrides: Record<string, string | undefined>) {
+      const SUBAGENT_ENV_KEYS = [
+        "PI_SUBAGENT_SESSION",
+        "PI_SUBAGENT_AUTO_EXIT",
+        "PI_SUBAGENT_NUDGE_DISABLE",
+        "PI_SUBAGENT_NUDGE_DELAY_MS",
+        "PI_SUBAGENT_ID",
+        "PI_SUBAGENT_ACTIVITY_FILE",
+        "PI_SUBAGENT_NAME",
+        "PI_SUBAGENT_AGENT",
+        "PI_DENY_TOOLS",
+      ];
+      const saved: Record<string, string | undefined> = {};
+      for (const key of SUBAGENT_ENV_KEYS) {
+        saved[key] = process.env[key];
+        delete process.env[key];
+      }
+      for (const [key, value] of Object.entries(envOverrides)) {
+        if (value !== undefined) process.env[key] = value;
+      }
+
+      // Cache-bust the dynamic import URL so each test gets a fresh module.
+      const cacheBust = `?t=${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+      const url = new URL(
+        `../pi-extension/subagents/subagent-done.ts${cacheBust}`,
+        import.meta.url,
+      ).href;
+      const mod: any = await import(url);
+
+      const restore = () => {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+      };
+      return { mod, restore };
+    }
+
+    function restoreAllEnv(saved: Record<string, string | undefined>) {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+
+    it("does NOT write .exit file from agent_end even when PI_SUBAGENT_AUTO_EXIT=1 (bug regression)", async () => {
+      await withTempDir(async (dir) => {
+        const sessionFile = join(dir, "session.jsonl");
+        writeFileSync(sessionFile, "");
+
+        const { mod, restore } = await loadSubagentDoneDefaultWithEnv({
+          PI_SUBAGENT_SESSION: sessionFile,
+          PI_SUBAGENT_AUTO_EXIT: "1",
+          PI_SUBAGENT_NUDGE_DISABLE: "1",
+        });
+
+        try {
+          const mock = createHandlerCapturingMockApi();
+          mod.default(mock.api);
+
+          const sessionStart = mock.handlers.session_start?.[0];
+          const agentEnd = mock.handlers.agent_end?.[0];
+          assert.ok(sessionStart, "session_start handler should be registered");
+          assert.ok(agentEnd, "agent_end handler should be registered");
+
+          sessionStart({}, mock.ctx);
+          agentEnd(
+            { messages: [{ role: "assistant", stopReason: "stop" }] },
+            mock.ctx,
+          );
+
+          // ── Core assertion: .exit must NOT exist after agent_end ──
+          const exitFile = `${sessionFile}.exit`;
+          assert.equal(
+            existsSync(exitFile),
+            false,
+            `.exit file must not be written by agent_end handler (auto-exit removed). ` +
+              `File would have been written by the pre-fix short-circuit.`,
+          );
+
+          // ── ctx.shutdown must NOT be called by agent_end ──
+          assert.equal(
+            mock.ctxShutdowns.length,
+            0,
+            `ctx.shutdown must not be called by agent_end handler. ` +
+              `Pre-fix code called ctx.shutdown() after writing .exit.`,
+          );
+        } finally {
+          restore();
+        }
+      });
+    });
+
+    it("schedules a nudge after agent_end (so agent remembers to call subagent_done)", async () => {
+      await withTempDir(async (dir) => {
+        const sessionFile = join(dir, "session.jsonl");
+        writeFileSync(sessionFile, "");
+
+        const { mod, restore } = await loadSubagentDoneDefaultWithEnv({
+          PI_SUBAGENT_SESSION: sessionFile,
+          // Shorten nudge delay so the test completes quickly.
+          PI_SUBAGENT_NUDGE_DELAY_MS: "50",
+        });
+
+        try {
+          const mock = createHandlerCapturingMockApi();
+          mod.default(mock.api);
+
+          const sessionStart = mock.handlers.session_start?.[0];
+          const agentEnd = mock.handlers.agent_end?.[0];
+          sessionStart({}, mock.ctx);
+          agentEnd(
+            { messages: [{ role: "assistant", stopReason: "stop" }] },
+            mock.ctx,
+          );
+
+          // Wait past the nudge delay (NUDGE_DELAY_MS defaults to 5000ms,
+          // Math.max(1000, ...) floor prevents going below 1s).
+          await new Promise((resolve) => setTimeout(resolve, 6000));
+
+          // Nudge must have been sent — agent needs the reminder to call
+          // subagent_done itself, since we no longer auto-exit.
+          assert.ok(
+            mock.sentUserMessages.some((m) => m.includes("subagent_done")),
+            `Expected a nudge mentioning subagent_done after agent_end. ` +
+              `Got: ${JSON.stringify(mock.sentUserMessages)}`,
+          );
+        } finally {
+          restore();
+        }
+      });
+    });
+  });
+});
+describe("commands", () => {
+  it("/iterate always emits a full-context fork tool call", () => {
+    const { api, registeredCommands, sentUserMessages } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    const iterate = registeredCommands.find((command) => command.name === "iterate");
+    assert.ok(iterate, "expected /iterate to be registered");
+
+    iterate.handler("Fix the bug", {});
+
+    assert.equal(sentUserMessages.length, 1);
+    assert.match(sentUserMessages[0], /fork: true/);
+    assert.match(sentUserMessages[0], /name: "Iterate"/);
+  });
+});
+
+describe("tool registration", () => {
+  it("defaults resumed subagents to auto-exit and non-interactive tracking", () => {
+    const testApi = (subagentsModule as any).__test__;
+
+    assert.deepEqual(testApi.resolveResumeLaunchBehavior({}), {
+      autoExit: true,
+      interactive: false,
+    });
+    assert.deepEqual(testApi.resolveResumeLaunchBehavior({ autoExit: false }), {
+      autoExit: false,
+      interactive: true,
+    });
+  });
+
+  it("expands spawning false to deny subagent interruption", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const denied = testApi.resolveDenyTools({ spawning: false });
+
+    assert.equal(denied.has("subagent"), true);
+    assert.equal(denied.has("subagent_interrupt"), true);
+    assert.equal(denied.has("subagent_resume"), true);
+  });
+
+  it("renders partial subagent tool-call args without throwing", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const subagentTool = registeredTools.find((tool) => tool.name === "subagent");
+    assert.ok(subagentTool, "expected subagent tool to be registered");
+
+    const theme = {
+      fg(_color: string, text: string) {
+        return text;
+      },
+      bold(text: string) {
+        return text;
+      },
+    };
+    const rendered = subagentTool.renderCall({}, theme);
+    const output = rendered.render(80).join("\n");
+
+    assert.match(output, /\(unnamed\)/);
+  });
+
+  it("registers subagent_resume with an autoExit override", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const resumeTool = registeredTools.find((tool) => tool.name === "subagent_resume");
+    assert.ok(resumeTool, "expected subagent_resume tool to be registered");
+
+    const autoExitSchema = resumeTool.parameters.properties.autoExit;
+    assert.equal(autoExitSchema.type, "boolean");
+    assert.match(autoExitSchema.description, /Defaults to true/);
+  });
+});
+
+describe("subagent activity snapshots", () => {
+  function validActivity(overrides: Record<string, unknown> = {}) {
+    return {
+      version: 1,
+      runningChildId: "child-1",
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      sequence: 1,
+      latestEvent: "session_start",
+      phase: "starting",
+      agentActive: false,
+      turnActive: false,
+      providerActive: false,
+      toolActive: false,
+      ...overrides,
+    };
+  }
+
+  it("writes and validates activity files by running child id", () => {
+    withTempDir((dir) => {
+      const activityFile = getSubagentActivityFile(dir, "child-1");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-1",
+        activityFile,
+        now: () => 1_000,
+      });
+
+      recorder.sessionStart();
+      recorder.toolExecutionStart("tool-1", "bash");
+
+      const read = readSubagentActivityFile(activityFile, "child-1");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "active");
+      assert.equal(read.activity.activeScope, "tool");
+      assert.equal(read.activity.toolName, "bash");
+
+      assert.deepEqual(readSubagentActivityFile(activityFile, "other-child"), {
+        ok: false,
+        reason: "wrong-id",
+      });
+    });
+  });
+
+  it("records waiting and final done states", () => {
+    withTempDir((dir) => {
+      let currentNow = 2_000;
+      const activityFile = getSubagentActivityFile(dir, "child-2");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-2",
+        activityFile,
+        now: () => currentNow,
+      });
+
+      recorder.sessionStart();
+      currentNow = 3_000;
+      recorder.agentEndWaiting();
+      let read = readSubagentActivityFile(activityFile, "child-2");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "waiting");
+      assert.equal(read.activity.waitingSince, 3_000);
+
+      currentNow = 4_000;
+      recorder.subagentDone();
+      read = readSubagentActivityFile(activityFile, "child-2");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "done");
+      assert.equal(read.activity.agentActive, false);
+    });
+  });
+
+  it("rejects malformed activity fields used by classification and rendering", () => {
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "subagent-activity"), { recursive: true });
+      const cases = [
+        { activeSince: "bad" },
+        { waitingSince: "bad" },
+        { activeScope: "database" },
+        { latestEvent: "unknown" },
+        { runningChildId: 42 },
+        { toolActive: "yes" },
+        { toolName: "bad\nname" },
+      ];
+
+      for (const [index, overrides] of cases.entries()) {
+        const activityFile = getSubagentActivityFile(dir, `child-${index}`);
+        const activity = validActivity({ runningChildId: `child-${index}`, ...overrides });
+        writeFileSync(activityFile, `${JSON.stringify(activity)}\n`);
+
+        const read = readSubagentActivityFile(activityFile, `child-${index}`);
+        assert.equal(read.ok, false);
+        assert.equal((read as { ok: false; reason: string }).reason, "invalid");
+      }
+    });
+  });
+
+  it("does not let tool_result resurrect finished tool activity", () => {
+    withTempDir((dir) => {
+      let currentNow = 1_000;
+      const activityFile = getSubagentActivityFile(dir, "child-3");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-3",
+        activityFile,
+        now: () => currentNow,
+      });
+
+      recorder.sessionStart();
+      recorder.agentStart();
+      recorder.turnStart(1);
+      currentNow = 2_000;
+      recorder.toolExecutionStart("tool-1", "bash");
+      currentNow = 3_000;
+      recorder.toolExecutionEnd("tool-1", "bash");
+      currentNow = 4_000;
+      recorder.toolResult("tool-1", "bash");
+
+      const read = readSubagentActivityFile(activityFile, "child-3");
+      assert.ok(read.ok);
+      assert.equal(read.activity.toolActive, false);
+      assert.equal(read.activity.activeScope, "turn");
+    });
+  });
+
+  it("does not mark reload shutdown as the final done snapshot", () => {
+    withTempDir((dir) => {
+      const activityFile = getSubagentActivityFile(dir, "child-4");
+      const recorder = createSubagentActivityRecorder({
+        runningChildId: "child-4",
+        activityFile,
+        now: () => 1_000,
+      });
+
+      recorder.sessionStart();
+      recorder.sessionShutdown("reload");
+
+      const read = readSubagentActivityFile(activityFile, "child-4");
+      assert.ok(read.ok);
+      assert.equal(read.activity.phase, "starting");
+      assert.equal(read.activity.latestEvent, "session_start");
+    });
+  });
+
+  it("cancels pending throttled writes on reload shutdown", async () => {
+    const dir = createTestDir();
+    try {
+      await new Promise<void>((resolve) => {
+        let currentNow = 1_000;
+        const activityFile = getSubagentActivityFile(dir, "child-5");
+        const recorder = createSubagentActivityRecorder({
+          runningChildId: "child-5",
+          activityFile,
+          now: () => currentNow,
+        });
+
+        recorder.sessionStart();
+        currentNow = 1_100;
+        recorder.messageUpdate("delta");
+        recorder.sessionShutdown("reload");
+
+        setTimeout(() => {
+          const read = readSubagentActivityFile(activityFile, "child-5");
+          assert.ok(read.ok);
+          assert.equal(read.activity.phase, "starting");
+          assert.equal(read.activity.latestEvent, "session_start");
+          resolve();
+        }, 650);
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("subagent interruption", () => {
+  function makeRunning(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "a1",
+      name: "Worker",
+      task: "",
+      surface: "pane-1",
+      startTime: 0,
+      sessionFile: "worker.jsonl",
+      interactive: false,
+      statusState: createStatusState({ source: "pi", startTimeMs: 0 }),
+      ...overrides,
+    };
+  }
+
+  it("registers subagent_interrupt in the main session extension", () => {
+    const { api, registeredTools } = createMockExtensionApi();
+
+    (subagentsModule as any).default(api);
+
+    assert.equal(registeredTools.some((tool) => tool.name === "subagent_interrupt"), true);
+  });
+
+  it("resolves interrupt targets by exact id and reports name ambiguity", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({ id: "a1", name: "Worker", surface: "a1", sessionFile: "a1.jsonl" }));
+      runningMap.set("b2", makeRunning({ id: "b2", name: "Worker", surface: "b2", sessionFile: "b2.jsonl" }));
+      runningMap.set("c3", makeRunning({ id: "c3", name: "Scout", surface: "c3", sessionFile: "c3.jsonl" }));
+
+      const byId = testApi.resolveInterruptTarget({ id: "c3", name: "Worker" });
+      assert.equal(byId.running.id, "c3");
+
+      const ambiguous = testApi.resolveInterruptTarget({ name: "Worker" });
+      assert.match(ambiguous.error, /Ambiguous subagent name/);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("returns an explicit error when Escape delivery fails", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let aborted = false;
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborted = true;
+        },
+      },
+    });
+
+    const result = testApi.requestSubagentInterrupt(running, () => {
+      throw new Error("mux write failed");
+    });
+
+    assert.match(result.error, /Failed to send Escape/);
+    assert.equal(aborted, false);
+    assert.equal("interruptRequested" in running, false);
+  });
+
+  it("leaves status unchanged when Escape delivery fails in the tool path", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    runningMap.clear();
+
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 5_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 5_000,
+        activityLabel: "bash",
+      },
+      5_000,
+    );
+
+    try {
+      runningMap.set("a1", makeRunning({ statusState: activeState }));
+
+      const result = withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, () => {
+        throw new Error("mux write failed");
+      }));
+
+      assert.match(result.content[0].text, /Failed to send Escape/);
+      assert.equal(classifyStatus(runningMap.get("a1").statusState, 20_000).kind, "active");
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("sends Escape without aborting or mutating running state", () => {
+    const testApi = (subagentsModule as any).__test__;
+    let aborted = false;
+    let sentSurface = "";
+    const running = makeRunning({
+      abortController: {
+        abort() {
+          aborted = true;
+        },
+      },
+    });
+
+    const result = testApi.requestSubagentInterrupt(running, (surface: string) => {
+      sentSurface = surface;
+    });
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(sentSurface, "pane-1");
+    assert.equal(aborted, false);
+    assert.equal("interruptRequested" in running, false);
+  });
+
+  it("refreshes the latest activity snapshot before forcing local interrupt waiting", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let sentSurface = "";
+    runningMap.clear();
+
+    withTempDir((dir) => {
+      mkdirSync(join(dir, "subagent-activity"), { recursive: true });
+      const activityFile = getSubagentActivityFile(dir, "a1");
+      const activity = {
+        version: 1,
+        runningChildId: "a1",
+        createdAt: 1_000,
+        updatedAt: 19_000,
+        sequence: 7,
+        latestEvent: "tool_execution_start",
+        phase: "active",
+        agentActive: true,
+        turnActive: true,
+        providerActive: false,
+        toolActive: true,
+        activeScope: "tool",
+        activeSince: 19_000,
+        toolName: "bash",
+      };
+      writeFileSync(activityFile, `${JSON.stringify(activity)}\n`);
+
+      try {
+        runningMap.set("a1", makeRunning({
+          activityFile,
+          statusState: createStatusState({ source: "pi", startTimeMs: 0 }),
+        }));
+
+        withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+          sentSurface = surface;
+        }));
+
+        assert.equal(sentSurface, "pane-1");
+        const state = runningMap.get("a1").statusState;
+        const snapshot = classifyStatus(state, 20_000);
+        assert.equal(snapshot.kind, "waiting");
+        assert.equal(snapshot.activityLabel, "interrupted");
+        assert.equal(state.lastActivityAtMs, 20_000);
+        assert.equal(state.lastActivitySequence, 7);
+        assert.equal(state.localOverrideSequence, 7);
+      } finally {
+        runningMap.clear();
+      }
+    });
+  });
+
+  it("acknowledges Pi-backed interrupt requests and forces local status waiting", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let sentSurface = "";
+    runningMap.clear();
+
+    const activeState = observeStatus(
+      createStatusState({ source: "pi", startTimeMs: 0 }),
+      {
+        snapshot: "present",
+        updatedAt: 5_000,
+        sequence: 1,
+        phase: "active",
+        active: true,
+        activeScope: "tool",
+        activeSince: 5_000,
+        activityLabel: "bash",
+      },
+      5_000,
+    );
+
+    try {
+      runningMap.set("a1", makeRunning({ statusState: activeState }));
+
+      const result = withMockedNow(20_000, () => testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        sentSurface = surface;
+      }));
+
+      assert.equal(sentSurface, "pane-1");
+      assert.equal(result.content[0].text, 'Interrupt requested for subagent "Worker".');
+      assert.deepEqual(result.details, { id: "a1", name: "Worker", status: "interrupt_requested" });
+      const snapshot = classifyStatus(runningMap.get("a1").statusState, 20_000);
+      assert.equal(snapshot.kind, "waiting");
+      assert.equal(snapshot.activityLabel, "interrupted");
+      assert.equal(runningMap.has("a1"), true);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("sends Escape again for repeated interrupt requests", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    const surfaces: string[] = [];
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning());
+
+      testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        surfaces.push(surface);
+      });
+      testApi.handleSubagentInterrupt({ name: "Worker" }, (surface: string) => {
+        surfaces.push(surface);
+      });
+
+      assert.deepEqual(surfaces, ["pane-1", "pane-1"]);
+      assert.equal(runningMap.has("a1"), true);
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("rejects Claude-backed interrupt requests before delivery", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const runningMap = testApi.runningSubagents as Map<string, any>;
+    let delivered = false;
+    runningMap.clear();
+
+    try {
+      runningMap.set("a1", makeRunning({ cli: "claude" }));
+
+      const result = testApi.handleSubagentInterrupt({ name: "Worker" }, () => {
+        delivered = true;
+      });
+
+      assert.equal(delivered, false);
+      assert.match(result.content[0].text, /currently supported only for Pi-backed subagents/i);
+      assert.deepEqual(result.details, {
+        error: "claude interrupt unsupported",
+        id: "a1",
+        name: "Worker",
+      });
+    } finally {
+      runningMap.clear();
+    }
+  });
+
+  it("formats exit code 130 as an ordinary failure", () => {
+    const testApi = (subagentsModule as any).__test__;
+    const presentation = testApi.resolveResultPresentation(
+      {
+        exitCode: 130,
+        elapsed: 61,
+        summary: "Sub-agent exited with code 130",
+        sessionFile: "/tmp/subagent.jsonl",
+      },
+      "Worker",
+    );
+
+    assert.match(presentation, /failed \(exit code 130\)/);
+    assert.doesNotMatch(presentation, /interrupted/);
+    assert.match(presentation, /Resume: pi --session/);
+  });
+});
+
+describe("subagent status renderer", () => {
+  function createTheme() {
+    return {
+      fg(_color: string, text: string) {
+        return text;
+      },
+      bg(_color: string, text: string) {
+        return text;
+      },
+      bold(text: string) {
+        return text;
+      },
+    };
+  }
+
+  it("renders only capped lines plus overflow", () => {
+    const { api, registeredMessageRenderers } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const rendererEntry = registeredMessageRenderers.find((entry) => entry.name === "subagent_status");
+    assert.ok(rendererEntry, "expected subagent_status renderer to be registered");
+
+    const visibleLines = [
+      "Worker running 5m, active (bash 2m).",
+      "Scout running 3m, waiting 1m.",
+      "Reviewer running 2m, active (streaming 30s).",
+      "Planner running 4m, waiting 2m.",
+    ];
+    const rendered = rendererEntry.renderer(
+      {
+        customType: "subagent_status",
+        content: "Subagent status:\n• Worker running 5m, active (bash 2m).",
+        details: {
+          lines: visibleLines,
+          overflow: 2,
+        },
+      },
+      { expanded: true },
+      createTheme(),
+    );
+    const output = rendered.render(80).join("\n");
+
+    assert.match(output, /Subagent status/);
+    for (const line of visibleLines) {
+      assert.match(output, new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+    assert.match(output, /\+2 more running\./);
+  });
+
+  it("stays within narrow widths", () => {
+    const { api, registeredMessageRenderers } = createMockExtensionApi();
+    (subagentsModule as any).default(api);
+
+    const rendererEntry = registeredMessageRenderers.find((entry) => entry.name === "subagent_status");
+    assert.ok(rendererEntry, "expected subagent_status renderer to be registered");
+
+    const rendered = rendererEntry.renderer(
+      {
+        customType: "subagent_status",
+        content: "Subagent status:\n• Worker running 5m, active (bash 2m).",
+        details: { lines: ["Worker running 5m, active (bash 2m)."], overflow: 0 },
+      },
+      { expanded: true },
+      createTheme(),
+    );
+
+    for (const width of [4, 5, 6]) {
+      for (const line of rendered.render(width)) {
+        assert.ok(
+          visibleWidth(line) <= width,
+          `expected line width <= ${width}, got ${visibleWidth(line)} for ${JSON.stringify(line)}`,
+        );
+      }
+    }
+  });
+});
+
+describe("subagent startup delay", () => {
+  it("defaults to 500ms when no env var is set", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.getShellReadyDelayMs, "function");
+
+    const original = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    try {
+      assert.equal(testApi.getShellReadyDelayMs(), 500);
+    } finally {
+      if (original == null) delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+      else process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = original;
+    }
+  });
+
+  it("uses PI_SUBAGENT_SHELL_READY_DELAY_MS when it is set", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.getShellReadyDelayMs, "function");
+
+    const original = process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+    process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = "2500";
+    try {
+      assert.equal(testApi.getShellReadyDelayMs(), 2500);
+    } finally {
+      if (original == null) delete process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS;
+      else process.env.PI_SUBAGENT_SHELL_READY_DELAY_MS = original;
+    }
+  });
+});
+describe("subagents widget rendering", () => {
+  it("keeps every rendered line within a very narrow width", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.renderSubagentWidgetLines, "function");
+
+    const originalNow = Date.now;
+    Date.now = () => 1_000_000;
+    try {
+      const lines = testApi.renderSubagentWidgetLines([
+        {
+          id: "a1",
+          name: "A",
+          task: "",
+          surface: "s1",
+          startTime: 1_000_000 - 13_000,
+          sessionFile: "sess1",
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 13_000 }),
+        },
+        {
+          id: "a2",
+          name: "B",
+          task: "",
+          surface: "s2",
+          startTime: 1_000_000 - 21_000,
+          sessionFile: "sess2",
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 21_000 }),
+        },
+        {
+          id: "a3",
+          name: "C",
+          task: "",
+          surface: "s3",
+          startTime: 1_000_000 - 27_000,
+          sessionFile: "sess3",
+          statusState: createStatusState({ source: "pi", startTimeMs: 1_000_000 - 27_000 }),
+        },
+      ], 16);
+
+      assert.deepEqual(
+        lines.map((line: string) => visibleWidth(line)),
+        [16, 16, 16, 16, 16],
+      );
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("truncates the right-hand status instead of overflowing when it alone is too wide", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.borderLine, "function");
+
+    const line = testApi.borderLine(" A ", " 999 msgs (999.9KB) ", 16);
+    assert.equal(visibleWidth(line), 16);
+  });
+
+  it("handles ultra-narrow widths without exceeding the width contract", () => {
+    const testApi = (subagentsModule as any).__test__;
+    assert.ok(testApi, "expected subagents test helpers to be exported");
+    assert.equal(typeof testApi.renderSubagentWidgetLines, "function");
+
+    const widths = [0, 1, 2];
+    for (const width of widths) {
+      const startTime = Date.now() - 5_000;
+      const lines = testApi.renderSubagentWidgetLines([
+        {
+          id: "a1",
+          name: "A",
+          task: "",
+          surface: "s1",
+          startTime,
+          sessionFile: "sess1",
+          statusState: createStatusState({ source: "pi", startTimeMs: startTime }),
+        },
+      ], width);
+
+      for (const line of lines) {
+        assert.ok(
+          visibleWidth(line) <= width,
+          `expected line width <= ${width}, got ${visibleWidth(line)} for ${JSON.stringify(line)}`,
+        );
+      }
+    }
+  });
+});
+
+describe("cmux.ts", () => {
+  describe("shellEscape", () => {
+    it("wraps in single quotes", () => {
+      assert.equal(shellEscape("hello"), "'hello'");
+    });
+
+    it("escapes single quotes", () => {
+      assert.equal(shellEscape("it's"), "'it'\\''s'");
+    });
+
+    it("handles empty string", () => {
+      assert.equal(shellEscape(""), "''");
+    });
+
+    it("handles special characters", () => {
+      const input = 'echo "hello $world" && rm -rf /';
+      const escaped = shellEscape(input);
+      assert.ok(escaped.startsWith("'"));
+      assert.ok(escaped.endsWith("'"));
+      // Inside single quotes, everything is literal
+      assert.ok(escaped.includes("$world"));
+    });
+  });
+
+  describe("parseCmuxFocusedSnapshot", () => {
+    it("parses focused surface and pane refs", () => {
+      assert.deepEqual(
+        parseCmuxFocusedSnapshot({ focused: { surface_ref: "surface:3", pane_ref: "pane:2" } }),
+        { surfaceRef: "surface:3", paneRef: "pane:2" },
+      );
+    });
+
+    it("does not fall back to caller refs", () => {
+      assert.equal(
+        parseCmuxFocusedSnapshot({ caller: { surface_ref: "surface:1", pane_ref: "pane:1" } }),
+        null,
+      );
+    });
+
+    it("returns null for malformed values", () => {
+      assert.equal(parseCmuxFocusedSnapshot(null), null);
+      assert.equal(parseCmuxFocusedSnapshot({ focused: {} }), null);
+    });
+  });
+
+  describe("parseCmuxJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxJson("not json"), null);
+    });
+
+    it("parses valid JSON text", () => {
+      assert.deepEqual(parseCmuxJson('{"ok":true}'), { ok: true });
+    });
+  });
+
+  describe("parseCmuxFocusedSnapshotFromJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxFocusedSnapshotFromJson("not json"), null);
+    });
+
+    it("returns null when focused is absent or not an object", () => {
+      assert.equal(
+        parseCmuxFocusedSnapshotFromJson('{"focused":null,"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"}}'),
+        null,
+      );
+      assert.equal(
+        parseCmuxFocusedSnapshotFromJson('{"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"}}'),
+        null,
+      );
+    });
+
+    it("parses focused refs without falling back to caller refs", () => {
+      assert.deepEqual(
+        parseCmuxFocusedSnapshotFromJson(
+          '{"caller":{"surface_ref":"surface:1","pane_ref":"pane:1"},"focused":{"surface_ref":"surface:2","pane_ref":"pane:3"}}',
+        ),
+        { surfaceRef: "surface:2", paneRef: "pane:3" },
+      );
+    });
+  });
+
+  describe("parseCmuxPaneRefForSurface", () => {
+    it("parses top-level pane refs for a surface", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface({ surface_ref: "surface:7", pane_ref: "pane:4" }, "surface:7"),
+        "pane:4",
+      );
+    });
+
+    it("parses caller pane refs for identify --surface output", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface(
+          { caller: { surface_ref: "surface:7", pane_ref: "pane:4" } },
+          "surface:7",
+        ),
+        "pane:4",
+      );
+    });
+
+    it("returns null when the surface does not match", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurface({ surface_ref: "surface:8", pane_ref: "pane:4" }, "surface:7"),
+        null,
+      );
+    });
+  });
+
+  describe("parseCmuxPaneRefForSurfaceFromJson", () => {
+    it("returns null for malformed JSON text", () => {
+      assert.equal(parseCmuxPaneRefForSurfaceFromJson("not json", "surface:7"), null);
+    });
+
+    it("parses caller refs from cmux identify --surface JSON text", () => {
+      assert.equal(
+        parseCmuxPaneRefForSurfaceFromJson(
+          '{"caller":{"surface_ref":"surface:7","pane_ref":"pane:4"}}',
+          "surface:7",
+        ),
+        "pane:4",
+      );
+    });
+  });
+
+  describe("zellij placement", () => {
+    const pane = (overrides: any) => ({
+      id: 1,
+      is_plugin: false,
+      is_floating: false,
+      is_selectable: true,
+      exited: false,
+      pane_rows: 20,
+      pane_columns: 80,
+      tab_id: 1,
+      ...overrides,
+    });
+
+    it("matches Zellij direction and minimum split rules", () => {
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 5, pane_columns: 11 })), "right");
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 11, pane_columns: 5 })), "down");
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 5, pane_columns: 10 })), null);
+      assert.equal(predictZellijSplitDirection(pane({ pane_rows: 4, pane_columns: 80 })), null);
+
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 5, pane_columns: 11 })), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 11, pane_columns: 5 })), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 5, pane_columns: 10 })), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 4, pane_columns: 80 })), false);
+
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 30, pane_columns: 100 }), 80, 20), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 45, pane_columns: 100 }), 80, 20), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 30, pane_columns: 170 }), 80, 20), true);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 31, pane_columns: 47 }), 50, 10), false);
+      assert.equal(canSplitZellijPane(pane({ pane_rows: 31, pane_columns: 77 }), 50, 10), true);
+    });
+
+    it("uses tab-scoped split only when all Zellij split candidates are safe", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 40, pane_columns: 120 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 120, pane_columns: 100 }),
+          pane({ id: 12, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "split",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+        splitDirection: "down",
+      });
+    });
+
+    it("stacks when any Zellij split candidate would fall below Pi's configured minimum", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 100, pane_columns: 47 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 31, pane_columns: 77 }),
+        ],
+        10,
+        50,
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("stacks when Zellij would split a pane below Pi's usable minimum", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 20, pane_columns: 20 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 18, pane_columns: 60 }),
+          pane({ id: 12, tab_id: 1, pane_rows: 10, pane_columns: 70 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("never chooses the parent pane as the stack target", () => {
+      const plan = selectZellijStackPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 60, pane_columns: 200 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 10, pane_columns: 20 }),
+          pane({ id: 12, tab_id: 1, pane_rows: 8, pane_columns: 30 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 12,
+        targetPaneId: 12,
+        tabId: 1,
+      });
+    });
+
+    it("does not stack when the only usable pane is the parent", () => {
+      const plan = selectZellijStackPlacement(
+        [pane({ id: 10, tab_id: 1, pane_rows: 60, pane_columns: 200 })],
+        10,
+      );
+
+      assert.equal(plan, null);
+    });
+
+    it("stacks on the largest usable non-parent pane when none can split", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 5, pane_columns: 10 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 6, pane_columns: 8 }),
+          pane({ id: 12, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.deepEqual(plan, {
+        mode: "stack",
+        anchorPaneId: 11,
+        targetPaneId: 11,
+        tabId: 1,
+      });
+    });
+
+    it("ignores floating, plugin, exited, unselectable, and other-tab panes", () => {
+      const plan = selectZellijPlacement(
+        [
+          pane({ id: 10, tab_id: 1, pane_rows: 5, pane_columns: 10 }),
+          pane({ id: 11, tab_id: 1, pane_rows: 60, pane_columns: 200, is_floating: true }),
+          pane({ id: 12, tab_id: 1, pane_rows: 60, pane_columns: 200, is_plugin: true }),
+          pane({ id: 13, tab_id: 1, pane_rows: 60, pane_columns: 200, exited: true }),
+          pane({ id: 14, tab_id: 1, pane_rows: 60, pane_columns: 200, is_selectable: false }),
+          pane({ id: 15, tab_id: 2, pane_rows: 60, pane_columns: 200 }),
+        ],
+        10,
+      );
+
+      assert.equal(plan, null);
+    });
+
+    it("returns null when the parent pane cannot be found", () => {
+      assert.equal(selectZellijPlacement([pane({ id: 10 })], 99), null);
+    });
+  });
+
+  describe("isCmuxAvailable", () => {
+    it("returns boolean based on CMUX_SOCKET_PATH", () => {
+      // Can't easily mock env in node:test, just verify it returns a boolean
+      const result = isCmuxAvailable();
+      assert.equal(typeof result, "boolean");
+    });
+  });
+
+  describe("isWezTermAvailable", () => {
+    it("returns boolean based on WEZTERM_UNIX_SOCKET", () => {
+      const result = isWezTermAvailable();
+      assert.equal(typeof result, "boolean");
+    });
+  });
+});

--- a/packages/pi-interactive-subagents/tsconfig.json
+++ b/packages/pi-interactive-subagents/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "pi-extension/**/*.ts"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,8 @@
     "packages/pi-extensions-tool-display": {},
     "packages/pi-terminal-mux": {},
     "packages/pi-metrics": {},
-    "packages/pi-models-discovery": {}
+    "packages/pi-models-discovery": {},
+    "packages/pi-dynamic-workflows": {},
+    "packages/pi-interactive-subagents": {}
   }
 }


### PR DESCRIPTION
## 背景

将两个 fork 包迁入本公开仓并以 npm scope 发布，README 致谢原作者。因原名 `pi-dynamic-workflows`（michaelliv）与 `pi-interactive-subagents`（HazAT）已被原作者占用，改用 `@maplezzk/` scope。

## 变更

### pi-dynamic-workflows（`@maplezzk/pi-dynamic-workflows`）
- 环境变量配置迁移为 `/workflow-config` 斜杠命令 + JSON 持久化（`PI_WORKFLOW_BACKEND` / `PI_WORKFLOW_ASYNC` 仅作兜底）
- 接入 pi-extensions-i18n，用户可见文案中英双语
- 适配 pi 0.78→0.80（tool result `details`、`Component.invalidate` 等）
- 致谢原作者 **michaelliv**

### pi-interactive-subagents（`@maplezzk/pi-interactive-subagents`）
- 结构适配 monorepo，修复 pi 0.74→0.80 类型兼容（判别联合类型守卫、`Component.invalidate`、tool result `details`、`unknown` 收窄等 17 处）
- 最小诚实版 i18n（唯一硬编码中文「自动提醒」抽成中英 catalog；英文 UI 文案完整 i18n 留作后续）
- 致谢原作者 **HazAT**

### 仓库级
- 两包加入 release-please 配置、manifest 与发布矩阵
- 根 README 中英双语补充包清单
- 清理源包带入的 docs/、demos/（含原作者本机路径）

## 验证

- `npm run check` 通过（9 个包）：typecheck + test + no-local-path + no-private-domain + i18n-keys
- pi-dynamic-workflows：typecheck 0 错误，36/36 测试通过
- pi-interactive-subagents：typecheck 0 错误，116/116 测试通过