### PR TITLE
fix: use a compatible hollow distill icon

### DIFF
--- a/packages/pi-distill/locales/fallback-renderer.json
+++ b/packages/pi-distill/locales/fallback-renderer.json
@@ -56,8 +56,8 @@
     "en-US": " • Ctrl+O to expand"
   },
   "header": {
-    "zh-CN": "⟡ Distill  {status}",
-    "en-US": "⟡ Distill  {status}"
+    "zh-CN": "◇ Distill  {status}",
+    "en-US": "◇ Distill  {status}"
   },
   "summary": {
     "zh-CN": "摘要",

--- a/packages/pi-distill/src/fallback-renderer.ts
+++ b/packages/pi-distill/src/fallback-renderer.ts
@@ -58,8 +58,8 @@ function formatCount(value: number): string {
 
 function renderDistillAuditLine(audit: DistillAuditView, line: string, index: number, theme: RenderTheme): string {
   if (index === 0) {
-    const title = theme.fg("accent", theme.bold("⟡ Distill"));
-    const afterTitle = line.slice("⟡ Distill".length);
+    const title = theme.fg("accent", theme.bold("◇ Distill"));
+    const afterTitle = line.slice("◇ Distill".length);
     const statusIndex = afterTitle.indexOf(audit.statusLabel);
     if (statusIndex < 0) return `${title}${theme.fg("muted", afterTitle)}`;
     const beforeStatus = afterTitle.slice(0, statusIndex);

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -723,14 +723,14 @@ test("pi-distill 可以追加 UI-only 保底审计", () => {
   assert.deepEqual(
     buildDistillAuditLines("bash", details, false, render)?.lines,
     [
-      "⟡ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s • Ctrl+O to expand",
+      "◇ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s • Ctrl+O to expand",
     ],
   );
 
   assert.deepEqual(
     buildDistillAuditLines("bash", details, true, render)?.lines,
     [
-      "⟡ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s",
+      "◇ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s",
       "├─ outputRequest  只保留计数范围和结论",
       "└─ Summary  计数器从 1 到 100，乘积从 2 到 200。",
     ],
@@ -739,7 +739,7 @@ test("pi-distill 可以追加 UI-only 保底审计", () => {
   assert.deepEqual(
     buildDistillAuditLines("bash", details, true, { ...render, showPrompt: false })?.lines,
     [
-      "⟡ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s",
+      "◇ Distill  ✓ Summarized  12,000 → 1,200 chars · 10.00× · 90.0% saved · Distill 1.2s",
       "└─ Summary  计数器从 1 到 100，乘积从 2 到 200。",
     ],
   );
@@ -749,7 +749,7 @@ test("pi-distill 可以追加 UI-only 保底审计", () => {
     fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
     bold: (text: string) => `<b>${text}</b>`,
   } as any);
-  assert.match(styled, /<accent><b>⟡ Distill<\/b><\/accent>/);
+  assert.match(styled, /<accent><b>◇ Distill<\/b><\/accent>/);
   assert.match(styled, /<success>✓ Summarized<\/success>/);
   assert.match(styled, /<accent>outputRequest<\/accent>/);
   assert.match(styled, /<success>Summary<\/success>/);
@@ -800,7 +800,7 @@ test("pi-distill 通过通用 tool-display result middleware 渲染且不重复�
     const renderedLines = component.render(120);
     assert.equal(renderedLines[0], "");
     const output = renderedLines.join("\n");
-    assert.match(output, /⟡ Distill  ✓ Summarized/);
+    assert.match(output, /◇ Distill  ✓ Summarized/);
     assert.match(output, /├─ outputRequest  只保留最终结论/);
     assert.match(output, /└─ Summary  协议渲染的提炼结果/);
     assert.doesNotMatch(output, /不应重复的基础正文/);


### PR DESCRIPTION
## Problem

Some terminal fonts do not provide a glyph for `⟡`, so pi-distill can render its header icon as a tofu square.

## Changes

- Replace `⟡ Distill` with the more widely supported hollow diamond `◇ Distill`.
- Keep the bilingual catalog and renderer assertions aligned.

## Validation

- `npm run check --workspace=pi-distill`
- 28 tests passed
- Typecheck and package dry-run passed