### PR TITLE
fix: correct Pi npm install commands

### DIFF
--- a/packages/pi-dynamic-workflows/README.md
+++ b/packages/pi-dynamic-workflows/README.md
@@ -15,7 +15,7 @@ Claude-Code-style dynamic workflow orchestration for Pi.
 ## Installation
 
 ```bash
-pi install @maplezzk/pi-dynamic-workflows
+pi install npm:@maplezzk/pi-dynamic-workflows
 ```
 
 ## Configuration

--- a/packages/pi-dynamic-workflows/README.zh-CN.md
+++ b/packages/pi-dynamic-workflows/README.zh-CN.md
@@ -15,7 +15,7 @@
 ## 安装
 
 ```bash
-pi install @maplezzk/pi-dynamic-workflows
+pi install npm:@maplezzk/pi-dynamic-workflows
 ```
 
 ## 配置

--- a/packages/pi-dynamic-workflows/locales/index.json
+++ b/packages/pi-dynamic-workflows/locales/index.json
@@ -72,7 +72,7 @@
     "en-US": "📄 Result: {path}"
   },
   "subagentRequired": {
-    "zh-CN": "PI_WORKFLOW_BACKEND=subagent 需要 pi-interactive-subagents 扩展。\n安装: pi install pi-interactive-subagents",
-    "en-US": "PI_WORKFLOW_BACKEND=subagent requires the pi-interactive-subagents extension.\nInstall: pi install pi-interactive-subagents"
+    "zh-CN": "PI_WORKFLOW_BACKEND=subagent 需要 pi-interactive-subagents 扩展。\n安装: pi install npm:@maplezzk/pi-interactive-subagents",
+    "en-US": "PI_WORKFLOW_BACKEND=subagent requires the pi-interactive-subagents extension.\nInstall: pi install npm:@maplezzk/pi-interactive-subagents"
   }
 }

--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -28,7 +28,7 @@ subagent({ name: "Scout: DB", agent: "scout", task: "Map database schema" });
 ## Install
 
 ```bash
-pi install @maplezzk/pi-interactive-subagents
+pi install npm:@maplezzk/pi-interactive-subagents
 ```
 
 Supported multiplexers:

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -17,7 +17,7 @@ subagent({ name: "Scout: DB", agent: "scout", task: "梳理数据库 schema" });
 ## 安装
 
 ```bash
-pi install @maplezzk/pi-interactive-subagents
+pi install npm:@maplezzk/pi-interactive-subagents
 ```
 
 支持的终端复用器：[cmux](https://github.com/manaflow-ai/cmux)、[tmux](https://github.com/tmux/tmux)、[zellij](https://zellij.dev)、[WezTerm](https://wezfurlong.org/wezterm/)、[herdr](https://herdr.dev)、[Otty](https://otty.sh)。


### PR DESCRIPTION
## Summary
- add the required `npm:` prefix to scoped Pi package installation commands
- update both English and Chinese READMEs
- fix the dynamic workflows subagent installation hint

## Validation
- full repository scan found no unprefixed `pi install` commands
- package config check passed
- locale JSON validation passed
- `npm run check` is currently blocked by pre-existing missing workspace dependencies: `acorn`, `@sinclair/typebox`, and `ajv`