### PR TITLE
docs(pi-dynamic-workflows): clarify subagent backend error and add troubleshooting

### DIFF
--- a/packages/pi-dynamic-workflows/README.md
+++ b/packages/pi-dynamic-workflows/README.md
@@ -22,7 +22,7 @@ pi install npm:@maplezzk/pi-dynamic-workflows
 
 Run `/workflow-config` to interactively configure:
 
-- **Execution backend**: `workflow` (built-in in-process agent) or `subagent` (requires `pi-interactive-subagents`)
+- **Execution backend**: `workflow` (built-in in-process agent) or `subagent` (requires `pi-interactive-subagents` to be installed and loaded; each agent gets a real tool session)
 - **Async mode**: run workflows in the background with a live status widget
 
 Config is persisted to `~/.pi/agent/extensions/pi-dynamic-workflows/config.json`.
@@ -35,6 +35,30 @@ Environment variables are supported as fallback only:
 | `PI_WORKFLOW_ASYNC` | `true` | Enable async mode (fallback) |
 
 JSON config takes priority over environment variables.
+
+> **Note:** The `subagent` backend depends on the `pi-interactive-subagents` extension injecting its capabilities into `globalThis.__pi_subagents` at runtime. If the backend is set to `subagent` but that extension is not installed/loaded, every `agent()` call in the workflow will fail.
+
+## Troubleshooting
+
+### Error: the subagent execution backend requires the pi-interactive-subagents extension, which is not currently loaded
+
+**Cause**: the workflow execution backend is set to `subagent`, but the `pi-interactive-subagents` extension is not installed or not loaded, so `globalThis.__pi_subagents` is not injected.
+
+The `subagent` backend can be activated by either of:
+
+- The `PI_WORKFLOW_BACKEND=subagent` environment variable
+- The persisted config written by `/workflow-config` (`~/.pi/agent/extensions/pi-dynamic-workflows/config.json`)
+
+**Fix (choose one)**:
+
+1. Install and load the extension (keep using the subagent backend):
+
+   ```bash
+   pi install npm:@maplezzk/pi-interactive-subagents
+   ```
+
+2. Switch back to the built-in `workflow` backend: run `/workflow-config` and set the execution backend to `workflow`. The persisted config takes priority over environment variables, so this overrides `PI_WORKFLOW_BACKEND`.
+3. If you enabled it via an environment variable, remove `export PI_WORKFLOW_BACKEND=subagent` from your shell config (e.g. `.zshrc` / `.zshenv`) and restart pi.
 
 ## Usage
 

--- a/packages/pi-dynamic-workflows/README.zh-CN.md
+++ b/packages/pi-dynamic-workflows/README.zh-CN.md
@@ -22,7 +22,7 @@ pi install npm:@maplezzk/pi-dynamic-workflows
 
 运行 `/workflow-config` 进行交互式配置：
 
-- **执行后端**：`workflow`（内置进程内 agent）或 `subagent`（需安装 `pi-interactive-subagents`）
+- **执行后端**：`workflow`（内置进程内 agent）或 `subagent`（需安装并加载 `pi-interactive-subagents`，每个 agent 拥有真实工具会话）
 - **异步模式**：后台运行 workflow，带实时状态 widget
 
 配置持久化到 `~/.pi/agent/extensions/pi-dynamic-workflows/config.json`。
@@ -35,6 +35,30 @@ pi install npm:@maplezzk/pi-dynamic-workflows
 | `PI_WORKFLOW_ASYNC` | `true` | 启用异步模式（兜底） |
 
 JSON 配置优先级高于环境变量。
+
+> **注意**：`subagent` 后端依赖 `pi-interactive-subagents` 扩展在运行时向 `globalThis.__pi_subagents` 注入能力。若后端被设为 `subagent` 但该扩展未安装/未加载，workflow 中的每个 `agent()` 都会失败。
+
+## 常见问题
+
+### 报错：subagent 执行后端需要 pi-interactive-subagents 扩展，但当前未加载
+
+**原因**：workflow 的执行后端被设为 `subagent`，但 `pi-interactive-subagents` 扩展未安装或未加载，导致 `globalThis.__pi_subagents` 未注入。
+
+`subagent` 后端可能由以下任一来源触发：
+
+- 环境变量 `PI_WORKFLOW_BACKEND=subagent`
+- `/workflow-config` 写入的持久化配置（`~/.pi/agent/extensions/pi-dynamic-workflows/config.json`）
+
+**解决方式（任选其一）**：
+
+1. 安装并加载扩展（继续使用 subagent 后端）：
+
+   ```bash
+   pi install npm:@maplezzk/pi-interactive-subagents
+   ```
+
+2. 切回内置 `workflow` 后端：运行 `/workflow-config`，将执行后端改为 `workflow`。持久化配置优先级高于环境变量，可覆盖 `PI_WORKFLOW_BACKEND`。
+3. 若是通过环境变量启用，移除 shell 配置（如 `.zshrc` / `.zshenv`）中的 `export PI_WORKFLOW_BACKEND=subagent` 后重启 pi。
 
 ## 用法
 

--- a/packages/pi-dynamic-workflows/locales/index.json
+++ b/packages/pi-dynamic-workflows/locales/index.json
@@ -72,7 +72,7 @@
     "en-US": "📄 Result: {path}"
   },
   "subagentRequired": {
-    "zh-CN": "PI_WORKFLOW_BACKEND=subagent 需要 pi-interactive-subagents 扩展。\n安装: pi install npm:@maplezzk/pi-interactive-subagents",
-    "en-US": "PI_WORKFLOW_BACKEND=subagent requires the pi-interactive-subagents extension.\nInstall: pi install npm:@maplezzk/pi-interactive-subagents"
+    "zh-CN": "subagent 执行后端需要 pi-interactive-subagents 扩展，但当前未加载。\n\n解决方式（任选其一）：\n1. 安装扩展：pi install npm:@maplezzk/pi-interactive-subagents\n2. 运行 /workflow-config 将执行后端切回 workflow\n\n说明：subagent 后端由环境变量 PI_WORKFLOW_BACKEND=subagent 或 /workflow-config 持久化配置触发。",
+    "en-US": "The subagent execution backend requires the pi-interactive-subagents extension, which is not currently loaded.\n\nFix (choose one):\n1. Install the extension: pi install npm:@maplezzk/pi-interactive-subagents\n2. Run /workflow-config to switch the execution backend back to workflow\n\nNote: the subagent backend is activated by the PI_WORKFLOW_BACKEND=subagent environment variable or the /workflow-config persisted setting."
   }
 }


### PR DESCRIPTION
## 问题

当 workflow 执行后端为 `subagent` 但 `pi-interactive-subagents` 扩展未安装/未加载时，报错文案为 `PI_WORKFLOW_BACKEND=subagent requires the pi-interactive-subagents extension`，存在两个问题：

1. 把原因硬编码成环境变量，但该后端实际可由环境变量 **或** `/workflow-config` 持久化配置触发，文案误导用户；
2. 只给出「安装扩展」一条出路，未告知可切回内置 `workflow` 后端。

且 README 缺少对应的故障排查说明。

## 行为变化

- `subagentRequired` 报错改为准确诊断（不绑定具体来源），并给出两种解法：安装 `pi-interactive-subagents`，或运行 `/workflow-config` 切回 `workflow`；补充说明后端来源可能是环境变量或持久化配置。
- README 配置章节补充 `subagent` 后端需扩展「安装并加载」的前提，以及 `globalThis.__pi_subagents` 注入机制说明。
- 新增 Troubleshooting / 常见问题段落：报错原因、两种触发来源、三种解决方式。

## 影响

- 包：`pi-dynamic-workflows`（仅 `locales/index.json` 文案 + `README.md` / `README.zh-CN.md`）。
- 无代码逻辑、公开 API、配置契约变更。

## 验证

- `npm run check --workspace=@maplezzk/pi-dynamic-workflows`：typecheck ✓ / 36/36 测试 ✓ / pack ✓
- locale JSON 合法性 ✓，`catalog.test.ts` 覆盖中英文条目齐全 ✓
- 无旧文案残留引用 ✓