### PR TITLE
fix: restore pi-distill final output limit

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -157,6 +157,7 @@ Start from [`config.example.json`](./config.example.json):
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
+  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
@@ -174,7 +175,8 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | --- | --- |
 | `model` | Optional `provider/model`; empty uses the current Pi session model. |
 | `minChars` | Minimum output size before a summary is requested. |
-| `maxChars` | Maximum output budget for the distillation model (about `maxChars / 2` tokens) and a diagnostic reference; no longer used to write files. |
+| `maxChars` | Distilled text is written to a temporary file when it exceeds this length. |
+| `maxOutputChars` | Maximum text returned to the Agent. Oversized text is written to a temporary file and replaced with a file pointer. |
 | `timeoutSeconds` | Maximum time allowed for the distillation model call. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
 | `summarizeErrors` | Whether error results that meet `minChars` should still be sent to the distillation model. |
@@ -183,7 +185,7 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 `/pi-distill` remains available as a compatibility alias.
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
-The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`. The legacy `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` option is still parsed for backward compatibility but no longer has any effect.
+The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_MAX_OUTPUT_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`.
 
 ## Requirements
 

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -159,6 +159,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
+  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
@@ -177,7 +178,8 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | --- | --- |
 | `model` | 可选的 `provider/model`；为空时使用当前 Pi 会话模型。 |
 | `minChars` | 达到此输出长度后才请求提炼。 |
-| `maxChars` | 提炼模型的最大输出预算（约 `maxChars / 2` tokens），同时作为诊断参考；不再用于写文件。 |
+| `maxChars` | 提炼结果超过此字符数时写入临时文件。 |
+| `maxOutputChars` | 最终返回给 Agent 的文本上限。超出后写入临时文件，只返回文件指针。 |
 | `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
 | `summarizeErrors` | 工具返回错误且达到 `minChars` 时，是否仍发送给提炼模型。 |
@@ -186,7 +188,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 `/pi-distill` 仍作为兼容别名保留。
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
-主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。旧配置中的 `maxOutputChars` / `PI_DISTILL_MAX_OUTPUT_CHARS` 仍会被解析以兼容旧文件，但不再生效。
+主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_MAX_OUTPUT_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。
 
 ## 要求
 

--- a/packages/pi-distill/config.example.json
+++ b/packages/pi-distill/config.example.json
@@ -3,6 +3,7 @@
   "model": "",
   "minChars": 200,
   "maxChars": 100000,
+  "maxOutputChars": 10000,
   "timeoutSeconds": 10,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,

--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -119,6 +119,14 @@
     "zh-CN": "最终输出字符上限",
     "en-US": "Final output character limit"
   },
+  "outputLimitExceeded": {
+    "zh-CN": "输出超过 {maxChars} 个字符，完整内容已写入：{path}",
+    "en-US": "Output exceeded {maxChars} chars and was written to: {path}"
+  },
+  "outputLimitWriteFailed": {
+    "zh-CN": "无法写入超长输出临时文件，将返回截断内容：{error}",
+    "en-US": "Failed to write oversized output to a temp file; returning truncated content: {error}"
+  },
   "timeoutTitle": {
     "zh-CN": "提炼模型超时（秒）",
     "en-US": "Summarizer timeout (seconds)"

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -6,7 +6,8 @@
  *
  * 所有工具统一使用 outputRequest：严格传入 RAW 时返回原始输出；其他非空
  * outputRequest 表示调用提炼模型，具体保留内容由 outputRequest 决定。
- * 提炼结果超过 maxChars 时写入临时文件，只返回文件路径。
+ * 提炼结果超过 maxChars 时写入临时文件，只返回文件路径；最终返回内容
+ * 超过 maxOutputChars 时同样写入临时文件，只把文件指针交给 Agent。
  *
  * 配置文件优先；旧环境变量继续兼容：
  * - ~/.pi/agent/extensions/pi-distill/config.json
@@ -36,7 +37,7 @@ import {
   isDistillToolDisplayMiddlewareActive,
   registerDistillToolDisplayMiddleware,
 } from "./tool-display-bridge.ts";
-import { getTextContent, hasNonTextContent } from "./output-limit.ts";
+import { getTextContent, hasNonTextContent, limitReturnedToolResult } from "./output-limit.ts";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -431,8 +432,10 @@ export async function processToolResult(
   const loaded = loadDistillConfig();
   const config = loaded.config;
   const outputSummaryRender = { ...loaded.render };
-  // Merge with Pi's native output limiter; this extension must not truncate tool results itself.
-  const finish = (candidate: ToolResult) => candidate;
+  // Pi may persist raw tool output before this hook runs. This second limit
+  // protects the post-distillation result, including RAW and fallbacks.
+  const maxReturnedChars = config?.maxOutputChars ?? 10_000;
+  const finish = (candidate: ToolResult) => limitReturnedToolResult(candidate, maxReturnedChars);
   if (loaded.warnings.length > 0) {
     console.warn(`[pi-distill] ${loaded.warnings.join(" | ")}`);
   }

--- a/packages/pi-distill/src/output-limit.ts
+++ b/packages/pi-distill/src/output-limit.ts
@@ -1,3 +1,10 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+
+const i18n = createTranslator(loadCatalog(new URL("../locales/index.json", import.meta.url)));
+
 export type OutputLimitToolResult = {
   content: Array<{ type?: string; text?: string }>;
   details?: {
@@ -14,4 +21,54 @@ export function getTextContent(result: OutputLimitToolResult): string {
 
 export function hasNonTextContent(result: OutputLimitToolResult): boolean {
   return result.content.some((content) => content.type !== "text" || typeof content.text !== "string");
+}
+
+async function writeOutputFile(text: string): Promise<string> {
+  const directory = join(tmpdir(), "pi-distill");
+  await mkdir(directory, { recursive: true });
+  const filePath = join(
+    directory,
+    `output-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
+  );
+  await writeFile(filePath, text, "utf8");
+  return filePath;
+}
+
+/** Limit text entering the next Agent context; preserve non-text content. */
+export async function limitReturnedToolResult(
+  result: OutputLimitToolResult,
+  maxChars: number,
+): Promise<OutputLimitToolResult> {
+  if (hasNonTextContent(result)) return result;
+
+  const text = getTextContent(result);
+  if (text.length <= maxChars) return result;
+
+  try {
+    const filePath = await writeOutputFile(text);
+    const pointer = i18n.t("outputLimitExceeded", { maxChars, path: filePath });
+    return {
+      ...result,
+      content: [{ type: "text", text: pointer.slice(0, maxChars) }],
+      details: {
+        ...(result.details ?? {}),
+        fullOutputPath: filePath,
+        outputTruncated: true,
+        outputLimitChars: maxChars,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(i18n.t("outputLimitWriteFailed", { error: message }));
+    return {
+      ...result,
+      content: [{ type: "text", text: text.slice(0, maxChars) }],
+      details: {
+        ...(result.details ?? {}),
+        outputTruncated: true,
+        outputLimitChars: maxChars,
+        outputFileError: message,
+      },
+    };
+  }
 }

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hasNonTextContent } from "../src/output-limit.ts";
+import { hasNonTextContent, limitReturnedToolResult } from "../src/output-limit.ts";
 import {
   appendDistillFallbackAudit,
   buildDistillAuditLines,
@@ -65,12 +65,13 @@ function fakeToolResult(output: string, isError = false): TestResult {
 }
 
 /** 为摘要处理链创建隔离配置，避免测试读取用户配置。 */
-async function withFakeSummaryConfig<T>(action: () => Promise<T>): Promise<T> {
+async function withFakeSummaryConfig<T>(action: () => Promise<T>, maxOutputChars = 10000): Promise<T> {
   const keys = [
     "PI_CODING_AGENT_DIR",
     "PI_DISTILL_MODEL",
     "PI_DISTILL_MIN_CHARS",
     "PI_DISTILL_MAX_CHARS",
+    "PI_DISTILL_MAX_OUTPUT_CHARS",
     "PI_DISTILL_TIMEOUT_SECONDS",
   ];
   const previous = new Map(keys.map((key) => [key, process.env[key]] as const));
@@ -82,12 +83,14 @@ async function withFakeSummaryConfig<T>(action: () => Promise<T>): Promise<T> {
     model: "fake/model",
     minChars: 1,
     maxChars: 10000,
+    maxOutputChars,
     timeoutSeconds: 1,
   }));
   process.env.PI_CODING_AGENT_DIR = agentDir;
   process.env.PI_DISTILL_MODEL = "fake/model";
   process.env.PI_DISTILL_MIN_CHARS = "1";
   process.env.PI_DISTILL_MAX_CHARS = "10000";
+  process.env.PI_DISTILL_MAX_OUTPUT_CHARS = String(maxOutputChars);
   process.env.PI_DISTILL_TIMEOUT_SECONDS = "1";
   try {
     return await action();
@@ -670,6 +673,41 @@ test("包含图片等非文本内容时识别为非纯文本输出", () => {
     hasNonTextContent({ content: [{ type: "text", text: "纯文本" }] }),
     false,
   );
+});
+
+test("最终文本超过上限时写入临时文件并返回文件指针", async () => {
+  const finalContent = "x".repeat(10_001);
+  const result = await limitReturnedToolResult(
+    { content: [{ type: "text", text: finalContent }] },
+    10_000,
+  );
+
+  assert.equal(result.details?.outputTruncated, true);
+  assert.equal(result.details?.outputLimitChars, 10_000);
+  assert.match(result.content[0]?.text ?? "", /Output exceeded 10000 chars/);
+  assert.equal(
+    await readFile(result.details?.fullOutputPath as string, "utf8"),
+    finalContent,
+  );
+});
+
+test("最终输出限制覆盖摘要结果", async () => {
+  await withFakeSummaryConfig(async () => {
+    const result = await processToolResult(
+      fakeSummaryContext(),
+      fakeToolResult("a".repeat(500)),
+      0,
+      fakeCompletion("x".repeat(200)),
+    );
+
+    assert.equal(result.details?.outputTruncated, true);
+    assert.equal(result.details?.outputLimitChars, 100);
+    assert.equal((result.content[0]?.text ?? "").length, 100);
+    assert.match(
+      await readFile(result.details?.fullOutputPath as string, "utf8"),
+      /^x{200}/,
+    );
+  }, 100);
 });
 
 test("按工具开关动态注入和移除 outputRequest", () => {


### PR DESCRIPTION
## 问题
`maxOutputChars` 在此前的清理中只保留了配置兼容读取，但没有限制 pi-distill 处理后的最终文本。Pi 原生限制发生在工具执行前，摘要失败或原文回退时仍可能把完整文本重新送入 Agent 上下文。

## 变更
- 恢复最终文本上限：超限结果写入 pi-distill 临时文件，只返回文件指针。
- 覆盖摘要、RAW 和回退路径；非文本结果保持不变。
- 增加中英文提示词、本地化配置说明和测试。
- 默认 `maxOutputChars` 为 10000 字符。

## 验证
- `packages/pi-distill`: `npm run check`
- 31 个测试全部通过。