### PR TITLE
feat: 支持按失败类型配置提炼重试

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -110,7 +110,7 @@ Agent consumes a result suited to the current decision, with auditable diagnosti
 2. The `tool_call` handler captures the parameter and removes it before forwarding the call, so the underlying tool never receives the extension-only field.
 3. The `tool_result` handler sees the actual output and decides what to do; it does not rely on the agent predicting the output size.
 4. Every tool call must include a non-empty `outputRequest`. A prompt containing only `RAW` explicitly requests the original. Any other non-empty prompt permits distillation once the configured threshold is reached.
-5. If distillation fails, no model is available, or compression is ineffective, the original facts are retained and the status is exposed through details and the audit card. JSON responses wrapped in Markdown fences such as `````json … ````` are also accepted.
+5. A timed-out attempt is retried according to `timeoutRetryCount`, while other failures use `errorRetryCount` (both default to one retry). If all attempts fail, no model is available, or compression is ineffective, the original facts are retained and the status is exposed through details and the audit card. JSON responses wrapped in Markdown fences such as `````json … ````` are also accepted.
 
 ## Output contract
 
@@ -118,7 +118,7 @@ Agent consumes a result suited to the current decision, with auditable diagnosti
 | --- | --- | --- |
 | Omitted | Invalid tool call; Pi rejects the call before the underlying tool runs | Never omit it; use `RAW` when no compression is explicitly requested |
 | Exactly `RAW` (case-insensitive) | Skip the distillation model and keep the complete original text; oversized text is handled by Pi's own output-limiting mechanism | You need to inspect, copy, or verify exact output |
-| Any non-empty value other than `RAW` | Call the model once the output reaches the threshold; the prompt defines what to retain | “Keep errors, warnings, and final status” workflows |
+| Any non-empty value other than `RAW` | Call the model when the output reaches the threshold; timed-out and other failed attempts use separate retry budgets, and the prompt defines what to retain | “Keep errors, warnings, and final status” workflows |
 | Any non-text content such as images or audio | Preserve the result as-is; do not send it to the distillation model or apply text truncation | Image reads, binary results, and mixed text/media results |
 
 `RAW` is the deterministic completeness signal. The distillation prompt tells the summarizer to return exactly `RAW` when the request clearly asks for complete extraction without omissions, especially for syntax, parameters, SQL, API calls, or other text that must be copied. Passing `RAW` directly remains the preferred option when the tool caller can control the parameter.
@@ -159,6 +159,8 @@ Start from [`config.example.json`](./config.example.json):
   "maxChars": 100000,
   "maxOutputChars": 10000,
   "timeoutSeconds": 10,
+  "timeoutRetryCount": 1,
+  "errorRetryCount": 1,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
   "render": {
@@ -177,7 +179,9 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 | `minChars` | Minimum output size before a summary is requested. |
 | `maxChars` | Distilled text is written to a temporary file when it exceeds this length. |
 | `maxOutputChars` | Maximum text returned to the Agent. Oversized text is written to a temporary file and replaced with a file pointer. |
-| `timeoutSeconds` | Maximum time allowed for the distillation model call. |
+| `timeoutSeconds` | Maximum time allowed for each distillation model attempt. |
+| `timeoutRetryCount` | Number of additional attempts after a timeout. Defaults to `1`; set to `0` to disable timeout retries. |
+| `errorRetryCount` | Number of additional attempts after any non-timeout error. Defaults to `1`; set to `0` to disable other error retries. |
 | `missedCompressionRatio` | Long-output threshold for a diagnostic when no summary prompt was supplied. |
 | `summarizeErrors` | Whether error results that meet `minChars` should still be sent to the distillation model. |
 | `tools.<name>.enabled` | Enables or disables `outputRequest` injection and result distillation for one tool. `edit` and `write` default to disabled; other unconfigured tools default to enabled. It can also be changed from `/config:distill`. |
@@ -185,7 +189,7 @@ Configuration-file fields take precedence over environment variables. Unspecifie
 `/pi-distill` remains available as a compatibility alias.
 | `render.*` | Controls the audit card, prompt preview, and result preview. |
 
-The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_MAX_OUTPUT_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`.
+The main environment variables are `PI_DISTILL_MODEL`, `PI_DISTILL_MIN_CHARS`, `PI_DISTILL_MAX_CHARS`, `PI_DISTILL_MAX_OUTPUT_CHARS`, `PI_DISTILL_TIMEOUT_SECONDS`, `PI_DISTILL_TIMEOUT_RETRY_COUNT`, `PI_DISTILL_ERROR_RETRY_COUNT`, `PI_DISTILL_MISSED_COMPRESSION_RATIO`, and `PI_DISTILL_SUMMARIZE_ERRORS`.
 
 ## Requirements
 

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -112,7 +112,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 2. `tool_call` 事件捕获这个参数，并在交给底层工具前移除它，因此原工具不会收到扩展专用字段。
 3. `tool_result` 事件拿到真实输出后再做判断，不依赖 Agent 对输出长度的预测。
 4. 每次工具调用都必须包含非空的 `outputRequest`；严格的 `RAW` 表示明确要求原文；其他非空 prompt 才允许进入提炼流程。
-5. 提炼失败、没有可用模型或结果收益过低时，扩展保留原始事实，并通过 details 和审计卡片暴露状态；模型用 Markdown 的 JSON 代码围栏（如 `````json … `````）包裹响应时也会兼容解析。
+5. 单次提炼超时后按照 `timeoutRetryCount` 重试，其他异常按照 `errorRetryCount` 重试（两者默认都重试 1 次）；全部尝试失败、没有可用模型或结果收益过低时，扩展保留原始事实，并通过 details 和审计卡片暴露状态；模型用 Markdown 的 JSON 代码围栏（如 `````json … `````）包裹响应时也会兼容解析。
 
 ## 输出处理契约
 
@@ -120,7 +120,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | --- | --- | --- |
 | 未提供 | 工具调用无效；Pi 会在底层工具执行前拒绝该调用 | 不要省略；未明确要求压缩时使用 `RAW` |
 | 严格为 `RAW`（大小写不敏感） | 不调用提炼模型，保留完整原始文本；超长时由 Pi 自身的输出限制机制处理 | 逐字核对、复制内容、需要完整日志时 |
-| 任意非空且非 `RAW` | 输出达到阈值后调用模型，具体保留内容由 prompt 决定 | “只保留错误、警告和最终状态”等场景 |
+| 任意非空且非 `RAW` | 输出达到阈值后调用模型，超时与其他异常分别使用独立重试次数，具体保留内容由 prompt 决定 | “只保留错误、警告和最终状态”等场景 |
 | 包含图片、音频或其他非文本内容 | 原样保留，不发送给提炼模型，不做文本长度截断 | 图片读取、二进制结果、混合文本与图片结果 |
 
 `RAW` 是确定性的完整输出信号。提炼 prompt 会要求总结模型在用户明确要求“不遗漏地完整提取”时直接返回 `RAW`，尤其适用于语法、参数、SQL、API 调用或其他需要复制的精确文本。工具调用方可以控制参数时，直接传 `RAW` 仍然是首选方式。
@@ -161,6 +161,8 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
   "maxChars": 100000,
   "maxOutputChars": 10000,
   "timeoutSeconds": 10,
+  "timeoutRetryCount": 1,
+  "errorRetryCount": 1,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
   "tools": {},
@@ -180,7 +182,9 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 | `minChars` | 达到此输出长度后才请求提炼。 |
 | `maxChars` | 提炼结果超过此字符数时写入临时文件。 |
 | `maxOutputChars` | 最终返回给 Agent 的文本上限。超出后写入临时文件，只返回文件指针。 |
-| `timeoutSeconds` | 提炼模型调用的最长等待时间。 |
+| `timeoutSeconds` | 每次提炼模型尝试的最长等待时间。 |
+| `timeoutRetryCount` | 超时后的额外重试次数。默认 `1`；设为 `0` 时不重试超时。 |
+| `errorRetryCount` | 非超时异常后的额外重试次数。默认 `1`；设为 `0` 时不重试其他异常。 |
 | `missedCompressionRatio` | 没有提供摘要 prompt 时，用于长输出诊断的倍数阈值。 |
 | `summarizeErrors` | 工具返回错误且达到 `minChars` 时，是否仍发送给提炼模型。 |
 | `tools.<name>.enabled` | 按工具开启或关闭 `outputRequest` 注入和结果提炼。`edit` 和 `write` 默认关闭，其他未配置工具默认开启，也可以通过 `/config:distill` 修改。 |
@@ -188,7 +192,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 `/pi-distill` 仍作为兼容别名保留。
 | `render.*` | 控制审计卡片、prompt 预览和结果预览。 |
 
-主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_MAX_OUTPUT_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。
+主要环境变量包括 `PI_DISTILL_MODEL`、`PI_DISTILL_MIN_CHARS`、`PI_DISTILL_MAX_CHARS`、`PI_DISTILL_MAX_OUTPUT_CHARS`、`PI_DISTILL_TIMEOUT_SECONDS`、`PI_DISTILL_TIMEOUT_RETRY_COUNT`、`PI_DISTILL_ERROR_RETRY_COUNT`、`PI_DISTILL_MISSED_COMPRESSION_RATIO` 和 `PI_DISTILL_SUMMARIZE_ERRORS`。
 
 ## 要求
 

--- a/packages/pi-distill/config.example.json
+++ b/packages/pi-distill/config.example.json
@@ -5,6 +5,8 @@
   "maxChars": 100000,
   "maxOutputChars": 10000,
   "timeoutSeconds": 10,
+  "timeoutRetryCount": 1,
+  "errorRetryCount": 1,
   "missedCompressionRatio": 10,
   "summarizeErrors": true,
   "tools": {},

--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -11,6 +11,10 @@
     "zh-CN": "请输入大于 0 的整数。",
     "en-US": "Enter a positive integer."
   },
+  "nonNegativeInteger": {
+    "zh-CN": "请输入大于或等于 0 的整数。",
+    "en-US": "Enter a non-negative integer."
+  },
   "modelInput": {
     "zh-CN": "模型（provider/model；留空使用当前会话模型）",
     "en-US": "Model (provider/model; leave empty to use the current session model)"
@@ -71,6 +75,14 @@
     "zh-CN": "超时：{value}s",
     "en-US": "Timeout: {value}s"
   },
+  "timeoutRetryCount": {
+    "zh-CN": "超时重试：{value} 次",
+    "en-US": "Timeout retries: {value}"
+  },
+  "errorRetryCount": {
+    "zh-CN": "异常重试：{value} 次",
+    "en-US": "Error retries: {value}"
+  },
   "threshold": {
     "zh-CN": "长输出阈值：{value}x",
     "en-US": "Long-output threshold: {value}x"
@@ -130,6 +142,26 @@
   "timeoutTitle": {
     "zh-CN": "提炼模型超时（秒）",
     "en-US": "Summarizer timeout (seconds)"
+  },
+  "timeoutRetryCountTitle": {
+    "zh-CN": "提炼超时重试次数",
+    "en-US": "Distillation timeout retry count"
+  },
+  "errorRetryCountTitle": {
+    "zh-CN": "提炼非超时异常重试次数",
+    "en-US": "Distillation non-timeout error retry count"
+  },
+  "retryingSummary": {
+    "zh-CN": "提炼发生{kind}，正在进行第 {retry}/{limit} 次重试：{error}",
+    "en-US": "Distillation hit {kind}; starting retry {retry}/{limit}: {error}"
+  },
+  "retryKindTimeout": {
+    "zh-CN": "超时",
+    "en-US": "a timeout"
+  },
+  "retryKindError": {
+    "zh-CN": "非超时异常",
+    "en-US": "a non-timeout error"
   },
   "thresholdTitle": {
     "zh-CN": "长输出阈值",

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -16,6 +16,8 @@
  * - PI_DISTILL_MAX_CHARS=提炼结果超过此字符数时写入文件，默认 100000
  * - PI_DISTILL_MAX_OUTPUT_CHARS=最终返回内容超过此字符数时写入文件，默认 10000
  * - PI_DISTILL_TIMEOUT_SECONDS=模型调用最长等待秒数，默认 10
+ * - PI_DISTILL_TIMEOUT_RETRY_COUNT=提炼超时后的额外重试次数，默认 1；0 表示不重试
+ * - PI_DISTILL_ERROR_RETRY_COUNT=其他异常后的额外重试次数，默认 1；0 表示不重试
  * - PI_DISTILL_MISSED_COMPRESSION_RATIO=长输出提醒倍数，默认 10
  * - 旧 PI_BASH_SUMMARY_* 变量作为兼容回退
  */
@@ -416,6 +418,63 @@ async function summarizeOutput(
   };
 }
 
+async function summarizeOutputWithRetries(
+  prompt: string,
+  output: string,
+  config: BashSummaryConfig,
+  context: DistillExecutionContext,
+  completion: SummaryCompletion,
+): Promise<SummaryResult> {
+  let timeoutRetries = 0;
+  let errorRetries = 0;
+
+  while (true) {
+    if (context.signal?.aborted) {
+      throw new Error("Summarization aborted");
+    }
+
+    const attemptController = new AbortController();
+    const abortFromParent = () => attemptController.abort();
+    context.signal?.addEventListener("abort", abortFromParent, { once: true });
+    if (context.signal?.aborted) attemptController.abort();
+    let timedOut = false;
+    const timeout = setTimeout(
+      () => {
+        timedOut = true;
+        attemptController.abort();
+      },
+      config.timeoutSeconds * 1000,
+    );
+
+    try {
+      return await summarizeOutput(
+        prompt,
+        output,
+        config,
+        context,
+        attemptController.signal,
+        completion,
+      );
+    } catch (error) {
+      if (context.signal?.aborted) throw error;
+      const retryLimit = timedOut ? config.timeoutRetryCount : config.errorRetryCount;
+      const retriesUsed = timedOut ? timeoutRetries : errorRetries;
+      if (retriesUsed >= retryLimit) throw error;
+      if (timedOut) timeoutRetries += 1;
+      else errorRetries += 1;
+      console.warn(i18n.t("retryingSummary", {
+        kind: i18n.t(timedOut ? "retryKindTimeout" : "retryKindError"),
+        retry: retriesUsed + 1,
+        limit: retryLimit,
+        error: error instanceof Error ? error.message : String(error),
+      }));
+    } finally {
+      clearTimeout(timeout);
+      context.signal?.removeEventListener("abort", abortFromParent);
+    }
+  }
+}
+
 function getOutputRequest(params: Record<string, unknown>): string {
   return typeof params.outputRequest === "string"
     ? params.outputRequest.trim()
@@ -515,17 +574,12 @@ export async function processToolResult(
   }
 
   const summaryStartedAt = performance.now();
-  const timeoutController = new AbortController();
-  const abortFromParent = () => timeoutController.abort();
-  context.signal?.addEventListener("abort", abortFromParent, { once: true });
-  const timeout = setTimeout(() => timeoutController.abort(), config.timeoutSeconds * 1000);
   try {
-    const summarized = await summarizeOutput(
+    const summarized = await summarizeOutputWithRetries(
       prompt,
       output,
       config,
       context,
-      timeoutController.signal,
       completion,
     );
     const summaryDurationMs = Math.round(performance.now() - summaryStartedAt);
@@ -660,9 +714,6 @@ export async function processToolResult(
         : result.content,
     };
     return finish(candidate);
-  } finally {
-    clearTimeout(timeout);
-    context.signal?.removeEventListener("abort", abortFromParent);
   }
 }
 
@@ -756,7 +807,7 @@ function toToolResultEventResult(result: ToolResult): ToolResultEventPatch {
   };
 }
 
-type DistillUiConfig = Required<Pick<DistillConfigFile, "enabled" | "model" | "minChars" | "maxChars" | "maxOutputChars" | "timeoutSeconds" | "missedCompressionRatio" | "summarizeErrors">> & {
+type DistillUiConfig = Required<Pick<DistillConfigFile, "enabled" | "model" | "minChars" | "maxChars" | "maxOutputChars" | "timeoutSeconds" | "timeoutRetryCount" | "errorRetryCount" | "missedCompressionRatio" | "summarizeErrors">> & {
   tools: DistillToolConfig;
   render: DistillRenderConfig;
 };
@@ -773,6 +824,8 @@ function getDistillUiConfig(): DistillUiConfig {
     maxChars: config?.maxChars ?? 100_000,
     maxOutputChars: config?.maxOutputChars ?? 10_000,
     timeoutSeconds: config?.timeoutSeconds ?? 10,
+    timeoutRetryCount: config?.timeoutRetryCount ?? 1,
+    errorRetryCount: config?.errorRetryCount ?? 1,
     missedCompressionRatio: config?.missedCompressionRatio ?? 10,
     summarizeErrors: config?.summarizeErrors ?? true,
     tools: Object.fromEntries(
@@ -794,6 +847,22 @@ async function editDistillNumber(
     return undefined;
   }
   return Number(value);
+}
+
+async function editDistillNonNegativeInteger(
+  ctx: ExtensionCommandContext,
+  title: string,
+  current: number,
+): Promise<number | undefined> {
+  const value = await ctx.ui.input(title, String(current));
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  const parsed = Number(normalized);
+  if (!/^\d+$/.test(normalized) || !Number.isSafeInteger(parsed)) {
+    ctx.ui.notify(i18n.t("nonNegativeInteger"), "error");
+    return undefined;
+  }
+  return parsed;
 }
 
 async function editDistillModel(
@@ -884,6 +953,8 @@ async function runDistillConfigUi(
       i18n.t("summaryLimit", { value: config.maxChars }),
       i18n.t("finalLimit", { value: config.maxOutputChars }),
       i18n.t("timeout", { value: config.timeoutSeconds }),
+      i18n.t("timeoutRetryCount", { value: config.timeoutRetryCount }),
+      i18n.t("errorRetryCount", { value: config.errorRetryCount }),
       i18n.t("threshold", { value: config.missedCompressionRatio }),
       i18n.t("summarizeErrors", { value: config.summarizeErrors ? i18n.t("on") : i18n.t("off") }),
       i18n.t("auditRenderer", { value: config.render.enabled ? i18n.t("on") : i18n.t("off") }),
@@ -928,24 +999,44 @@ async function runDistillConfigUi(
         await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
     } else if (choice === choices[6]) {
+      const value = await editDistillNonNegativeInteger(
+        ctx,
+        i18n.t("timeoutRetryCountTitle"),
+        config.timeoutRetryCount,
+      );
+      if (value !== undefined) {
+        config.timeoutRetryCount = value;
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
+      }
+    } else if (choice === choices[7]) {
+      const value = await editDistillNonNegativeInteger(
+        ctx,
+        i18n.t("errorRetryCountTitle"),
+        config.errorRetryCount,
+      );
+      if (value !== undefined) {
+        config.errorRetryCount = value;
+        await saveDistillConfigFile(ctx, config, configPath, onSaved);
+      }
+    } else if (choice === choices[8]) {
       const value = await editDistillNumber(ctx, i18n.t("thresholdTitle"), config.missedCompressionRatio);
       if (value !== undefined) {
         config.missedCompressionRatio = value;
         await saveDistillConfigFile(ctx, config, configPath, onSaved);
       }
-    } else if (choice === choices[7]) {
+    } else if (choice === choices[9]) {
       config.summarizeErrors = !config.summarizeErrors;
       await saveDistillConfigFile(ctx, config, configPath, onSaved);
-    } else if (choice === choices[8]) {
+    } else if (choice === choices[10]) {
       config.render.enabled = !config.render.enabled;
       await saveDistillConfigFile(ctx, config, configPath, onSaved);
-    } else if (choice === choices[9]) {
+    } else if (choice === choices[11]) {
       config.render.showPrompt = !config.render.showPrompt;
       await saveDistillConfigFile(ctx, config, configPath, onSaved);
-    } else if (choice === choices[10]) {
+    } else if (choice === choices[12]) {
       config.render.showResult = !config.render.showResult;
       await saveDistillConfigFile(ctx, config, configPath, onSaved);
-    } else if (choice === choices[11]) {
+    } else if (choice === choices[13]) {
       await runDistillToolConfigUi(ctx, pi, config, configPath, onSaved);
     }
   }

--- a/packages/pi-distill/src/summary-utils.ts
+++ b/packages/pi-distill/src/summary-utils.ts
@@ -9,6 +9,8 @@ const DEFAULT_MIN_CHARS = 200;
 const DEFAULT_MAX_CHARS = 100_000;
 const DEFAULT_MAX_OUTPUT_CHARS = 10_000;
 const DEFAULT_TIMEOUT_SECONDS = 10;
+const DEFAULT_TIMEOUT_RETRY_COUNT = 1;
+const DEFAULT_ERROR_RETRY_COUNT = 1;
 const DEFAULT_MISSED_COMPRESSION_RATIO = 10;
 const DEFAULT_SUMMARIZE_ERRORS = true;
 const DEFAULT_RENDER_ENABLED = true;
@@ -30,6 +32,10 @@ export interface BashSummaryConfig {
   maxOutputChars: number;
   /** 模型调用最长等待时间。 */
   timeoutSeconds: number;
+  /** 单次提炼因超时失败后的额外重试次数。 */
+  timeoutRetryCount: number;
+  /** 单次提炼因非超时异常失败后的额外重试次数。 */
+  errorRetryCount: number;
   /** 无 prompt 的长输出触发 missed-compression 提醒所需的倍数。 */
   missedCompressionRatio: number;
   /** 工具返回错误且达到最小长度时是否仍调用提炼模型。 */
@@ -60,6 +66,8 @@ export interface DistillConfigFile {
   maxChars?: number;
   maxOutputChars?: number;
   timeoutSeconds?: number;
+  timeoutRetryCount?: number;
+  errorRetryCount?: number;
   missedCompressionRatio?: number;
   summarizeErrors?: boolean;
   tools?: DistillToolConfig;
@@ -109,6 +117,8 @@ export function parseBashSummaryConfig(
   const timeoutSecondsValue = (
     env.PI_DISTILL_TIMEOUT_SECONDS ?? env.PI_BASH_SUMMARY_TIMEOUT_SECONDS
   )?.trim();
+  const timeoutRetryCountValue = env.PI_DISTILL_TIMEOUT_RETRY_COUNT?.trim();
+  const errorRetryCountValue = env.PI_DISTILL_ERROR_RETRY_COUNT?.trim();
   const missedCompressionRatioValue = (
     env.PI_DISTILL_MISSED_COMPRESSION_RATIO ?? env.PI_BASH_SUMMARY_MISSED_COMPRESSION_RATIO
   )?.trim();
@@ -127,6 +137,12 @@ export function parseBashSummaryConfig(
   const timeoutSeconds = timeoutSecondsValue
     ? parsePositiveInteger(timeoutSecondsValue)
     : DEFAULT_TIMEOUT_SECONDS;
+  const timeoutRetryCount = timeoutRetryCountValue
+    ? parseNonNegativeInteger(timeoutRetryCountValue)
+    : DEFAULT_TIMEOUT_RETRY_COUNT;
+  const errorRetryCount = errorRetryCountValue
+    ? parseNonNegativeInteger(errorRetryCountValue)
+    : DEFAULT_ERROR_RETRY_COUNT;
   const missedCompressionRatio = missedCompressionRatioValue
     ? parsePositiveNumber(missedCompressionRatioValue)
     : DEFAULT_MISSED_COMPRESSION_RATIO;
@@ -138,12 +154,14 @@ export function parseBashSummaryConfig(
     minChars === undefined ||
     maxChars === undefined ||
     timeoutSeconds === undefined ||
+    timeoutRetryCount === undefined ||
+    errorRetryCount === undefined ||
     maxOutputChars === undefined ||
     missedCompressionRatio === undefined ||
     summarizeErrors === undefined
   ) {
     console.warn(
-      "[pi-distill] Invalid distillation config; distillation disabled. Check PI_DISTILL_MIN_CHARS, PI_DISTILL_MAX_CHARS, PI_DISTILL_MAX_OUTPUT_CHARS, PI_DISTILL_TIMEOUT_SECONDS, PI_DISTILL_MISSED_COMPRESSION_RATIO, and PI_DISTILL_SUMMARIZE_ERRORS (legacy PI_BASH_SUMMARY_* variables remain supported).",
+      "[pi-distill] Invalid distillation config; distillation disabled. Check PI_DISTILL_MIN_CHARS, PI_DISTILL_MAX_CHARS, PI_DISTILL_MAX_OUTPUT_CHARS, PI_DISTILL_TIMEOUT_SECONDS, PI_DISTILL_TIMEOUT_RETRY_COUNT, PI_DISTILL_ERROR_RETRY_COUNT, PI_DISTILL_MISSED_COMPRESSION_RATIO, and PI_DISTILL_SUMMARIZE_ERRORS (legacy PI_BASH_SUMMARY_* variables remain supported).",
     );
     return undefined;
   }
@@ -154,6 +172,8 @@ export function parseBashSummaryConfig(
       maxChars,
       maxOutputChars,
       timeoutSeconds,
+      timeoutRetryCount,
+      errorRetryCount,
       missedCompressionRatio,
       summarizeErrors,
     };
@@ -174,6 +194,8 @@ export function parseBashSummaryConfig(
     maxChars,
     maxOutputChars,
     timeoutSeconds,
+    timeoutRetryCount,
+    errorRetryCount,
     missedCompressionRatio,
     summarizeErrors,
   };
@@ -187,6 +209,12 @@ function parsePositiveInteger(value: string | undefined): number | undefined {
   if (!value || !/^\d+$/.test(value)) return undefined;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseNonNegativeInteger(value: string | undefined): number | undefined {
+  if (!value || !/^\d+$/.test(value)) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
 function parsePositiveNumber(value: string): number | undefined {
@@ -279,6 +307,19 @@ function appendFileValueToEnv(
     return;
   }
 
+  if (
+    key === "timeoutRetryCount" ||
+    key === "errorRetryCount"
+  ) {
+    if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+      warnings.push(`Config field ${key} must be a non-negative integer.`);
+      env[envKey] = "__invalid_file_value__";
+      return;
+    }
+    env[envKey] = String(value);
+    return;
+  }
+
   if (typeof value !== "number" || !Number.isFinite(value)) {
     warnings.push(`Config field ${key} must be a positive number.`);
     env[envKey] = "__invalid_file_value__";
@@ -326,6 +367,20 @@ export function loadDistillConfig(
     appendFileValueToEnv(
       effectiveEnv,
       file,
+      "timeoutRetryCount",
+      "PI_DISTILL_TIMEOUT_RETRY_COUNT",
+      warnings,
+    );
+    appendFileValueToEnv(
+      effectiveEnv,
+      file,
+      "errorRetryCount",
+      "PI_DISTILL_ERROR_RETRY_COUNT",
+      warnings,
+    );
+    appendFileValueToEnv(
+      effectiveEnv,
+      file,
       "missedCompressionRatio",
       "PI_DISTILL_MISSED_COMPRESSION_RATIO",
       warnings,
@@ -357,6 +412,8 @@ export function defaultDistillConfigFile(): DistillConfigFile {
     maxChars: DEFAULT_MAX_CHARS,
     maxOutputChars: DEFAULT_MAX_OUTPUT_CHARS,
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    timeoutRetryCount: DEFAULT_TIMEOUT_RETRY_COUNT,
+    errorRetryCount: DEFAULT_ERROR_RETRY_COUNT,
     missedCompressionRatio: DEFAULT_MISSED_COMPRESSION_RATIO,
     summarizeErrors: DEFAULT_SUMMARIZE_ERRORS,
     tools: {},

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -65,7 +65,17 @@ function fakeToolResult(output: string, isError = false): TestResult {
 }
 
 /** 为摘要处理链创建隔离配置，避免测试读取用户配置。 */
-async function withFakeSummaryConfig<T>(action: () => Promise<T>, maxOutputChars = 10000): Promise<T> {
+async function withFakeSummaryConfig<T>(
+  action: () => Promise<T>,
+  maxOutputChars = 10000,
+  retryConfig: {
+    timeoutRetryCount?: number;
+    errorRetryCount?: number;
+  } = {
+    timeoutRetryCount: 1,
+    errorRetryCount: 1,
+  },
+): Promise<T> {
   const keys = [
     "PI_CODING_AGENT_DIR",
     "PI_DISTILL_MODEL",
@@ -73,6 +83,8 @@ async function withFakeSummaryConfig<T>(action: () => Promise<T>, maxOutputChars
     "PI_DISTILL_MAX_CHARS",
     "PI_DISTILL_MAX_OUTPUT_CHARS",
     "PI_DISTILL_TIMEOUT_SECONDS",
+    "PI_DISTILL_TIMEOUT_RETRY_COUNT",
+    "PI_DISTILL_ERROR_RETRY_COUNT",
   ];
   const previous = new Map(keys.map((key) => [key, process.env[key]] as const));
   const agentDir = await mkdtemp(join(tmpdir(), "pi-distill-summary-test-"));
@@ -85,6 +97,7 @@ async function withFakeSummaryConfig<T>(action: () => Promise<T>, maxOutputChars
     maxChars: 10000,
     maxOutputChars,
     timeoutSeconds: 1,
+    ...retryConfig,
   }));
   process.env.PI_CODING_AGENT_DIR = agentDir;
   process.env.PI_DISTILL_MODEL = "fake/model";
@@ -92,6 +105,13 @@ async function withFakeSummaryConfig<T>(action: () => Promise<T>, maxOutputChars
   process.env.PI_DISTILL_MAX_CHARS = "10000";
   process.env.PI_DISTILL_MAX_OUTPUT_CHARS = String(maxOutputChars);
   process.env.PI_DISTILL_TIMEOUT_SECONDS = "1";
+  for (const [key, value] of [
+    ["PI_DISTILL_TIMEOUT_RETRY_COUNT", retryConfig.timeoutRetryCount],
+    ["PI_DISTILL_ERROR_RETRY_COUNT", retryConfig.errorRetryCount],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = String(value);
+  }
   try {
     return await action();
   } finally {
@@ -132,6 +152,8 @@ test("只配置总结模型时使用默认阈值", () => {
       maxChars: 100000,
       maxOutputChars: 10000,
       timeoutSeconds: 10,
+      timeoutRetryCount: 1,
+      errorRetryCount: 1,
       missedCompressionRatio: 10,
       summarizeErrors: true,
     },
@@ -151,6 +173,8 @@ test("新 pi-distill 环境变量优先于旧 Bash 变量", () => {
     maxChars: 100000,
     maxOutputChars: 10000,
     timeoutSeconds: 10,
+    timeoutRetryCount: 1,
+    errorRetryCount: 1,
     missedCompressionRatio: 10,
     summarizeErrors: true,
   });
@@ -161,12 +185,29 @@ test("支持按秒配置提炼超时，并兼容旧变量", () => {
   assert.equal(parseBashSummaryConfig({ PI_BASH_SUMMARY_TIMEOUT_SECONDS: "8" })?.timeoutSeconds, 8);
 });
 
+test("超时和非超时异常支持独立重试次数", () => {
+  assert.equal(parseBashSummaryConfig({})?.timeoutRetryCount, 1);
+  assert.equal(parseBashSummaryConfig({})?.errorRetryCount, 1);
+  assert.equal(parseBashSummaryConfig({
+    PI_DISTILL_TIMEOUT_RETRY_COUNT: "2",
+    PI_DISTILL_ERROR_RETRY_COUNT: "0",
+  })?.timeoutRetryCount, 2);
+  assert.equal(parseBashSummaryConfig({
+    PI_DISTILL_TIMEOUT_RETRY_COUNT: "2",
+    PI_DISTILL_ERROR_RETRY_COUNT: "0",
+  })?.errorRetryCount, 0);
+  assert.equal(parseBashSummaryConfig({ PI_DISTILL_TIMEOUT_RETRY_COUNT: "1.5" }), undefined);
+  assert.equal(parseBashSummaryConfig({ PI_DISTILL_ERROR_RETRY_COUNT: "-1" }), undefined);
+});
+
 test("未配置总结模型时使用当前会话模型的默认配置", () => {
   assert.deepEqual(parseBashSummaryConfig({}), {
     minChars: 200,
     maxChars: 100000,
     maxOutputChars: 10000,
     timeoutSeconds: 10,
+    timeoutRetryCount: 1,
+    errorRetryCount: 1,
     missedCompressionRatio: 10,
     summarizeErrors: true,
   });
@@ -179,6 +220,8 @@ test("未配置总结模型时使用当前会话模型的默认配置", () => {
       maxChars: 100000,
       maxOutputChars: 10000,
       timeoutSeconds: 10,
+      timeoutRetryCount: 1,
+      errorRetryCount: 1,
       missedCompressionRatio: 10,
       summarizeErrors: true,
     },
@@ -199,6 +242,8 @@ test("解析 provider/model、最小输入阈值和最大总结阈值", () => {
       maxChars: 500,
       maxOutputChars: 10000,
       timeoutSeconds: 10,
+      timeoutRetryCount: 1,
+      errorRetryCount: 1,
       missedCompressionRatio: 10,
       summarizeErrors: true,
     },
@@ -230,6 +275,8 @@ test("配置文件优先于兼容环境变量", async () => {
     model: "file-provider/file-model",
     minChars: 321,
     maxChars: 654,
+    timeoutRetryCount: 0,
+    errorRetryCount: 2,
     missedCompressionRatio: 4.5,
     render: {
       enabled: true,
@@ -243,6 +290,8 @@ test("配置文件优先于兼容环境变量", async () => {
     PI_BASH_SUMMARY_MIN_CHARS: "100",
     PI_BASH_SUMMARY_MAX_CHARS: "200",
     PI_BASH_SUMMARY_MISSED_COMPRESSION_RATIO: "2",
+    PI_DISTILL_TIMEOUT_RETRY_COUNT: "3",
+    PI_DISTILL_ERROR_RETRY_COUNT: "4",
   }, configFile);
 
   assert.deepEqual(loaded.config, {
@@ -252,6 +301,8 @@ test("配置文件优先于兼容环境变量", async () => {
     maxChars: 654,
     maxOutputChars: 10000,
     timeoutSeconds: 10,
+    timeoutRetryCount: 0,
+    errorRetryCount: 2,
     missedCompressionRatio: 4.5,
     summarizeErrors: true,
   });
@@ -310,6 +361,8 @@ test("只有明确需要摘要且输出达到阈值时才总结", () => {
     maxChars: 100,
     maxOutputChars: 10000,
     timeoutSeconds: 10,
+    timeoutRetryCount: 1,
+    errorRetryCount: 1,
     missedCompressionRatio: 10,
     summarizeErrors: true,
   };
@@ -336,6 +389,8 @@ test("错误工具输出也遵守最小长度阈值，并支持关闭总结", ()
     maxChars: 1000,
     maxOutputChars: 1000,
     timeoutSeconds: 10,
+    timeoutRetryCount: 1,
+    errorRetryCount: 1,
     missedCompressionRatio: 10,
     summarizeErrors: true,
   };
@@ -548,6 +603,86 @@ test("fake provider 覆盖摘要链路的 RAW、有效摘要和低收益回退",
   });
 });
 
+test("提炼首次失败后默认重试一次并可成功返回", async () => {
+  await withFakeSummaryConfig(async () => {
+    const output = "FAIL checkout\nERROR at checkout.ts:8\nnext: inspect the payment provider\n".repeat(4);
+    const successfulCompletion = fakeCompletion("ERROR at checkout.ts:8; inspect the payment provider");
+    let attempts = 0;
+    const flakyCompletion: TestCompletion = async (...args) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary provider failure");
+      return successfulCompletion(...args);
+    };
+
+    const result = await processToolResult(
+      fakeSummaryContext(),
+      fakeToolResult(output),
+      0,
+      flakyCompletion,
+    );
+
+    assert.equal(attempts, 2);
+    assert.equal(result.details?.outputSummaryStatus, "summarized");
+    assert.equal(result.content[0]?.text, "ERROR at checkout.ts:8; inspect the payment provider");
+  });
+});
+
+test("errorRetryCount 为零时非超时异常不重试", async () => {
+  await withFakeSummaryConfig(async () => {
+    let attempts = 0;
+    const failingCompletion: TestCompletion = async () => {
+      attempts += 1;
+      throw new Error("provider unavailable");
+    };
+
+    const result = await processToolResult(
+      fakeSummaryContext(),
+      fakeToolResult("FAIL checkout\nERROR at checkout.ts:8\nnext: retry"),
+      0,
+      failingCompletion,
+    );
+
+    assert.equal(attempts, 1);
+    assert.equal(result.details?.outputSummaryStatus, "summary-failed");
+    assert.match(String(result.details?.outputSummaryError), /provider unavailable/);
+  }, 10000, { timeoutRetryCount: 1, errorRetryCount: 0 });
+});
+
+test("超时使用独立重试次数并可在下一次尝试成功", async () => {
+  await withFakeSummaryConfig(async () => {
+    const output = "ERROR deployment timeout at api\n".repeat(10);
+    const successfulCompletion = fakeCompletion("ERROR deployment timeout at api");
+    let attempts = 0;
+    const timeoutThenSuccess: TestCompletion = async (...args) => {
+      attempts += 1;
+      if (attempts > 1) return successfulCompletion(...args);
+      const signal = args[2]?.signal;
+      return new Promise((_, reject) => {
+        if (!signal) {
+          reject(new Error("test completion did not receive an abort signal"));
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => reject(new Error("fake provider timed out")),
+          { once: true },
+        );
+      });
+    };
+
+    const result = await processToolResult(
+      fakeSummaryContext(),
+      fakeToolResult(output),
+      0,
+      timeoutThenSuccess,
+    );
+
+    assert.equal(attempts, 2);
+    assert.equal(result.details?.outputSummaryStatus, "summarized");
+    assert.equal(result.content[0]?.text, "ERROR deployment timeout at api");
+  }, 10000, { timeoutRetryCount: 1, errorRetryCount: 0 });
+});
+
 test("fake provider 的空响应、非法响应和异常都保留原文", async () => {
   await withFakeSummaryConfig(async () => {
     const context = fakeSummaryContext();
@@ -610,8 +745,10 @@ test("fake provider 超时后保留原文并记录失败", async () => {
   await withFakeSummaryConfig(async () => {
     const context = fakeSummaryContext();
     const output = "ERROR deployment timeout at api";
+    let attempts = 0;
     const timeoutCompletion: TestCompletion = async (_model, _request, options) => (
       new Promise((_, reject) => {
+        attempts += 1;
         const signal = options?.signal;
         if (!signal) {
           reject(new Error("test completion did not receive an abort signal"));
@@ -622,10 +759,11 @@ test("fake provider 超时后保留原文并记录失败", async () => {
     );
 
     const result = await processToolResult(context, fakeToolResult(output), 0, timeoutCompletion);
+    assert.equal(attempts, 1);
     assert.equal(result.content[0]?.text, output);
     assert.equal(result.details?.outputSummaryStatus, "summary-failed");
     assert.match(String(result.details?.outputSummaryError), /fake provider aborted/);
-  });
+  }, 10000, { timeoutRetryCount: 0, errorRetryCount: 1 });
 });
 
 test("fallback 审计显示为原文回退而非已提炼", async () => {
@@ -726,6 +864,8 @@ test("按工具开关动态注入和移除 outputRequest", () => {
       maxChars: 100000,
       maxOutputChars: 10000,
       timeoutSeconds: 10,
+      timeoutRetryCount: 1,
+      errorRetryCount: 1,
       missedCompressionRatio: 10,
       summarizeErrors: true,
       tools: { bash: { enabled: false }, edit: { enabled: true } },


### PR DESCRIPTION
## 问题

pi-distill 的提炼模型调用失败后会直接回退原始输出，无法分别控制超时和其他异常的重试策略。

## 行为变化

- 新增 `timeoutRetryCount`，控制单次提炼超时后的额外重试次数，默认 `1`，设为 `0` 时不重试。
- 新增 `errorRetryCount`，控制非超时异常后的额外重试次数，默认 `1`，设为 `0` 时不重试。
- 两类失败分别消耗独立重试额度，每次尝试独立遵守 `timeoutSeconds`。
- 上级请求取消时不会继续重试；全部尝试失败后仍保留原始工具结果。
- `/config:distill` 增加两个独立设置项，并补充对应环境变量和中英文提示。

## 包与文档影响

仅修改 `pi-distill`。已同步 `config.example.json`、英文 README、中文 README 和本地化目录。

## 验证

- `npm run check --workspace=pi-distill`
- `npm run check`
- pi-distill 35 项测试全部通过，包括超时重试、超时禁用重试、非超时异常重试和非超时异常禁用重试。

## 限制

无已知限制。