### PR TITLE
fix(pi-distill): stabilize output limit test

### DIFF
--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -840,7 +840,9 @@ test("最终输出限制覆盖摘要结果", async () => {
 
     assert.equal(result.details?.outputTruncated, true);
     assert.equal(result.details?.outputLimitChars, 100);
-    assert.equal((result.content[0]?.text ?? "").length, 100);
+    const returnedText = result.content[0]?.text ?? "";
+    assert.ok(returnedText.length <= 100);
+    assert.match(returnedText, /Output exceeded 100 chars/);
     assert.match(
       await readFile(result.details?.fullOutputPath as string, "utf8"),
       /^x{200}/,


### PR DESCRIPTION
## What changed

- Treat `maxOutputChars` as an upper bound in the final-output limiter regression test.
- Continue asserting that the returned pointer reports the limit and that the complete summarized output is preserved on disk.

## Root cause

The test required the localized file pointer to be exactly 100 characters. Its length depends on the generated temporary path, so the CI runner produced a valid 99-character pointer and failed with `99 !== 100`.

## Impact

This removes a platform- and path-length-dependent CI failure without changing production behavior.

## Validation

- `npm test --workspace pi-distill` (35/35 passed)
- `npm run typecheck --workspace pi-distill`
- `npm run check`
- `git diff --check`
