### PR TITLE
fix(pi-dynamic-workflows): prevent abort crash

### DIFF
--- a/packages/pi-dynamic-workflows/src/workflow.ts
+++ b/packages/pi-dynamic-workflows/src/workflow.ts
@@ -203,7 +203,7 @@ export async function runWorkflow<T = unknown>(
   };
 
   const context = vm.createContext({
-    agent,
+    __agent: agent,
     parallel,
     pipeline,
     log,
@@ -230,7 +230,21 @@ export async function runWorkflow<T = unknown>(
     Promise,
   });
 
-  const wrapped = `(async () => {\n${body}\n})()`;
+  // A host Promise receives a context-local wrapper when it crosses into vm.
+  // Track that wrapper in the vm realm itself so a fire-and-forget agent() that
+  // later rejects (notably during cancellation) cannot become an unhandled
+  // rejection and terminate Pi. Returning the original promise preserves normal
+  // await/rejection semantics for workflow scripts.
+  const wrapped = `(async (__workflowAgent) => {
+const trackedAgent = (...args) => {
+  const promise = __workflowAgent(...args)
+  void promise.catch(() => {})
+  return promise
+}
+return await (async (agent) => {
+${body}
+})(trackedAgent)
+})(__agent)`;
   const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
   await Promise.allSettled([...pendingAgentRuns]);
   assertStructuredCloneable(result, "workflow result");

--- a/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
@@ -133,8 +133,15 @@ test("runWorkflow aborts once without unhandled rejections from unawaited agent 
   const onUnhandled = (reason: unknown) => unhandled.push(reason);
   process.on("unhandledRejection", onUnhandled);
 
+  let startedCount = 0;
+  let resolveAllStarted = () => {};
+  const allStarted = new Promise<void>((resolve) => {
+    resolveAllStarted = resolve;
+  });
   const abortingAgent = {
     run(_prompt: string, options: { signal?: AbortSignal }): Promise<never> {
+      startedCount++;
+      if (startedCount === 3) resolveAllStarted();
       return new Promise((_resolve, reject) => {
         const onAbort = () => reject(new Error("Subagent was aborted"));
         options.signal?.addEventListener("abort", onAbort, { once: true });
@@ -155,10 +162,10 @@ const second = agent('second', { label: 'second', schema: {} })
 const final = agent(JSON.stringify({ first, second }), { label: 'final', schema: {} })
 return final
 `,
-      { agent: abortingAgent, signal: abortController.signal },
+      { agent: abortingAgent, signal: abortController.signal, concurrency: 3 },
     );
 
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await allStarted;
     abortController.abort();
 
     await assert.rejects(workflow, /Subagent was aborted/);

--- a/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
+++ b/packages/pi-dynamic-workflows/tests/workflow-runtime.test.ts
@@ -126,3 +126,45 @@ return { scan }
     "result:Catalog Date.now(), Math.random(), and new Date() usage",
   );
 });
+
+test("runWorkflow aborts once without unhandled rejections from unawaited agent promises", async () => {
+  const abortController = new AbortController();
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+
+  const abortingAgent = {
+    run(_prompt: string, options: { signal?: AbortSignal }): Promise<never> {
+      return new Promise((_resolve, reject) => {
+        const onAbort = () => reject(new Error("Subagent was aborted"));
+        options.signal?.addEventListener("abort", onAbort, { once: true });
+      });
+    },
+  };
+
+  try {
+    const workflow = runWorkflow(
+      `export const meta = {
+  name: 'abort_fanout',
+  description: 'Abort unawaited fan-out safely',
+  phases: [{ title: 'Fan out' }]
+}
+
+const first = agent('first', { label: 'first', schema: {} })
+const second = agent('second', { label: 'second', schema: {} })
+const final = agent(JSON.stringify({ first, second }), { label: 'final', schema: {} })
+return final
+`,
+      { agent: abortingAgent, signal: abortController.signal },
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    abortController.abort();
+
+    await assert.rejects(workflow, /Subagent was aborted/);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandled);
+  }
+});


### PR DESCRIPTION
## 问题

取消包含未等待 agent Promise 的 workflow 时，VM realm 包装 Promise 会产生未处理拒绝，Node 最终触发 uncaughtException 并退出 Pi。

## 行为变更

- 在 VM realm 内为每个 agent Promise 注册拒绝观察器，避免 fire-and-forget Promise 触发未处理拒绝
- 返回原 Promise，保持正常 await 和错误传播语义
- 增加多 agent fan-out 取消场景回归测试

## 包与文档影响

- 影响包：@maplezzk/pi-dynamic-workflows
- 无配置或文档兼容性变更

## 验证

- npm run check
- @maplezzk/pi-dynamic-workflows package check
- 回归测试确认取消只报告一次错误且无 unhandledRejection