### PR TITLE
fix(pi-distill): route runtime warnings through Pi UI

### DIFF
--- a/packages/pi-distill/locales/index.json
+++ b/packages/pi-distill/locales/index.json
@@ -163,6 +163,14 @@
     "zh-CN": "非超时异常",
     "en-US": "a non-timeout error"
   },
+  "outputRequestUnavailable": {
+    "zh-CN": "无法扩展工具 {tool} 的参数结构；outputRequest 不可用。",
+    "en-US": "Could not extend the {tool} parameter schema; outputRequest is unavailable."
+  },
+  "extendOutputRequestFailed": {
+    "zh-CN": "扩展 outputRequest 参数失败：{error}",
+    "en-US": "Failed to extend the outputRequest parameter: {error}"
+  },
   "thresholdTitle": {
     "zh-CN": "长输出阈值",
     "en-US": "Long-output threshold"

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -132,6 +132,7 @@ type SummaryResult = {
 };
 
 type SummaryCompletion = (...args: Parameters<typeof complete>) => ReturnType<typeof complete>;
+type DistillWarningReporter = (message: string) => void;
 
 type SummaryDiagnostics = {
   toolExecutionMs?: number;
@@ -462,12 +463,12 @@ async function summarizeOutputWithRetries(
       if (retriesUsed >= retryLimit) throw error;
       if (timedOut) timeoutRetries += 1;
       else errorRetries += 1;
-      console.warn(i18n.t("retryingSummary", {
+      context.ctx.ui.notify(i18n.t("retryingSummary", {
         kind: i18n.t(timedOut ? "retryKindTimeout" : "retryKindError"),
         retry: retriesUsed + 1,
         limit: retryLimit,
         error: error instanceof Error ? error.message : String(error),
-      }));
+      }), "warning");
     } finally {
       clearTimeout(timeout);
       context.signal?.removeEventListener("abort", abortFromParent);
@@ -496,7 +497,9 @@ export async function processToolResult(
   const maxReturnedChars = config?.maxOutputChars ?? 10_000;
   const finish = (candidate: ToolResult) => limitReturnedToolResult(candidate, maxReturnedChars);
   if (loaded.warnings.length > 0) {
-    console.warn(`[pi-distill] ${loaded.warnings.join(" | ")}`);
+    context.ctx.ui.notify(i18n.t("configWarnings", {
+      warnings: loaded.warnings.join(" "),
+    }), "warning");
   }
 
   if (config && loaded.enabled && !isDistillToolEnabled(config, context.toolName)) return result;
@@ -535,9 +538,7 @@ export async function processToolResult(
   try {
     output = await getCompleteOutput(result);
   } catch (error) {
-    console.warn(
-      `[tool-output-summary] ${context.toolName} could not read the full output; returning the original result: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return finish(attachDiagnostics(result, {
       toolExecutionMs,
       outputSummaryPrompt: prompt || undefined,
@@ -547,6 +548,7 @@ export async function processToolResult(
       summaryTriggerMaxChars: null,
       summaryResultMaxChars: config.maxChars,
       missedCompressionRatio: config.missedCompressionRatio,
+      outputSummaryError: errorMessage,
     }));
   }
 
@@ -687,9 +689,6 @@ export async function processToolResult(
     const summaryDurationMs = Math.round(performance.now() - summaryStartedAt);
     const errorMessage = error instanceof Error ? error.message : String(error);
     // 总结链路任何异常都必须保留原始结果，不能把异常文本替换给 AI。
-    console.warn(
-      `[tool-output-summary] ${context.toolName} summarization failed; returning the original result: ${errorMessage}`,
-    );
     const diagnostics: SummaryDiagnostics = {
       toolExecutionMs,
       summaryDurationMs,
@@ -739,17 +738,21 @@ function restoreOutputRequestParameter(parameters: Record<string, unknown>): boo
   return true;
 }
 
-function extendOutputRequestParameter(tool: ToolInfo, enabled: boolean): boolean {
+function extendOutputRequestParameter(
+  tool: ToolInfo,
+  enabled: boolean,
+  reportWarning: DistillWarningReporter,
+): boolean {
   const parameters = tool.parameters as unknown as Record<string, unknown> | undefined;
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
-    console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
+    reportWarning(i18n.t("outputRequestUnavailable", { tool: tool.name }));
     return false;
   }
 
   if (!enabled) return restoreOutputRequestParameter(parameters);
 
   if (parameters.type !== "object") {
-    console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
+    reportWarning(i18n.t("outputRequestUnavailable", { tool: tool.name }));
     return false;
   }
 
@@ -758,7 +761,7 @@ function extendOutputRequestParameter(tool: ToolInfo, enabled: boolean): boolean
   if (properties === undefined) {
     parameters.properties = {};
   } else if (typeof properties !== "object" || properties === null || Array.isArray(properties)) {
-    console.warn(`[pi-distill] Could not extend the ${tool.name} parameter schema; outputRequest is unavailable.`);
+    reportWarning(i18n.t("outputRequestUnavailable", { tool: tool.name }));
     return false;
   }
 
@@ -790,11 +793,12 @@ function extendOutputRequestParameter(tool: ToolInfo, enabled: boolean): boolean
 export function extendDistillToolParameters(
   pi: Pick<ExtensionAPI, "getAllTools">,
   loaded = loadDistillConfig(),
+  reportWarning: DistillWarningReporter = () => undefined,
 ): number {
   let extended = 0;
   for (const tool of pi.getAllTools()) {
     const enabled = loaded.enabled && Boolean(loaded.config) && isDistillToolEnabled(loaded.config, tool.name);
-    if (extendOutputRequestParameter(tool, enabled) && enabled) extended += 1;
+    if (extendOutputRequestParameter(tool, enabled, reportWarning) && enabled) extended += 1;
   }
   return extended;
 }
@@ -1042,7 +1046,10 @@ async function runDistillConfigUi(
   }
 }
 
-function registerDistillConfigCommand(pi: ExtensionAPI, onSaved: () => void): void {
+function registerDistillConfigCommand(
+  pi: ExtensionAPI,
+  onSaved: (ctx: ExtensionCommandContext) => void,
+): void {
   const command = {
     description: i18n.t("commandDescription"),
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
@@ -1050,7 +1057,7 @@ function registerDistillConfigCommand(pi: ExtensionAPI, onSaved: () => void): vo
         ctx.ui.notify(i18n.t("interactiveOnly"), "warning");
         return;
       }
-      await runDistillConfigUi(ctx, pi, getDistillConfigPath(), onSaved);
+      await runDistillConfigUi(ctx, pi, getDistillConfigPath(), () => onSaved(ctx));
     },
   };
   for (const name of ["config:distill", "pi-distill"] as const) {
@@ -1060,21 +1067,29 @@ function registerDistillConfigCommand(pi: ExtensionAPI, onSaved: () => void): vo
 
 export default function piDistillExtension(pi: ExtensionAPI) {
   const pendingCalls = new Map<string, PendingDistillCall>();
+  const reportedWarnings = new Set<string>();
   let originalUserPrompt = "";
   const disposeToolDisplayMiddleware = registerDistillToolDisplayMiddleware();
   registerDistillFallbackRenderer(pi);
-  const extendParameters = () => {
+  const extendParameters = (ctx: ExtensionContext) => {
+    const reportWarning = (message: string) => {
+      if (reportedWarnings.has(message)) return;
+      reportedWarnings.add(message);
+      ctx.ui.notify(message, "warning");
+    };
     try {
-      extendDistillToolParameters(pi, loadDistillConfig());
+      extendDistillToolParameters(pi, loadDistillConfig(), reportWarning);
     } catch (error) {
-      console.warn(`[pi-distill] Failed to extend the outputRequest parameter: ${error instanceof Error ? error.message : String(error)}`);
+      reportWarning(i18n.t("extendOutputRequestFailed", {
+        error: error instanceof Error ? error.message : String(error),
+      }));
     }
   };
 
-  pi.on("session_start", extendParameters);
-  pi.on("before_agent_start", (event) => {
+  pi.on("session_start", (_event, ctx) => extendParameters(ctx));
+  pi.on("before_agent_start", (event, ctx) => {
     originalUserPrompt = typeof event.prompt === "string" ? event.prompt : "";
-    extendParameters();
+    extendParameters(ctx);
     return {
       systemPrompt: [
         typeof event.systemPrompt === "string" ? event.systemPrompt : "",

--- a/packages/pi-distill/src/output-limit.ts
+++ b/packages/pi-distill/src/output-limit.ts
@@ -59,7 +59,6 @@ export async function limitReturnedToolResult(
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(i18n.t("outputLimitWriteFailed", { error: message }));
     return {
       ...result,
       content: [{ type: "text", text: text.slice(0, maxChars) }],

--- a/packages/pi-distill/src/summary-utils.ts
+++ b/packages/pi-distill/src/summary-utils.ts
@@ -160,9 +160,6 @@ export function parseBashSummaryConfig(
     missedCompressionRatio === undefined ||
     summarizeErrors === undefined
   ) {
-    console.warn(
-      "[pi-distill] Invalid distillation config; distillation disabled. Check PI_DISTILL_MIN_CHARS, PI_DISTILL_MAX_CHARS, PI_DISTILL_MAX_OUTPUT_CHARS, PI_DISTILL_TIMEOUT_SECONDS, PI_DISTILL_TIMEOUT_RETRY_COUNT, PI_DISTILL_ERROR_RETRY_COUNT, PI_DISTILL_MISSED_COMPRESSION_RATIO, and PI_DISTILL_SUMMARIZE_ERRORS (legacy PI_BASH_SUMMARY_* variables remain supported).",
-    );
     return undefined;
   }
 
@@ -181,9 +178,6 @@ export function parseBashSummaryConfig(
 
   const separator = modelRef.indexOf("/");
   if (separator <= 0 || separator === modelRef.length - 1) {
-    console.warn(
-      `[pi-distill] Invalid PI_DISTILL_MODEL; expected provider/model, got: ${modelRef}`,
-    );
     return undefined;
   }
 

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hasNonTextContent, limitReturnedToolResult } from "../src/output-limit.ts";
@@ -39,13 +39,17 @@ type TestCompletion = NonNullable<Parameters<typeof processToolResult>[3]>;
 type TestCompletionResult = Awaited<ReturnType<TestCompletion>>;
 
 /** 构造真实摘要处理链所需的最小扩展上下文。 */
-function fakeSummaryContext(): TestContext {
+function fakeSummaryContext(
+  notify: (message: string, type?: "info" | "warning" | "error") => void = () => undefined,
+): TestContext {
   const model = { provider: "fake", id: "model" };
   return {
     toolName: "fake-tool",
     toolCallId: "fake-call",
     params: { outputRequest: "提取错误和下一步" },
     ctx: {
+      hasUI: true,
+      ui: { notify },
       model,
       modelRegistry: {
         find: () => model,
@@ -607,6 +611,7 @@ test("提炼首次失败后默认重试一次并可成功返回", async () => {
   await withFakeSummaryConfig(async () => {
     const output = "FAIL checkout\nERROR at checkout.ts:8\nnext: inspect the payment provider\n".repeat(4);
     const successfulCompletion = fakeCompletion("ERROR at checkout.ts:8; inspect the payment provider");
+    const notices: Array<{ message: string; type?: string }> = [];
     let attempts = 0;
     const flakyCompletion: TestCompletion = async (...args) => {
       attempts += 1;
@@ -615,7 +620,7 @@ test("提炼首次失败后默认重试一次并可成功返回", async () => {
     };
 
     const result = await processToolResult(
-      fakeSummaryContext(),
+      fakeSummaryContext((message, type) => notices.push({ message, type })),
       fakeToolResult(output),
       0,
       flakyCompletion,
@@ -624,7 +629,25 @@ test("提炼首次失败后默认重试一次并可成功返回", async () => {
     assert.equal(attempts, 2);
     assert.equal(result.details?.outputSummaryStatus, "summarized");
     assert.equal(result.content[0]?.text, "ERROR at checkout.ts:8; inspect the payment provider");
+    assert.deepEqual(notices, [{
+      message: "Distillation hit a non-timeout error; starting retry 1/1: temporary provider failure",
+      type: "warning",
+    }]);
   });
+});
+
+test("运行期源码禁止直接调用 console API", async () => {
+  const sourceDirectory = join(import.meta.dirname, "..", "src");
+  const sourceFiles = (await readdir(sourceDirectory, { recursive: true }))
+    .filter((file) => file.endsWith(".ts"));
+  const violations: string[] = [];
+
+  for (const file of sourceFiles) {
+    const source = await readFile(join(sourceDirectory, file), "utf8");
+    if (/\bconsole\s*\./.test(source)) violations.push(file);
+  }
+
+  assert.deepEqual(violations, []);
 });
 
 test("errorRetryCount 为零时非超时异常不重试", async () => {


### PR DESCRIPTION
## 问题

pi-distill 在重试、配置解析和失败回退等运行期路径直接调用 `console.warn`，绕过 Pi UI 并污染 TUI/stdout/stderr。现有测试和门禁没有阻止这类调用。

## 行为变化

- 将重试、配置和参数扩展告警改为通过 Pi UI 通知，并对参数扩展告警进行会话内去重
- 将摘要失败、完整输出读取失败和临时文件写入失败保留在结果 details/审计信息中，不再直接写终端
- 移除 pi-distill 运行期源码中的全部 `console.*` 调用
- 增加中英文告警文案和 no-console 回归测试

## 包与文档影响

仅影响 `pi-distill` 的运行期告警展示通道；没有配置格式或兼容性变化，无需修改 README 或 config.example.json。

## 验证

- `npm run typecheck && npm test`（packages/pi-distill，36/36 通过）
- `npm run check`（仓库完整门禁通过）