### PR TITLE
feat(pi-distill): enable native JSON response format

### DIFF
--- a/packages/pi-distill/README.md
+++ b/packages/pi-distill/README.md
@@ -110,7 +110,7 @@ Agent consumes a result suited to the current decision, with auditable diagnosti
 2. The `tool_call` handler captures the parameter and removes it before forwarding the call, so the underlying tool never receives the extension-only field.
 3. The `tool_result` handler sees the actual output and decides what to do; it does not rely on the agent predicting the output size.
 4. Every tool call must include a non-empty `outputRequest`. A prompt containing only `RAW` explicitly requests the original. Any other non-empty prompt permits distillation once the configured threshold is reached.
-5. A timed-out attempt is retried according to `timeoutRetryCount`, while other failures use `errorRetryCount` (both default to one retry). If all attempts fail, no model is available, or compression is ineffective, the original facts are retained and the status is exposed through details and the audit card. JSON responses wrapped in Markdown fences such as `````json … ````` are also accepted.
+5. OpenAI-compatible completion requests enable native JSON mode with `response_format: { "type": "json_object" }`; OpenAI Responses-compatible requests use the equivalent `text.format`. A timed-out attempt is retried according to `timeoutRetryCount`, while other failures use `errorRetryCount` (both default to one retry). If all attempts fail, no model is available, or compression is ineffective, the original facts are retained and the status is exposed through details and the audit card. JSON responses wrapped in Markdown fences such as `````json … ````` are also accepted.
 
 ## Output contract
 

--- a/packages/pi-distill/README.zh-CN.md
+++ b/packages/pi-distill/README.zh-CN.md
@@ -112,7 +112,7 @@ Agent 消费更适合当前决策的结果，并获得可审计的处理诊断
 2. `tool_call` 事件捕获这个参数，并在交给底层工具前移除它，因此原工具不会收到扩展专用字段。
 3. `tool_result` 事件拿到真实输出后再做判断，不依赖 Agent 对输出长度的预测。
 4. 每次工具调用都必须包含非空的 `outputRequest`；严格的 `RAW` 表示明确要求原文；其他非空 prompt 才允许进入提炼流程。
-5. 单次提炼超时后按照 `timeoutRetryCount` 重试，其他异常按照 `errorRetryCount` 重试（两者默认都重试 1 次）；全部尝试失败、没有可用模型或结果收益过低时，扩展保留原始事实，并通过 details 和审计卡片暴露状态；模型用 Markdown 的 JSON 代码围栏（如 `````json … `````）包裹响应时也会兼容解析。
+5. OpenAI-compatible Completions 提炼请求会通过 `response_format: { "type": "json_object" }` 启用原生 JSON 模式；OpenAI Responses-compatible 请求使用等价的 `text.format`。单次提炼超时后按照 `timeoutRetryCount` 重试，其他异常按照 `errorRetryCount` 重试（两者默认都重试 1 次）；全部尝试失败、没有可用模型或结果收益过低时，扩展保留原始事实，并通过 details 和审计卡片暴露状态；模型用 Markdown 的 JSON 代码围栏（如 `````json … `````）包裹响应时也会兼容解析。
 
 ## 输出处理契约
 

--- a/packages/pi-distill/src/index.ts
+++ b/packages/pi-distill/src/index.ts
@@ -152,7 +152,43 @@ type SummaryResult = {
 };
 
 type SummaryCompletion = (...args: Parameters<typeof complete>) => ReturnType<typeof complete>;
+type SummaryCompletionModel = Parameters<SummaryCompletion>[0];
+type SummaryCompletionOptions = Parameters<SummaryCompletion>[2];
 type DistillWarningReporter = (message: string) => void;
+
+const OPENAI_RESPONSES_APIS = new Set([
+  "openai-responses",
+  "openai-codex-responses",
+  "azure-openai-responses",
+]);
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Enforce JSON mode on OpenAI-compatible summary requests without breaking other APIs. */
+function addSummaryJsonResponseFormat(payload: unknown, model: SummaryCompletionModel): unknown {
+  if (!isObjectRecord(payload)) return undefined;
+
+  if (model.api === "openai-completions") {
+    return {
+      ...payload,
+      response_format: { type: "json_object" },
+    };
+  }
+
+  if (OPENAI_RESPONSES_APIS.has(model.api)) {
+    return {
+      ...payload,
+      text: {
+        ...(isObjectRecord(payload.text) ? payload.text : {}),
+        format: { type: "json_object" },
+      },
+    };
+  }
+
+  return undefined;
+}
 
 class SummaryAttemptError extends Error {
   constructor(message: string, readonly usage?: SummaryUsage) {
@@ -684,6 +720,14 @@ async function summarizeOutput(
   const auth = await context.ctx.modelRegistry.getApiKeyAndHeaders(model);
   if (auth.ok === false) throw new Error(`Summarizer authentication failed: ${auth.error}`);
 
+  const completionOptions = {
+    apiKey: auth.apiKey,
+    headers: auth.headers,
+    env: auth.env,
+    maxTokens: Math.max(256, Math.ceil(config.maxChars / 2)),
+    onPayload: addSummaryJsonResponseFormat,
+    signal,
+  } satisfies SummaryCompletionOptions;
   const response = await completion(
     model,
     {
@@ -702,13 +746,7 @@ async function summarizeOutput(
         },
       ],
     },
-    {
-      apiKey: auth.apiKey,
-      headers: auth.headers,
-      env: auth.env,
-      maxTokens: Math.max(256, Math.ceil(config.maxChars / 2)),
-      signal,
-    },
+    completionOptions,
   );
 
   const usage = normalizeSummaryUsage(response.usage);

--- a/packages/pi-distill/tests/bash-output-summary.test.ts
+++ b/packages/pi-distill/tests/bash-output-summary.test.ts
@@ -616,6 +616,68 @@ test("fake provider 覆盖摘要链路的 RAW、有效摘要和低收益回退",
   });
 });
 
+test("OpenAI 提炼请求通过 provider payload 设置 JSON response format", async () => {
+  await withFakeSummaryConfig(async () => {
+    let completionOptions: Parameters<TestCompletion>[2];
+    const completion: TestCompletion = async (...args) => {
+      completionOptions = args[2];
+      return fakeCompletion("ERROR E42")(...args);
+    };
+
+    await processToolResult(
+      fakeSummaryContext(),
+      fakeToolResult("FAIL checkout\nERROR E42\nnext: retry\n".repeat(8)),
+      0,
+      completion,
+    );
+
+    const onPayload = completionOptions?.onPayload;
+    assert.equal(typeof onPayload, "function");
+
+    const completionsPayload = { model: "model", messages: [], stream: true };
+    assert.deepEqual(
+      await onPayload?.(
+        completionsPayload,
+        { provider: "fake", id: "model", api: "openai-completions" } as never,
+      ),
+      {
+        ...completionsPayload,
+        response_format: { type: "json_object" },
+      },
+    );
+    assert.equal("response_format" in completionsPayload, false);
+
+    const responsesPayload = {
+      model: "model",
+      input: [],
+      stream: true,
+      text: { verbosity: "low" },
+    };
+    assert.deepEqual(
+      await onPayload?.(
+        responsesPayload,
+        { provider: "fake", id: "model", api: "openai-responses" } as never,
+      ),
+      {
+        ...responsesPayload,
+        text: {
+          verbosity: "low",
+          format: { type: "json_object" },
+        },
+      },
+    );
+    assert.deepEqual(responsesPayload.text, { verbosity: "low" });
+
+    assert.equal(
+      await onPayload?.(
+        { model: "model", messages: [] },
+        { provider: "fake", id: "model", api: "anthropic-messages" } as never,
+      ),
+      undefined,
+    );
+  });
+});
+
 test("提炼首次失败后默认重试一次并可成功返回", async () => {
   await withFakeSummaryConfig(async () => {
     const output = "FAIL checkout\nERROR at checkout.ts:8\nnext: inspect the payment provider\n".repeat(4);


### PR DESCRIPTION
## Summary

- inject `response_format: { "type": "json_object" }` into OpenAI-compatible Chat Completions summarizer payloads through pi-ai's `onPayload` hook
- inject the equivalent `text.format` into OpenAI Responses-family payloads while preserving existing `text` options
- leave unsupported provider APIs unchanged and add focused regression coverage plus bilingual documentation

## Tracking

Closes #72

## Validation

- `npm run check --workspace packages/pi-distill` — typecheck, 42/42 tests, and package dry-run passed
- `npm run check` — all workspace typechecks/tests and repository policy gates passed
- live `llm-proxy/LOW` smoke captured `response_format.type=json_object` and returned a valid SUMMARY
- live `llm-proxy-responses/LOW` smoke captured `text.format.type=json_object` and returned a valid SUMMARY
- both live paths preserved `E42`, `checkout.ts:8`, and `retry fixture`
- `git diff --check` passed

One earlier Chat smoke returned malformed JSON despite the field and correctly exercised the existing safe fallback; the final captured Chat and Responses runs passed. Provider JSON mode improves reliability but does not replace pi-distill's parser and fallback behavior.

## Review

- no must-fix, advisory, deferred, or non-autofix findings
- the structured requirements reviewer failed to return a result twice; an evidence-based manual fallback review covered all four changed files, the provider payload contract, tests, and bilingual docs
- no review fixes were required

## Release companion

None: no SQL, configuration, permissions, dependency, migration, or deployment-order changes.
