### PR TITLE
feat(pi-interactive-subagents): /config:subagent 支持 orca 后端

### DIFF
--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -39,6 +39,7 @@ Supported multiplexers:
 - [WezTerm](https://wezfurlong.org/wezterm/) (terminal emulator with built-in multiplexing)
 - [herdr](https://herdr.dev) (terminal-native agent multiplexer)
 - [Otty](https://otty.sh) (macOS terminal emulator with built-in multiplexing)
+- [Orca](https://orca.dev) (agent workbench with built-in terminal multiplexing)
 
 Start pi inside one of them:
 
@@ -54,11 +55,13 @@ zellij --session pi   # then run: pi
 # start herdr (`herdr`), split a pane (prefix+v or prefix+-), then run `pi` in it
 # or
 # just run pi inside Otty — no wrapper needed
+# or
+# just run pi inside Orca — no wrapper needed
 ```
 
-Optional: set `PI_SUBAGENT_MUX=muxy|cmux|tmux|zellij|wezterm|herdr|otty` to force a specific backend.
+Optional: set `PI_SUBAGENT_MUX=muxy|cmux|tmux|zellij|wezterm|herdr|otty|orca` to force a specific backend.
 
-You can also configure it from inside Pi with `/config:subagent`. Run it without arguments for an interactive menu, or use `/config:subagent auto|muxy|cmux|tmux|zellij|wezterm|herdr|otty` for a direct choice. The selection is persisted in Pi's user extension config directory; explicit `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` environment variables take precedence. `/subagent-config` and `/pi-subagent-config` remain available as compatibility aliases.
+You can also configure it from inside Pi with `/config:subagent`. Run it without arguments for an interactive menu, or use `/config:subagent auto|muxy|cmux|tmux|zellij|wezterm|herdr|otty|orca` for a direct choice. The selection is persisted in Pi's user extension config directory; explicit `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` environment variables take precedence. `/subagent-config` and `/pi-subagent-config` remain available as compatibility aliases.
 
 > **Otty notes:**
 > - Otty sets `TERM_PROGRAM=otty` automatically when pi runs inside it; the backend detects this env var.
@@ -501,6 +504,7 @@ Every sub-agent session displays a compact tools widget showing available and de
   - [WezTerm](https://wezfurlong.org/wezterm/)
   - [herdr](https://herdr.dev) (terminal-native agent multiplexer)
   - [Otty](https://otty.sh) (macOS terminal emulator; needs `ipc-allow-send-keys = true`)
+  - [Orca](https://orca.dev) (agent workbench; sets `TERM_PROGRAM=Orca` automatically)
 
 ```bash
 cmux pi
@@ -514,12 +518,14 @@ zellij --session pi   # then run: pi
 # start herdr (`herdr`), split a pane, then run `pi` in it
 # or
 # just run pi inside Otty
+# or
+# just run pi inside Orca
 ```
 
 Optional backend override:
 
 ```bash
-export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm, herdr, otty
+export PI_SUBAGENT_MUX=cmux   # or tmux, zellij, wezterm, herdr, otty, orca
 ```
 
 ---

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -20,7 +20,7 @@ subagent({ name: "Scout: DB", agent: "scout", task: "梳理数据库 schema" });
 pi install npm:@maplezzk/pi-interactive-subagents
 ```
 
-支持的终端复用器：[cmux](https://github.com/manaflow-ai/cmux)、[tmux](https://github.com/tmux/tmux)、[zellij](https://zellij.dev)、[WezTerm](https://wezfurlong.org/wezterm/)、[herdr](https://herdr.dev)、[Otty](https://otty.sh)。
+支持的终端复用器：[cmux](https://github.com/manaflow-ai/cmux)、[tmux](https://github.com/tmux/tmux)、[zellij](https://zellij.dev)、[WezTerm](https://wezfurlong.org/wezterm/)、[herdr](https://herdr.dev)、[Otty](https://otty.sh)、[Orca](https://orca.dev)。
 
 在其中启动 pi：
 
@@ -32,10 +32,10 @@ tmux new -A -s pi 'pi'
 zellij --session pi   # 然后运行 pi
 ```
 
-可选：设置 `PI_SUBAGENT_MUX=muxy|cmux|tmux|zellij|wezterm|herdr|otty` 强制指定后端。
+可选：设置 `PI_SUBAGENT_MUX=muxy|cmux|tmux|zellij|wezterm|herdr|otty|orca` 强制指定后端。
 
 也可以在 Pi 内通过 `/config:subagent` 配置：不带参数打开选择菜单，或直接运行
-`/config:subagent auto|muxy|cmux|tmux|zellij|wezterm|herdr|otty`。选择会保存到 Pi 的用户扩展配置目录；显式设置的 `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` 优先级更高。`/subagent-config` 和 `/pi-subagent-config` 仍作为兼容别名保留。
+`/config:subagent auto|muxy|cmux|tmux|zellij|wezterm|herdr|otty|orca`。选择会保存到 Pi 的用户扩展配置目录；显式设置的 `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` 优先级更高。`/subagent-config` 和 `/pi-subagent-config` 仍作为兼容别名保留。
 
 ## 主要能力
 

--- a/packages/pi-interactive-subagents/locales/index.json
+++ b/packages/pi-interactive-subagents/locales/index.json
@@ -32,8 +32,8 @@
     "en-US": "Subagent multiplexer set to: {value}"
   },
   "muxInvalid": {
-    "zh-CN": "不支持的 mux：{value}。可选：auto、muxy、cmux、tmux、zellij、wezterm、herdr、otty。",
-    "en-US": "Unsupported mux: {value}. Choose auto, muxy, cmux, tmux, zellij, wezterm, herdr, or otty."
+    "zh-CN": "不支持的 mux：{value}。可选：auto、muxy、cmux、tmux、zellij、wezterm、herdr、otty、orca。",
+    "en-US": "Unsupported mux: {value}. Choose auto, muxy, cmux, tmux, zellij, wezterm, herdr, otty, or orca."
   },
   "muxInteractiveOnly": {
     "zh-CN": "请在支持 UI 的 Pi 会话中运行 /config:subagent。",

--- a/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
@@ -38,6 +38,7 @@ import {
   isWezTermAvailable,
   isHerdrAvailable,
   isOttyAvailable,
+  isOrcaAvailable,
   type MuxBackend,
 } from "pi-terminal-mux";
 
@@ -963,6 +964,7 @@ function isMuxBackendAvailable(backend: MuxBackend): boolean {
     case "wezterm": return isWezTermAvailable();
     case "herdr": return isHerdrAvailable();
     case "otty": return isOttyAvailable();
+    case "orca": return isOrcaAvailable();
   }
 }
 

--- a/packages/pi-interactive-subagents/pi-extension/subagents/mux-config.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/mux-config.ts
@@ -11,7 +11,7 @@ export interface SubagentMuxConfig {
   source: SubagentMuxConfigSource;
 }
 
-const BACKENDS: readonly MuxBackend[] = ["muxy", "cmux", "tmux", "zellij", "wezterm", "herdr", "otty"];
+const BACKENDS: readonly MuxBackend[] = ["muxy", "cmux", "tmux", "zellij", "wezterm", "herdr", "otty", "orca"];
 const CONFIG_FILE = "config.json";
 
 function isMuxBackend(value: unknown): value is MuxBackend {


### PR DESCRIPTION
## 问题

`pi-terminal-mux` 已经完整支持 orca 后端（`detection.ts` 里的 `MuxBackend` 联合类型、`muxPreference()`、`getMuxBackend()`、`isOrcaAvailable()` 都已就位，`backends/orca.ts` 也有完整实现），但 `pi-interactive-subagents` 侧的两处后端清单没有同步，导致在 Orca 里 orca 后端无法通过配置命令选中：

1. `pi-extension/subagents/mux-config.ts` 的 `BACKENDS` 缺 `orca`：
   - `/config:subagent` 交互菜单不列出 orca；
   - 直接输入 `/config:subagent orca` 会被判为 `muxInvalid`；
   - 手工把 `config.json` 改成 `{"mux":"orca"}` 也会被 `normalizePreference()` 静默丢弃，回退成 `auto`。
2. `pi-extension/subagents/index.ts` 的 `isMuxBackendAvailable()` switch 缺 `case "orca"`，该 backend 的可用性显示不出来。

副作用是：如果用户配置里残留了旧的 `{"mux":"herdr"}`，在 Orca 环境下 `getMuxBackend()` 因显式偏好不回退而返回 `null`，subagent 分屏直接失效，而用户无法通过 `/config:subagent` 把它改成 orca，只能靠 `PI_TERMINAL_MUX=orca` 绕过。

## 改动

- `mux-config.ts`：`BACKENDS` 增加 `orca`。
- `index.ts`：`isMuxBackendAvailable()` 增加 `case "orca"`，并导入 `isOrcaAvailable`。
- `locales/index.json`：`muxInvalid` 的中英文案补上 orca。
- `README.md` / `README.zh-CN.md`：后端列表、`PI_SUBAGENT_MUX` 与 `/config:subagent` 的可选值补上 orca。

只补清单，不改探测逻辑和既有后端行为。

## 验证

环境 Orca 1.4.175 + pi 0.84.0：

- `packages/pi-interactive-subagents`：`npm run typecheck` 通过，`npm test` 118/118 通过；
- `packages/pi-terminal-mux`：`npm run typecheck` 通过，`npm test` 62/62 通过；
- 仓库门禁 `scripts/check-no-local-bindings.mjs`、`scripts/check-package-config.mjs` 均通过。

未做的验证：没有跑 `test/integration/`（需要真实复用器 harness），orca 分屏的端到端行为依赖已合入的 #78，本 PR 不涉及。