### PR TITLE
chore: 登记 pi-session-tools 0.1.0 基线

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,6 +6,7 @@
   "packages/pi-terminal-mux": "0.3.1",
   "packages/pi-metrics": "0.2.3",
   "packages/pi-models-discovery": "1.0.1",
+  "packages/pi-session-tools": "0.1.0",
   "packages/pi-dynamic-workflows": "1.1.3",
   "packages/pi-interactive-subagents": "3.9.0"
 }


### PR DESCRIPTION
在 .release-please-manifest.json 登记 packages/pi-session-tools: 0.1.0，使 release-please 识别已发布基线、对该包做 minor bump（0.1.0→0.2.0）而非首次发布 1.0.0。\n\n配套：已建 GitHub Release pi-session-tools-v0.1.0（tag 指向 bacb13e）。