### PR TITLE
fix: suppress reminders after aborted or failed runs

### DIFF
--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -8,7 +8,7 @@ https://github.com/user-attachments/assets/30adb156-cfb4-4c47-84ca-dd4aa80cba9f
 
 ## How It Works
 
-Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `starting`, `active`, `waiting`, `stalled`, or `running`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it.
+Call `subagent()` and it **returns immediately**. The sub-agent runs in its own terminal pane. A live widget above the input shows all running agents with their current state — `starting`, `active`, `waiting`, `stalled`, or `running`. When a sub-agent finishes, its result is **steered back** into the main session as an async notification — triggering a new turn so the agent can process it. Completion reminders are injected only after the model stops normally; user aborts and provider errors stay quiet.
 
 ```
 ╭─ Subagents ──────────────────────────── 2 running ─╮

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 ## 工作原理
 
-调用 `subagent()` 后**立即返回**，子 agent 在自己的终端分屏中运行。输入框上方的实时 widget 展示所有运行中的 agent 及其状态（`starting`、`active`、`waiting`、`stalled`、`running`）。子 agent 完成后，结果以异步通知形式**回流**到主会话，触发新一轮处理。
+调用 `subagent()` 后**立即返回**，子 agent 在自己的终端分屏中运行。输入框上方的实时 widget 展示所有运行中的 agent 及其状态（`starting`、`active`、`waiting`、`stalled`、`running`）。子 agent 完成后，结果以异步通知形式**回流**到主会话，触发新一轮处理。完成提醒仅在模型正常停止后注入；用户手动终止或提供方异常不会触发。
 
 ```typescript
 subagent({ name: "Scout: Auth", agent: "scout", task: "分析 auth 模块" });

--- a/packages/pi-interactive-subagents/package.json
+++ b/packages/pi-interactive-subagents/package.json
@@ -17,7 +17,7 @@
     "README.zh-CN.md"
   ],
   "scripts": {
-    "test": "tsx --test test/test.ts",
+    "test": "tsx --test test/subagent-done-nudge.test.ts test/test.ts",
     "test:integration": "tsx --test --test-concurrency=1 test/integration/*.test.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "build": "npm run typecheck",

--- a/packages/pi-interactive-subagents/pi-extension/subagents/subagent-done.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/subagent-done.ts
@@ -13,7 +13,7 @@
  *   现在不论 autoExit env 如何，agent 都必须主动调用 subagent_done 或 caller_ping
  *   才能结束。如果 agent 不调，会被 nudge 提醒。
  */
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Box, Text } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { writeFileSync } from "node:fs";
@@ -22,23 +22,41 @@ import { createTranslator, loadCatalog } from "pi-extensions-i18n";
 import { createSubagentActivityRecorder } from "./activity.ts";
 
 const i18n = createTranslator(loadCatalog(new URL("../../locales/index.json", import.meta.url)));
+const ASSISTANT_ROLE = "assistant";
+const NORMAL_STOP_REASON = "stop";
+const ABORTED_STOP_REASON = "aborted";
 
+/** Treat input as manual takeover only after the first agent run has started. */
 export function shouldMarkUserTookOver(agentStarted: boolean): boolean {
   return agentStarted;
 }
 
+/** Return true only when the latest assistant message ended by the model stopping normally. */
+export function shouldScheduleAgentEndNudge(
+  messages: readonly { role?: string; stopReason?: string }[] | undefined,
+): boolean {
+  if (!messages) return false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === ASSISTANT_ROLE) {
+      return message.stopReason === NORMAL_STOP_REASON;
+    }
+  }
+
+  return false;
+}
+
+/** Preserve the former auto-exit decision for callers that still use this helper. */
 export function shouldAutoExitOnAgentEnd(
   _userTookOver: boolean,
-  messages: any[] | undefined,
+  messages: readonly { role?: string; stopReason?: string }[] | undefined,
 ): boolean {
-  // Manual input should not strand an auto-exit subagent. If the latest agent
-  // turn completed normally, close the session. Escape/abort still leaves it
-  // open for inspection or another prompt.
   if (messages) {
     for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg?.role === "assistant") {
-        return msg.stopReason !== "aborted";
+      const message = messages[i];
+      if (message?.role === ASSISTANT_ROLE) {
+        return message.stopReason !== ABORTED_STOP_REASON;
       }
     }
   }
@@ -46,6 +64,7 @@ export function shouldAutoExitOnAgentEnd(
   return true;
 }
 
+/** Parse the comma-separated denied-tool setting and discard blank entries. */
 export function parseDeniedTools(rawValue: string | undefined): string[] {
   return (rawValue ?? "")
     .split(",")
@@ -81,6 +100,7 @@ export default function (pi: ExtensionAPI) {
   let userInputAfterAgentEnd = false;
   let nudgeTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /** Cancel and forget the pending completion reminder, if any. */
   function clearNudgeTimer(): void {
     if (nudgeTimer !== null) {
       clearTimeout(nudgeTimer);
@@ -89,18 +109,17 @@ export default function (pi: ExtensionAPI) {
   }
 
   /**
-   * After a non-auto-exit subagent finishes generating, schedule a nudge
-   * reminding it to call subagent_done if it hasn't already.
+   * After a subagent stops normally, schedule a nudge reminding it to call
+   * subagent_done if it hasn't already. Error and aborted runs are excluded.
    *
    * Each call replaces any pending nudge, so repeated agent_end events
-   * (e.g. during multi-turn tool use) automatically reset the timer.
-   * The nudge only fires if no new agent activity or user input arrives
-   * within NUDGE_DELAY_MS.
+   * automatically reset the timer. The nudge only fires if no new agent
+   * activity or user input arrives within NUDGE_DELAY_MS.
    */
   function scheduleAgentEndNudge(): void {
     clearNudgeTimer();
     // 不论 autoExit 是否启用，都必须 nudge — autoExit 已被移除，
-    // agent 结束 turn 后只能靠主动调用 subagent_done 才能真正退出。
+    // agent 正常结束 turn 后只能靠主动调用 subagent_done 才能真正退出。
     if (NUDGE_DISABLED || doneCalled) return;
 
     nudgeTimer = setTimeout(() => {
@@ -114,10 +133,11 @@ export default function (pi: ExtensionAPI) {
     }, NUDGE_DELAY_MS);
   }
 
-  function renderWidget(ctx: { ui: { setWidget: Function } }, _theme: any) {
+  /** Render the subagent identity and tool availability widget. */
+  function renderWidget(ctx: Pick<ExtensionContext, "ui">): void {
     ctx.ui.setWidget(
       "subagent-tools",
-      (_tui: any, theme: any) => {
+      (_tui, theme) => {
         const box = new Box(1, 0, (text: string) => theme.bg("toolSuccessBg", text));
 
         const label = subagentAgent || subagentName;
@@ -178,7 +198,7 @@ export default function (pi: ExtensionAPI) {
     toolNames = tools.map((t) => t.name).sort();
     denied = parseDeniedTools(deniedToolsValue);
 
-    renderWidget(ctx, null);
+    renderWidget(ctx);
   });
 
   pi.on("input", () => {
@@ -216,10 +236,13 @@ export default function (pi: ExtensionAPI) {
     // subagent_done（或 caller_ping）。如果 agent 不调，下面会有 nudge 提醒。
     recorder.agentEndWaiting();
 
-    // For non-auto-exit agents: schedule a nudge in case the AI forgot to call
-    // subagent_done. This is automatically cleared/reset on any subsequent
-    // agent activity or user input.
-    scheduleAgentEndNudge();
+    // Only a normal model stop means the agent itself chose to finish.
+    // Provider errors and user aborts must stay quiet.
+    if (shouldScheduleAgentEndNudge(event.messages)) {
+      scheduleAgentEndNudge();
+    } else {
+      clearNudgeTimer();
+    }
   });
 
   pi.on("turn_start", (event) => {
@@ -272,7 +295,7 @@ export default function (pi: ExtensionAPI) {
     description: "Toggle subagent tools widget",
     handler: (ctx) => {
       expanded = !expanded;
-      renderWidget(ctx, null);
+      renderWidget(ctx);
     },
   });
 

--- a/packages/pi-interactive-subagents/test/subagent-done-nudge.test.ts
+++ b/packages/pi-interactive-subagents/test/subagent-done-nudge.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldScheduleAgentEndNudge } from "../pi-extension/subagents/subagent-done.ts";
+
+test("completion nudge runs after the agent stops normally", () => {
+  assert.equal(
+    shouldScheduleAgentEndNudge([{ role: "assistant", stopReason: "stop" }]),
+    true,
+  );
+});
+
+test("completion nudge ignores provider errors", () => {
+  assert.equal(
+    shouldScheduleAgentEndNudge([{ role: "assistant", stopReason: "error" }]),
+    false,
+  );
+});
+
+test("completion nudge ignores user aborts", () => {
+  assert.equal(
+    shouldScheduleAgentEndNudge([{ role: "assistant", stopReason: "aborted" }]),
+    false,
+  );
+});
+
+test("completion nudge ignores output-limit stops", () => {
+  assert.equal(
+    shouldScheduleAgentEndNudge([{ role: "assistant", stopReason: "length" }]),
+    false,
+  );
+});

--- a/packages/pi-session-tools/README.md
+++ b/packages/pi-session-tools/README.md
@@ -21,7 +21,7 @@ pi install npm:pi-session-tools
 
 ## Context threshold nudges
 
-When the conversation crosses a threshold (default 150k / 200k / 250k / 300k tokens), the agent is nudged to consider squashing at a task boundary. Configure it:
+When the conversation crosses a threshold (default 150k / 200k / 250k / 300k tokens), the agent is nudged to consider squashing at a task boundary. The nudge runs only after the model stops normally; user aborts and provider errors do not trigger it. Configure it:
 
 ```jsonc
 // ~/.pi/agent/extensions/pi-session-tools/config.json

--- a/packages/pi-session-tools/README.zh-CN.md
+++ b/packages/pi-session-tools/README.zh-CN.md
@@ -23,7 +23,7 @@ pi install npm:pi-session-tools
 
 ## 上下文阈值提示
 
-对话变长跨过阈值时（默认 150k / 200k / 250k / 300k tokens），会提醒主 agent 在任务边界时考虑压缩，不强制。可配置：
+对话变长跨过阈值时（默认 150k / 200k / 250k / 300k tokens），会提醒主 agent 在任务边界时考虑压缩，不强制。仅在模型正常停止时触发；用户手动终止或提供方异常不会触发。可配置：
 
 ```jsonc
 // ~/.pi/agent/extensions/pi-session-tools/config.json

--- a/packages/pi-session-tools/src/session-tail-compaction-utils.ts
+++ b/packages/pi-session-tools/src/session-tail-compaction-utils.ts
@@ -12,6 +12,25 @@ export const SESSION_SQUASH_TASK_TYPE = "session-squash-task";
 /** 上下文阈值提示消息的 customType：建议主 agent 考虑压缩。 */
 export const SESSION_SQUASH_HINT_TYPE = "session-squash-hint";
 
+const ASSISTANT_ROLE = "assistant";
+const NORMAL_STOP_REASON = "stop";
+
+/** 判断最近一条 assistant 消息是否由模型主动正常停止。 */
+export function didAgentStopNormally(
+  messages: readonly { role?: string; stopReason?: string }[] | undefined,
+): boolean {
+  if (!messages) return false;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === ASSISTANT_ROLE) {
+      return message.stopReason === NORMAL_STOP_REASON;
+    }
+  }
+
+  return false;
+}
+
 /** 阈值类型：绝对 token 值，或相对 contextWindow 的百分比。 */
 export type SquashThreshold =
   | { kind: "tokens"; value: number }

--- a/packages/pi-session-tools/src/session-tail-compaction.ts
+++ b/packages/pi-session-tools/src/session-tail-compaction.ts
@@ -32,6 +32,7 @@ import { Type } from "typebox";
 import {
   buildSquashTaskPrompt,
   computeFileLists,
+  didAgentStopNormally,
   extractFileOps,
   formatFileOperations,
   formatThreshold,
@@ -231,6 +232,8 @@ function textResult(text: string, isError = false) {
 }
 
 export default function contextFoldExtension(pi: ExtensionAPI) {
+  let latestAgentRunStoppedNormally = false;
+
   pi.registerTool({
     name: "session_log",
     label: i18n.t("logLabel"),
@@ -335,9 +338,16 @@ export default function contextFoldExtension(pi: ExtensionAPI) {
     },
   });
 
+  pi.on("agent_end", (event) => {
+    latestAgentRunStoppedNormally = didAgentStopNormally(event.messages);
+  });
+
   pi.on("agent_settled", async (_event, ctx) => {
+    const shouldCheckContextThreshold = latestAgentRunStoppedNormally;
+    latestAgentRunStoppedNormally = false;
+
     if (!pending) {
-      checkContextThreshold(pi, ctx);
+      if (shouldCheckContextThreshold) checkContextThreshold(pi, ctx);
       return;
     }
 
@@ -536,7 +546,7 @@ async function handleConfigCommand(
 const HINT_DELIVER_MODE = "followUp" as const;
 
 /**
- * 上下文阈值提示：agent 结束且无压缩任务时，若上下文跨过未提示过的阈值，
+ * 上下文阈值提示：agent 主动正常停止且无压缩任务时，若上下文跨过未提示过的阈值，
  * 注入一条 followUp 消息建议主 agent 考虑 session_squash（停止后立即触发）。
  * 上下文跌回阈值以下（如压缩后）自动恢复该档位的可提示状态。
  */

--- a/packages/pi-session-tools/tests/agent-stop.test.ts
+++ b/packages/pi-session-tools/tests/agent-stop.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { didAgentStopNormally } from "../src/session-tail-compaction-utils.ts";
+
+test("normal model stop allows a context threshold reminder", () => {
+  assert.equal(
+    didAgentStopNormally([{ role: "assistant", stopReason: "stop" }]),
+    true,
+  );
+});
+
+test("provider error suppresses a context threshold reminder", () => {
+  assert.equal(
+    didAgentStopNormally([{ role: "assistant", stopReason: "error" }]),
+    false,
+  );
+});
+
+test("user abort suppresses a context threshold reminder", () => {
+  assert.equal(
+    didAgentStopNormally([{ role: "assistant", stopReason: "aborted" }]),
+    false,
+  );
+});
+
+test("output limit suppresses a context threshold reminder", () => {
+  assert.equal(
+    didAgentStopNormally([{ role: "assistant", stopReason: "length" }]),
+    false,
+  );
+});


### PR DESCRIPTION
## Problem

Completion and context-compaction reminders were also injected after provider/network failures and user-aborted runs, which could create repeated unwanted agent turns.

## Changes

- only schedule the interactive-subagent completion reminder when the latest assistant message stops normally (`stopReason: "stop"`)
- suppress completion reminders after provider errors, user aborts, and output-limit stops
- apply the same normal-stop-only rule to `pi-session-tools` context threshold reminders
- document the behavior in both English and Chinese READMEs
- add focused regression tests for both packages

## Package impact

- `@maplezzk/pi-interactive-subagents`
- `pi-session-tools`

No configuration changes are required.

## Validation

- `npm run check`
- 4 new completion-reminder tests passed
- 4 new context-threshold-reminder tests passed
