### PR TITLE
fix: stop old agent run after session squash

### DIFF
--- a/packages/pi-session-tools/src/session-tail-compaction.ts
+++ b/packages/pi-session-tools/src/session-tail-compaction.ts
@@ -445,7 +445,8 @@ export default function contextFoldExtension(pi: ExtensionAPI) {
 
       return {
         ...textResult(i18n.t("registered", { from: params.from })),
-        terminate: forceState !== null,
+        // 先结束旧分支上的 agent run，agent_settled 才能立即切分支并注入摘要。
+        terminate: true,
       };
     },
   });

--- a/packages/pi-session-tools/tests/session-tail-compaction.test.ts
+++ b/packages/pi-session-tools/tests/session-tail-compaction.test.ts
@@ -40,7 +40,7 @@ type RegisteredCommand = {
   handler: (args: string, context: unknown) => Promise<void>;
 };
 
-test("强制模式限制工具并持续要求 session_squash，成功后恢复工具", async (t) => {
+test("强制模式限制工具并持续要求压缩，普通模式提交后也终止当前 agent", async (t) => {
   const agentDir = mkdtempSync(join(tmpdir(), "pi-session-tools-force-"));
   const configDir = join(agentDir, "extensions", "pi-session-tools");
   mkdirSync(configDir, { recursive: true });
@@ -268,4 +268,15 @@ test("强制模式限制工具并持续要求 session_squash，成功后恢复�
   );
   assert.equal(sent.details.summary, sent.content);
   assert.ok(notifications.length >= 5);
+
+  await configCommand.handler("force off", context);
+  const normalResult = await squashTool.execute(
+    "tool-2",
+    { from: 0, summary: "## Goal\n普通模式压缩" },
+    undefined,
+    undefined,
+    context,
+  );
+  assert.equal(normalResult.isError, false);
+  assert.equal(normalResult.terminate, true);
 });


### PR DESCRIPTION
## Problem

A normal `session_squash` call did not terminate the current agent run. The agent could continue working on the old branch before `agent_settled` applied the squash, leaving that extra work outside the submitted summary.

## Change

- Always return `terminate: true` after a valid `session_squash` submission.
- End the old agent run before `agent_settled` switches branches and injects the summary.
- Add a regression assertion for normal mode while preserving forced-squash coverage.

## Package impact

- `pi-session-tools`: bug fix only; no configuration or API changes.
- Documentation and localization are unchanged.

## Validation

- Regression reproduced before the fix: 22 passed, 1 failed (`false !== true`).
- Package tests after the fix: 23 passed, 0 failed.
- `npm run check`: passed, including workspace type checks/tests, packaging/config checks, i18n checks, no-local-path, and no-private-domain gates.
