### PR TITLE
fix(pi-tool-supervisor): support recursive globstars

### DIFF
--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -93,6 +93,8 @@ consumers:
 ---
 ```
 
+`filePatterns` uses a simplified glob syntax: `*` does not cross `/`, `**` does, and `**/` at any position matches zero or more directory levels. Backslashes are normalized to `/`, and a leading `./` is ignored.
+
 ## Review semantics
 
 - A before reviewer rejection blocks the native tool call and emits a standalone audit with the complete reason; before failures/skips are fail-open but remain visible on the next tool result.

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -94,6 +94,8 @@ consumers:
 ---
 ```
 
+`filePatterns` 使用简化 glob：`*` 不跨 `/`，`**` 可以跨目录，任意位置的 `**/` 都可匹配零层或多层目录。反斜杠会归一化为 `/`，开头的 `./` 会被忽略。
+
 ## 审查语义
 
 - before reviewer 明确拒绝会阻断 Pi 原生工具调用，并用完整 reason 展示独立审计；before 失败/跳过会放行，但会在后续 tool result 中可见。

--- a/packages/pi-tool-supervisor/src/review-utils.ts
+++ b/packages/pi-tool-supervisor/src/review-utils.ts
@@ -332,14 +332,40 @@ function parseRuleFile(rawContent: string): ParsedRuleFile {
   return { metadata, content };
 }
 
+/** Converts the supported glob subset while preserving directory boundaries for a single star. */
+function filePatternToRegExp(pattern: string): RegExp {
+  const singleSegmentWildcard = "*";
+  const recursiveWildcard = "**";
+  const recursiveDirectoryWildcard = "**/";
+  let expression = "";
+  for (let index = 0; index < pattern.length;) {
+    const character = pattern[index];
+    if (character !== singleSegmentWildcard) {
+      expression += /[\\^$.*+?()[\]{}|]/.test(character) ? `\\${character}` : character;
+      index += 1;
+      continue;
+    }
+    if (!pattern.startsWith(recursiveWildcard, index)) {
+      expression += "[^/]*";
+      index += singleSegmentWildcard.length;
+      continue;
+    }
+    if (pattern.startsWith(recursiveDirectoryWildcard, index)) {
+      expression += "(?:.*/)?";
+      index += recursiveDirectoryWildcard.length;
+      continue;
+    }
+    expression += ".*";
+    index += recursiveWildcard.length;
+  }
+  return new RegExp(`^${expression}$`);
+}
+
+/** Matches a normalized file path against one configured file pattern. */
 function matchesFilePattern(filePath: string, pattern: string): boolean {
   const normalizedPath = normalizeFilePath(filePath);
   const normalizedPattern = normalizeFilePath(pattern);
-  const patternBody = normalizedPattern.startsWith("**/") ? normalizedPattern.slice(3) : normalizedPattern;
-  const escaped = patternBody.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  const expression = escaped.replaceAll("*", "[^/]*");
-  const prefix = normalizedPattern.startsWith("**/") ? "(?:.*/)?" : "";
-  return new RegExp(`^${prefix}${expression}$`).test(normalizedPath);
+  return filePatternToRegExp(normalizedPattern).test(normalizedPath);
 }
 
 export function reviewerAppliesToFile(

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -226,6 +226,53 @@ test("reviewer 文件匹配条件只作用于 Java 文件", () => {
   assert.equal(reviewerAppliesToFile(reviewer, "src/main/Order.ts"), false);
 });
 
+test("filePatterns 中任意位置的双星号匹配零层或多层目录", () => {
+  const reviewer = {
+    name: "test-sql",
+    model: "provider/model",
+    rulesFile: "rules.md",
+    filePatterns: ["**/test/**/*.sql", "**/tests/**/*.sql"],
+  };
+
+  assert.equal(reviewerAppliesToFile(reviewer, "test/a.sql"), true);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/test/a.sql"), true);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/test/resources/a.sql"), true);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/test/resources/db/a.sql"), true);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/tests/a.sql"), true);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/main/resources/a.sql"), false);
+  assert.equal(reviewerAppliesToFile(reviewer, "src/test/resources/a.txt"), false);
+});
+
+test("filePatterns 保持单星号边界并归一化路径", () => {
+  const topLevelReviewer = {
+    model: "provider/model",
+    rulesFile: "rules.md",
+    filePatterns: ["*.ts"],
+  };
+  const recursiveReviewer = {
+    model: "provider/model",
+    rulesFile: "rules.md",
+    filePatterns: ["**/*.ts"],
+  };
+  const recursiveSuffixReviewer = {
+    model: "provider/model",
+    rulesFile: "rules.md",
+    filePatterns: ["src/**.ts"],
+  };
+  const windowsReviewer = {
+    model: "provider/model",
+    rulesFile: "rules.md",
+    filePatterns: ["**\\test\\**\\*.sql"],
+  };
+
+  assert.equal(reviewerAppliesToFile(topLevelReviewer, "a.ts"), true);
+  assert.equal(reviewerAppliesToFile(topLevelReviewer, "src/a.ts"), false);
+  assert.equal(reviewerAppliesToFile(recursiveReviewer, "a.ts"), true);
+  assert.equal(reviewerAppliesToFile(recursiveReviewer, "src/deep/a.ts"), true);
+  assert.equal(reviewerAppliesToFile(recursiveSuffixReviewer, "src/deep/a.ts"), true);
+  assert.equal(reviewerAppliesToFile(windowsReviewer, ".\\src\\test\\db\\a.sql"), true);
+});
+
 test("规则文件超过 100 行时返回警告", async () => {
   const directory = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-rule-"));
   const ruleFile = join(directory, "rules.md");


### PR DESCRIPTION
## Problem

`filePatterns` only treated a leading `**/` as recursive. A glob such as `**/test/**/*.sql` therefore matched exactly one directory below `test` instead of zero or any depth.

## Change

- parse glob patterns token by token so `*` stays within a path segment
- make `**` cross directory separators and `**/` match zero or more directory levels at any position
- retain `./` and Windows separator normalization
- document the supported simplified glob semantics in both package READMEs
- add regression coverage for zero/one/multiple directory levels, exclusions, recursive TypeScript patterns, and Windows paths

## Validation

- `npm run check --workspace pi-tool-supervisor` — passed, 30/30 tests
- `npm run check` — passed, 1116 tests across workspace summaries, 0 failed; packaging/i18n/portability/package-config gates passed
- `git diff --check` — passed

Runtime hook verification and the local rule rollback are tracked separately because the source fix is installed locally from a tarball pending a formal package release.
