### PR TITLE
fix: exclude terminal mux library from root manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements: Pi with the compatible extension API and Node.js 22 or newer.
 pi install git:github.com/maplezzk/pi-extensions
 ```
 
-The repository root is also a Pi package. Its manifest loads every `packages/*/index.ts`, so the command above installs all current extensions and automatically includes new packages added to this repository.
+The repository root is also a Pi package. Its manifest loads extension entrypoints under `packages/*/index.ts` while excluding library-only packages such as `pi-terminal-mux`, so the command above installs all current extensions without trying to load shared libraries as extensions.
 
 Reload Pi after installation:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 pi install git:github.com/maplezzk/pi-extensions
 ```
 
-仓库根目录本身也是一个 Pi package。它通过 manifest 自动加载所有 `packages/*/index.ts`，因此上面的命令会安装当前全部扩展；以后新增包也会自动包含，不需要再修改根 README 或安装命令。
+仓库根目录本身也是一个 Pi package。它通过 manifest 加载 `packages/*/index.ts` 下的扩展入口，并排除 `pi-terminal-mux` 等纯库包，因此上面的命令会安装当前全部扩展，但不会误把共享库作为扩展加载。
 
 安装后重新加载 Pi：
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "pi": {
     "extensions": [
-      "packages/*/index.ts"
+      "packages/*/index.ts",
+      "!packages/pi-terminal-mux/index.ts"
     ]
   },
   "peerDependencies": {

--- a/scripts/check-package-config.mjs
+++ b/scripts/check-package-config.mjs
@@ -11,6 +11,7 @@
  * 4. package.json has required fields (name, version, description, main, exports, files, license)
  * 5. i18n catalogs have both zh-CN and en-US for every key
  * 6. package.json "files" includes README.md and README.zh-CN.md
+ * 7. The root Pi package excludes library-only workspace entrypoints
  */
 
 import { readFileSync, existsSync, readdirSync } from "node:fs";
@@ -108,6 +109,13 @@ const packageDirs = readdirSync(PACKAGES_DIR, { withFileTypes: true })
   .filter((d) => d.isDirectory() && existsSync(join(PACKAGES_DIR, d.name, "package.json")))
   .map((d) => d.name);
 
+const rootPackageJson = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+const rootExtensionEntries = rootPackageJson.pi?.extensions ?? [];
+const WORKSPACE_PACKAGES_PATH = "packages";
+const EXTENSION_ENTRY_FILE = "index.ts";
+const PACKAGE_EXTENSION_ENTRY = `./${EXTENSION_ENTRY_FILE}`;
+const ROOT_EXTENSION_GLOB = `${WORKSPACE_PACKAGES_PATH}/*/${EXTENSION_ENTRY_FILE}`;
+const rootLoadsAllPackageIndexes = rootExtensionEntries.includes(ROOT_EXTENSION_GLOB);
 const REQUIRED_FILES = ["package.json", "index.ts", "README.md", "README.zh-CN.md", "tsconfig.json"];
 const REQUIRED_PKG_FIELDS = ["name", "version", "description", "main", "exports", "files", "license"];
 
@@ -115,6 +123,14 @@ for (const dir of packageDirs) {
   const pkgRoot = join(PACKAGES_DIR, dir);
   const pkgJson = JSON.parse(readFileSync(join(pkgRoot, "package.json"), "utf8"));
   const label = pkgJson.name ?? dir;
+
+  // The root Git package uses a workspace glob. Utility packages still have
+  // index.ts library entrypoints, so they must be excluded from Pi's loader.
+  const exposesIndexAsExtension = pkgJson.pi?.extensions?.includes(PACKAGE_EXTENSION_ENTRY) ?? false;
+  const rootExclusion = `!${WORKSPACE_PACKAGES_PATH}/${dir}/${EXTENSION_ENTRY_FILE}`;
+  if (rootLoadsAllPackageIndexes && !exposesIndexAsExtension && !rootExtensionEntries.includes(rootExclusion)) {
+    error(`${label}: root Pi manifest must exclude library-only entrypoint "${rootExclusion.slice(1)}"`);
+  }
 
   // 3. Required files
   for (const file of REQUIRED_FILES) {


### PR DESCRIPTION
## Problem

Installing the repository root with `pi install git:github.com/maplezzk/pi-extensions` caused Pi to load `packages/pi-terminal-mux/index.ts` as an extension. `pi-terminal-mux` is a shared library and does not export an extension factory, so Pi startup failed.

## Changes

- exclude the `pi-terminal-mux` library entrypoint from the root Pi extension manifest
- add a package configuration gate requiring library-only workspace entrypoints to be excluded
- update the English and Chinese installation documentation

## Validation

- `npm run check` — 1,114 tests passed, 0 failed
- Pi package-manager/loader integration check — 10 extensions declared, 10 loaded, 0 errors; `pi-terminal-mux` excluded
- `git diff --check`
