### PR TITLE
fix: remove supervisor output truncation

### DIFF
--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -14,6 +14,7 @@ An edit tool can complete successfully while the resulting file still violates l
 - Supports multiple reviewers running in parallel, each with its own model and one or more rule files.
 - Reads optional front matter from rule files for `enabled`, `filePatterns`, `complexity`, and `consumers`.
 - Returns `passed`, `rejected`, `failed`, or `skipped` status with summaries, findings, rule groups, and durations.
+- Passes native tool results through unchanged; it does not truncate or write tool output to temporary files. Output control belongs to Pi or other extensions.
 - Re-reads the configuration for every tool call, so configuration changes apply to the next matching operation.
 - Shows an audit card through Pi's display middleware or a fallback renderer. The shared display protocol is provided by `pi-extensions-tool-display`.
 
@@ -53,7 +54,6 @@ Start from [`config.example.json`](./config.example.json):
 {
   "enabled": true,
   "timeoutSeconds": 10,
-  "maxOutputChars": 10000,
   "maxRuleLines": 100,
   "reviewers": [
     {
@@ -75,7 +75,6 @@ Each reviewer must have a `provider/model` reference and either `rulesFile` or `
 | --- | --- |
 | `enabled` | Enables or disables the review layer. |
 | `timeoutSeconds` | Maximum time allowed for each reviewer model call. |
-| `maxOutputChars` | Maximum size of the returned tool result; larger output is written to a temporary file. |
 | `maxRuleLines` | Maximum rule-file size accepted for a single review rule. |
 | `reviewers` | Reviewer name, model, rule files, `tools`, and `trigger`. Missing lifecycle fields keep the legacy `edit`/`write` + `after` behavior. |
 

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -15,6 +15,7 @@
 - 支持多个 reviewer 并行执行，每个 reviewer 可以使用自己的模型和一个或多个规则文件。
 - 读取规则文件可选的 front matter：`enabled`、`filePatterns`、`complexity` 和 `consumers`。
 - 返回 `passed`、`rejected`、`failed` 或 `skipped` 状态，以及结论、发现、规则组和耗时。
+- 原样透传工具结果，不截断，也不把工具输出写入临时文件；输出控制由 Pi 或其他扩展负责。
 - 每次工具调用都重新读取配置，因此配置修改会在下一次匹配操作立即生效。
 - 当前 Pi 展示中间件可用时显示审计卡片，否则使用 fallback renderer。展示协议由公共运行库 `pi-extensions-tool-display` 提供。
 
@@ -54,7 +55,6 @@ pi install npm:pi-tool-supervisor
 {
   "enabled": true,
   "timeoutSeconds": 10,
-  "maxOutputChars": 10000,
   "maxRuleLines": 100,
   "reviewers": [
     {
@@ -76,7 +76,6 @@ pi install npm:pi-tool-supervisor
 | --- | --- |
 | `enabled` | 启用或关闭审查层。 |
 | `timeoutSeconds` | 每个 reviewer 模型调用的最长等待时间。 |
-| `maxOutputChars` | 工具结果最大返回长度，超出后写入临时文件。 |
 | `maxRuleLines` | 单条审查规则允许读取的最大行数。 |
 | `reviewers` | reviewer 名称、模型、规则文件、`tools` 与 `trigger`；省略生命周期字段时保持旧的 `edit`/`write` + `after` 行为。 |
 

--- a/packages/pi-tool-supervisor/SKILL.md
+++ b/packages/pi-tool-supervisor/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: configure-pi-tool-supervisor
-description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查、reviewer、规则文件和输出限制。Use when configuring tool lifecycle reviews."
+description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查、reviewer 和规则文件。Use when configuring tool lifecycle reviews."
 ---
 
 # 配置 pi-tool-supervisor
 
 ## 诊断
 
-定位实际 Pi agent 目录下的 `extensions/pi-tool-supervisor/config.json`；仅当新路径不存在时读取旧 `extensions/pi-file-edit-review/config.json`。确认顶层 `enabled`、`timeoutSeconds`、`maxOutputChars`、`maxRuleLines`、`reviewers`。
+定位实际 Pi agent 目录下的 `extensions/pi-tool-supervisor/config.json`；仅当新路径不存在时读取旧 `extensions/pi-file-edit-review/config.json`。确认顶层 `enabled`、`timeoutSeconds`、`maxRuleLines`、`reviewers`。
 
 每个 reviewer 必须有 `provider/model` 和唯一的 `rulesFile|rulesFiles`，并检查：
 

--- a/packages/pi-tool-supervisor/config.example.json
+++ b/packages/pi-tool-supervisor/config.example.json
@@ -1,7 +1,6 @@
 {
   "enabled": true,
   "timeoutSeconds": 10,
-  "maxOutputChars": 10000,
   "maxRuleLines": 100,
   "reviewers": [
     {

--- a/packages/pi-tool-supervisor/locales/index.json
+++ b/packages/pi-tool-supervisor/locales/index.json
@@ -123,17 +123,9 @@
     "zh-CN": "审查超时时间（秒）",
     "en-US": "Review timeout (seconds)"
   },
-  "outputInput": {
-    "zh-CN": "最终返回最大字符数",
-    "en-US": "Maximum final output characters"
-  },
   "rulesInput": {
     "zh-CN": "规则文件最大行数",
     "en-US": "Maximum rule file lines"
-  },
-  "outputConfig": {
-    "zh-CN": "最终返回上限：{value} 字符",
-    "en-US": "Final output limit: {value} chars"
   },
   "rulesConfig": {
     "zh-CN": "规则最大行数：{value}",
@@ -147,17 +139,9 @@
     "zh-CN": "当前模式不支持交互式配置，请使用有 UI 的 Pi 会话。",
     "en-US": "Interactive configuration is not supported in this mode; use a Pi session with a UI."
   },
-  "tempFileWriteFailed": {
-    "zh-CN": "超长工具结果写入临时文件失败，已截断返回：{message}",
-    "en-US": "Failed to write oversized tool result to temp file, truncated: {message}"
-  },
   "reviewAborted": {
     "zh-CN": "上级请求已终止，审查模型请求已取消或未发起。",
     "en-US": "The parent request was aborted; review-model requests were cancelled or not started."
-  },
-  "oversizedOutputPointer": {
-    "zh-CN": "工具结果超过 {maxChars} 个字符，已写入临时文件：{filePath}",
-    "en-US": "Tool result exceeded {maxChars} characters and was written to a temporary file: {filePath}"
   },
   "failedAfterReview": {
     "zh-CN": "工具调用失败，跳过 after 审查。",

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -17,7 +17,6 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { performance } from "node:perf_hooks";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import {
   appendSupervisorFallbackAudit,
@@ -54,6 +53,7 @@ const AFTER_TRIGGER: ReviewTrigger = "after";
 const BEFORE_TRIGGER: ReviewTrigger = "before";
 const MILLISECONDS_PER_SECOND = 1000;
 const REVIEW_MAX_TOKENS = 1200;
+const MAX_REVIEW_PAYLOAD_CHARS = 10_000;
 const REJECTED_STATUS = "rejected" as const;
 const SKIPPED_STATUS = "skipped" as const;
 const EDIT_TOOL = "edit";
@@ -106,50 +106,6 @@ function getRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-/** Joins text content for bounded result forwarding. */
-function getTextContent(result: ToolResult): string {
-  return result.content
-    .filter((content) => content.type === "text" && typeof content.text === "string")
-    .map((content) => content.text ?? "")
-    .join("\n");
-}
-
-/** Preserves oversized output in a temp file or visibly truncates it on write failure. */
-async function limitReturnedToolResult(result: ToolResult, maxChars: number): Promise<ToolResult> {
-  const text = getTextContent(result);
-  if (text.length <= maxChars) return result;
-
-  const directory = join(tmpdir(), "pi-tool-supervisor");
-  const filePath = join(directory, `tool-output-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`);
-  try {
-    await mkdir(directory, { recursive: true });
-    await writeFile(filePath, text, "utf8");
-    const pointer = i18n.t("oversizedOutputPointer", { maxChars, filePath });
-    return {
-      ...result,
-      content: [{ type: "text", text: pointer.slice(0, maxChars) }],
-      details: {
-        ...(result.details ?? {}),
-        outputTruncated: true,
-        outputLimitChars: maxChars,
-        fullOutputPath: filePath,
-      },
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[pi-tool-supervisor] ${i18n.t("tempFileWriteFailed", { message })}`);
-    return {
-      ...result,
-      content: [{ type: "text", text: text.slice(0, maxChars) }],
-      details: {
-        ...(result.details ?? {}),
-        outputTruncated: true,
-        outputLimitChars: maxChars,
-        outputFileError: message,
-      },
-    };
-  }
-}
 
 /** Detects tool execution failure without inspecting arbitrary detail fields. */
 function isFailedToolResult(result: ToolResult): boolean {
@@ -506,7 +462,7 @@ async function runBeforeReview(options: {
   const selectedFilePath = isFileTool ? getPath(context.params) : undefined;
   const serializedPayload = selectedFilePath
     ? { text: buildFileEditReviewDiff(selectedFilePath, undefined, typeof context.params.content === "string" ? context.params.content : undefined, fallbackDiff) }
-    : safeSerialize(context.params, loaded.config.maxOutputChars);
+    : safeSerialize(context.params, MAX_REVIEW_PAYLOAD_CHARS);
   const warnings = [...loaded.warnings];
   for (const reviewer of reviewers) {
     const loadedRules = loadReviewRules(reviewer, context.ctx.cwd, loaded.config.maxRuleLines);
@@ -580,7 +536,10 @@ async function processGenericReviewResult(context: FileReviewExecutionContext, p
     ? reviewers.map((reviewer) => ({ name: reviewer.name, model: reviewer.model, status: SKIPPED_STATUS, durationMs: 0, error: i18n.t("failedAfterReview") }))
     : [];
   if (!isFailedToolResult(result)) {
-    const serializedPayload = safeSerialize({ input: pending.params, result: { content: result.content, details: result.details, isError: result.isError } }, pending.loaded.config.maxOutputChars);
+    const serializedPayload = safeSerialize(
+      { input: pending.params, result: { content: result.content, details: result.details, isError: result.isError } },
+      MAX_REVIEW_PAYLOAD_CHARS,
+    );
     for (const reviewer of reviewers) {
       const loadedRules = loadReviewRules(reviewer, context.ctx.cwd, pending.loaded.config.maxRuleLines);
       const rules = loadedRules.rules.filter((rule) => rule.reviewer.enabled !== false && reviewerIsEditorLocal(rule.reviewer) && (rule.reviewer.filePatterns ?? []).length === 0);
@@ -610,14 +569,11 @@ async function processFileReviewResult(
   result: ToolResult,
 ): Promise<ToolResult> {
   const { loaded } = pending;
-  /** Bounds the returned tool text without changing the original error flag. */
-  const finish = (candidate: ToolResult) =>
-    limitReturnedToolResult(candidate, loaded.config.maxOutputChars);
   if (pending.beforeAudit && pending.beforeAudit.status === REJECTED_STATUS) {
-    return finish({ ...result, details: { ...(result.details ?? {}), fileEditReview: pending.beforeAudit } });
+    return { ...result, details: { ...(result.details ?? {}), fileEditReview: pending.beforeAudit } };
   }
-  if (!pending.snapshot) return finish(await processGenericReviewResult(context, pending, result));
-  return finish(await reviewToolResult({
+  if (!pending.snapshot) return processGenericReviewResult(context, pending, result);
+  return reviewToolResult({
     context,
     toolName: pending.toolName as typeof EDIT_TOOL | typeof WRITE_TOOL,
     config: loaded.config,
@@ -628,7 +584,7 @@ async function processFileReviewResult(
     result,
     afterReviewers: pending.afterReviewers,
     beforeAudit: pending.beforeAudit,
-  }));
+  });
 }
 
 async function inputPositiveInteger(
@@ -773,7 +729,6 @@ async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: strin
     const choices = [
       i18n.t("enabledConfig", { value: config.enabled ? i18n.t("enabled") : i18n.t("disabled") }),
       i18n.t("timeoutConfig", { value: config.timeoutSeconds }),
-      i18n.t("outputConfig", { value: config.maxOutputChars }),
       i18n.t("rulesConfig", { value: config.maxRuleLines }),
       ...reviewerChoices,
       i18n.t("addReviewer"),
@@ -791,18 +746,12 @@ async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: strin
         await saveFileEditReviewConfig(ctx, config, configPath);
       }
     } else if (choice === choices[2]) {
-      const value = await inputPositiveInteger(ctx, i18n.t("outputInput"), config.maxOutputChars);
-      if (value !== undefined) {
-        config.maxOutputChars = value;
-        await saveFileEditReviewConfig(ctx, config, configPath);
-      }
-    } else if (choice === choices[3]) {
       const value = await inputPositiveInteger(ctx, i18n.t("rulesInput"), config.maxRuleLines);
       if (value !== undefined) {
         config.maxRuleLines = value;
         await saveFileEditReviewConfig(ctx, config, configPath);
       }
-    } else if (choice === choices[4 + config.reviewers.length]) {
+    } else if (choice === choices[3 + config.reviewers.length]) {
       const added = await addReviewer(ctx, config.reviewers);
       if (added) await saveFileEditReviewConfig(ctx, config, configPath);
     } else if (choice.startsWith("● ") || choice.startsWith("○ ")) {

--- a/packages/pi-tool-supervisor/src/review-utils.ts
+++ b/packages/pi-tool-supervisor/src/review-utils.ts
@@ -6,7 +6,6 @@ import { createTranslator, loadCatalog } from "pi-extensions-i18n";
 const i18n = createTranslator(loadCatalog(new URL("../locales/review-utils.json", import.meta.url)));
 
 const DEFAULT_TIMEOUT_SECONDS = 10;
-const DEFAULT_MAX_CHARS = 10_000;
 const DEFAULT_MAX_RULE_LINES = 100;
 const CONFIG_DIRECTORY = "pi-tool-supervisor";
 const LEGACY_CONFIG_DIRECTORY = "pi-file-edit-review";
@@ -56,7 +55,6 @@ export interface FileEditReviewConfig {
   enabled: boolean;
   reviewers: FileEditReviewReviewerConfig[];
   timeoutSeconds: number;
-  maxOutputChars: number;
   maxRuleLines: number;
 }
 
@@ -206,7 +204,6 @@ export function loadFileEditReviewConfig(
     enabled: false,
     reviewers: [],
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
-    maxOutputChars: DEFAULT_MAX_CHARS,
     maxRuleLines: DEFAULT_MAX_RULE_LINES,
   };
   if (!existsSync(resolvedConfigFile)) {
@@ -257,10 +254,6 @@ export function loadFileEditReviewConfig(
         typeof source.timeoutMs === "number"
           ? Math.max(1, Math.ceil(source.timeoutMs / 1000))
           : DEFAULT_TIMEOUT_SECONDS,
-      ),
-      maxOutputChars: positiveInteger(
-        source.maxOutputChars ?? source.maxChars,
-        DEFAULT_MAX_CHARS,
       ),
       maxRuleLines: positiveInteger(source.maxRuleLines, DEFAULT_MAX_RULE_LINES),
     },

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -44,32 +44,29 @@ test("只加载有效的侧边审查配置，并提供默认参数", async () =>
   const loaded = loadFileEditReviewConfig(configFile);
   assert.equal(loaded.config.enabled, true);
   assert.equal(loaded.config.timeoutSeconds, 10);
-  assert.equal(loaded.config.maxOutputChars, 10000);
   assert.equal(loaded.config.maxRuleLines, 100);
   assert.deepEqual(loaded.config.reviewers[0]?.name, "language");
   assert.deepEqual(loaded.warnings, []);
 });
 
-test("兼容旧 timeoutMs，并支持秒和返回字符上限配置", async () => {
+test("兼容旧 timeoutMs 和当前 timeoutSeconds 配置", async () => {
   const directory = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-timeout-"));
   const configFile = join(directory, "config.json");
   await writeFile(configFile, JSON.stringify({
     enabled: true,
-    timeoutSeconds: 7,
-    maxChars: 3210,
+    timeoutMs: 6500,
     reviewers: [{ model: "provider/model", rulesFile: "rules.md" }],
   }));
   const loaded = loadFileEditReviewConfig(configFile);
   assert.equal(loaded.config.timeoutSeconds, 7);
-  assert.equal(loaded.config.maxOutputChars, 3210);
 
   await writeFile(configFile, JSON.stringify({
     enabled: true,
-    timeoutMs: 2500,
+    timeoutSeconds: 7,
     reviewers: [{ model: "provider/model", rulesFile: "rules.md" }],
   }));
-  const legacyLoaded = loadFileEditReviewConfig(configFile);
-  assert.equal(legacyLoaded.config.timeoutSeconds, 3);
+  const currentLoaded = loadFileEditReviewConfig(configFile);
+  assert.equal(currentLoaded.config.timeoutSeconds, 7);
 });
 
 test("reviewer lifecycle 配置保留旧默认并校验通配工具与非法字段", async () => {
@@ -1070,6 +1067,49 @@ test("custom exact 和 wildcard after 成功审查 input/result，并保留工�
     assert.deepEqual(failed.details.fileEditReview.reviewers.map((reviewer) => reviewer.status), ["skipped", "skipped"]);
   } finally {
     faux.unregister();
+    await handlers.get("session_shutdown")?.();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("未匹配 reviewer 的工具结果保持完整透传", async () => {
+  type TestHandler = (...args: unknown[]) => Promise<unknown> | unknown;
+  const { default: piSupervisorExtension } = await import("../src/index.ts");
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-output-pass-through-"));
+  const handlers = new Map<string, TestHandler>();
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const configDirectory = join(agentDir, "extensions", "pi-tool-supervisor");
+    await mkdir(configDirectory, { recursive: true });
+    await writeFile(join(configDirectory, "config.json"), JSON.stringify({
+      enabled: true,
+      reviewers: [{ name: "edit-only", model: "provider/model", rulesFile: "rules.md", tools: ["edit"], trigger: "after" }],
+    }));
+
+    const pi = {
+      getAllTools: () => [],
+      registerCommand: () => undefined,
+      registerEntryRenderer: () => undefined,
+      appendEntry: () => undefined,
+      on: (event: string, handler: TestHandler) => handlers.set(event, handler),
+    } as unknown as Parameters<typeof piSupervisorExtension>[0];
+    piSupervisorExtension(pi);
+    const context = { cwd: agentDir };
+    const text = "x".repeat(20_000);
+    await handlers.get("tool_call")?.({ toolName: "read", toolCallId: "read-large", input: { path: "large.txt" } }, context);
+    const result = await handlers.get("tool_result")?.({
+      toolName: "read",
+      toolCallId: "read-large",
+      input: { path: "large.txt" },
+      content: [{ type: "text", text }],
+      details: { source: "read" },
+      isError: false,
+    }, context) as { content: Array<{ text?: string }>; details?: Record<string, unknown> };
+    assert.equal(result.content[0]?.text, text);
+    assert.deepEqual(result.details, { source: "read" });
+  } finally {
     await handlers.get("session_shutdown")?.();
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = previousAgentDir;


### PR DESCRIPTION
## Summary

- remove `maxOutputChars` from `pi-tool-supervisor` configuration and interactive UI;
- stop truncating native tool results or writing them to supervisor temporary files;
- keep output handling with Pi or dedicated output extensions, while preserving bounded reviewer payload serialization;
- update documentation, locale entries, and regression coverage.

## Validation

- `npm run check`
- `npm --prefix packages/pi-tool-supervisor run typecheck`
- `npm --prefix packages/pi-tool-supervisor test` (31/31)
- `npm pack --dry-run` in `packages/pi-tool-supervisor`
