### PR TITLE
fix(tool-supervisor): include numbered file context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,7 +1013,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3155,6 +3155,15 @@
         }
       }
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -3967,6 +3976,7 @@
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
+        "diff": "^8.0.4",
         "pi-extensions-i18n": "^0.4.0",
         "pi-extensions-tool-display": "^1.1.0"
       },

--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -11,6 +11,7 @@ An edit tool can complete successfully while the resulting file still violates l
 - Each reviewer selects `tools` and a `trigger`: omitted fields default to `edit`/`write` and `after`; `"*"` matches every built-in or custom tool.
 - Before reviewers inspect the proposed input and an explicit rejection blocks the native Pi tool call; reviewer failures remain fail-open and visible.
 - Captures the file state before `edit` / `write` and the actual file state after the tool result.
+- Sends the real-line-numbered post-edit file with the diff; files above `maxFileContextChars` use bounded excerpts around the first and last changed lines.
 - Supports multiple reviewers running in parallel, each with its own model and one or more rule files.
 - Reads optional front matter from rule files for `enabled`, `filePatterns`, `complexity`, and `consumers`.
 - Returns `passed`, `rejected`, `failed`, or `skipped` status with summaries, findings, rule groups, and durations.
@@ -54,6 +55,7 @@ Start from [`config.example.json`](./config.example.json):
   "enabled": true,
   "timeoutSeconds": 10,
   "maxOutputChars": 10000,
+  "maxFileContextChars": 50000,
   "maxRuleLines": 100,
   "reviewers": [
     {
@@ -76,6 +78,7 @@ Each reviewer must have a `provider/model` reference and either `rulesFile` or `
 | `enabled` | Enables or disables the review layer. |
 | `timeoutSeconds` | Maximum time allowed for each reviewer model call. |
 | `maxOutputChars` | Maximum size of the returned tool result; larger output is written to a temporary file. |
+| `maxFileContextChars` | Maximum post-edit file context sent to reviewers. The default is 50,000 characters; oversized files use bounded, explicitly marked excerpts around changed lines. |
 | `maxRuleLines` | Maximum rule-file size accepted for a single review rule. |
 | `reviewers` | Reviewer name, model, rule files, `tools`, and `trigger`. Missing lifecycle fields keep the legacy `edit`/`write` + `after` behavior. |
 

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -11,6 +11,7 @@
 - 每个 reviewer 可选择 `tools` 与 `trigger`；省略时保持旧默认：`edit`/`write` + `after`，`"*"` 匹配全部内建和自定义工具。
 - before reviewer 审查执行前输入，明确拒绝会通过 Pi 原生机制阻断调用；审查失败仍 fail-open 且可见。
 - 在 `edit` / `write` 前捕获文件状态，在工具返回后读取实际文件状态。
+- 将带真实行号的修改后文件与 diff 一起发送；超过 `maxFileContextChars` 时，截取首次和末次变更附近并明确标记截断。
 - 构建 diff，并只选择规则文件匹配当前变更文件的 reviewer。
 - 支持多个 reviewer 并行执行，每个 reviewer 可以使用自己的模型和一个或多个规则文件。
 - 读取规则文件可选的 front matter：`enabled`、`filePatterns`、`complexity` 和 `consumers`。
@@ -55,6 +56,7 @@ pi install npm:pi-tool-supervisor
   "enabled": true,
   "timeoutSeconds": 10,
   "maxOutputChars": 10000,
+  "maxFileContextChars": 50000,
   "maxRuleLines": 100,
   "reviewers": [
     {
@@ -77,6 +79,7 @@ pi install npm:pi-tool-supervisor
 | `enabled` | 启用或关闭审查层。 |
 | `timeoutSeconds` | 每个 reviewer 模型调用的最长等待时间。 |
 | `maxOutputChars` | 工具结果最大返回长度，超出后写入临时文件。 |
+| `maxFileContextChars` | 发送给 reviewer 的修改后文件上下文上限，默认 50,000 字符；超大文件仅发送首次和末次变更附近的有界片段并明确标记。 |
 | `maxRuleLines` | 单条审查规则允许读取的最大行数。 |
 | `reviewers` | reviewer 名称、模型、规则文件、`tools` 与 `trigger`；省略生命周期字段时保持旧的 `edit`/`write` + `after` 行为。 |
 

--- a/packages/pi-tool-supervisor/SKILL.md
+++ b/packages/pi-tool-supervisor/SKILL.md
@@ -7,7 +7,7 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 ## 诊断
 
-定位实际 Pi agent 目录下的 `extensions/pi-tool-supervisor/config.json`；仅当新路径不存在时读取旧 `extensions/pi-file-edit-review/config.json`。确认顶层 `enabled`、`timeoutSeconds`、`maxOutputChars`、`maxRuleLines`、`reviewers`。
+定位实际 Pi agent 目录下的 `extensions/pi-tool-supervisor/config.json`；仅当新路径不存在时读取旧 `extensions/pi-file-edit-review/config.json`。确认顶层 `enabled`、`timeoutSeconds`、`maxOutputChars`、`maxFileContextChars`、`maxRuleLines`、`reviewers`。
 
 每个 reviewer 必须有 `provider/model` 和唯一的 `rulesFile|rulesFiles`，并检查：
 
@@ -24,7 +24,7 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 - `before` 审查工具输入；明确拒绝会阻断原生工具，失败或跳过则 fail-open 但保持可见；
 - `after` 审查工具结果；拒绝只诊断、不回滚，原工具失败时跳过 after；
-- `edit/write` 使用真实文件前后快照和 diff；其他工具使用有界序列化的 input/result；
+- `edit/write` 使用真实文件前后快照、带真实行号的 diff 和修改后文件上下文；超出 `maxFileContextChars` 时只保留首次与末次变更附近的有界片段并明确标记；其他工具使用有界序列化的 input/result；
 - 带 `filePatterns` 的规则只用于文件审查，通用工具规则不要设置 `filePatterns`；
 - `complexity: context` 或 `consumers` 不含 `editor-review` 的规则不会被本地审查消费。
 

--- a/packages/pi-tool-supervisor/config.example.json
+++ b/packages/pi-tool-supervisor/config.example.json
@@ -2,6 +2,7 @@
   "enabled": true,
   "timeoutSeconds": 10,
   "maxOutputChars": 10000,
+  "maxFileContextChars": 50000,
   "maxRuleLines": 100,
   "reviewers": [
     {

--- a/packages/pi-tool-supervisor/locales/index.json
+++ b/packages/pi-tool-supervisor/locales/index.json
@@ -127,6 +127,10 @@
     "zh-CN": "最终返回最大字符数",
     "en-US": "Maximum final output characters"
   },
+  "fileContextInput": {
+    "zh-CN": "修改后文件上下文最大字符数",
+    "en-US": "Maximum post-edit file context characters"
+  },
   "rulesInput": {
     "zh-CN": "规则文件最大行数",
     "en-US": "Maximum rule file lines"
@@ -134,6 +138,10 @@
   "outputConfig": {
     "zh-CN": "最终返回上限：{value} 字符",
     "en-US": "Final output limit: {value} chars"
+  },
+  "fileContextConfig": {
+    "zh-CN": "修改后文件上下文上限：{value} 字符",
+    "en-US": "Post-edit file context limit: {value} chars"
   },
   "rulesConfig": {
     "zh-CN": "规则最大行数：{value}",

--- a/packages/pi-tool-supervisor/locales/review-utils.json
+++ b/packages/pi-tool-supervisor/locales/review-utils.json
@@ -23,6 +23,10 @@
     "zh-CN": "passed 为 false 时，findings 必须给出 Agent 可以直接修正的具体问题；没有问题时 passed 为 true。",
     "en-US": "When passed is false, findings must contain concrete issues the Agent can fix directly; use passed true when there are no issues."
   },
+  "currentFileGuidance": {
+    "zh-CN": "current-file 是修改后的实际文件内容，行首数字是实际行号。它只用于理解 diff 上下文；仍然只报告 diff 中新增或修改代码的问题。",
+    "en-US": "current-file is the actual post-edit file and each line starts with its real line number. Use it only to understand diff context; report issues only in added or modified diff code."
+  },
   "tool": {
     "zh-CN": "工具：{value}",
     "en-US": "Tool: {value}"

--- a/packages/pi-tool-supervisor/package.json
+++ b/packages/pi-tool-supervisor/package.json
@@ -60,6 +60,7 @@
     "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
   },
   "dependencies": {
+    "diff": "^8.0.4",
     "pi-extensions-i18n": "^0.4.0",
     "pi-extensions-tool-display": "^1.1.0"
   },

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -28,6 +28,7 @@ import {
   registerSupervisorToolDisplayMiddleware,
 } from "./tool-display-bridge.ts";
 import {
+  buildCurrentFileContext,
   buildEditFallbackDiff,
   buildFileEditReviewDiff,
   buildMergedReviewPrompt,
@@ -41,6 +42,7 @@ import {
   reviewerMatchesTool,
   reviewerTrigger,
   safeSerialize,
+  type CurrentFileContext,
   type FileEditReviewAudit,
   type FileEditReviewConfig,
   type FileEditReviewReviewerConfig,
@@ -61,6 +63,12 @@ const WRITE_TOOL = "write";
 const ALL_TOOLS = "*";
 const DEFAULT_REVIEW_TOOLS = [EDIT_TOOL, WRITE_TOOL];
 const REVIEW_TRIGGERS = [BEFORE_TRIGGER, AFTER_TRIGGER];
+const CONFIG_ENABLED_CHOICE_INDEX = 0;
+const CONFIG_TIMEOUT_CHOICE_INDEX = 1;
+const CONFIG_OUTPUT_CHOICE_INDEX = 2;
+const CONFIG_FILE_CONTEXT_CHOICE_INDEX = 3;
+const CONFIG_RULES_CHOICE_INDEX = 4;
+const CONFIG_REVIEWER_CHOICE_OFFSET = 5;
 type ToolResult = {
   content: Array<{ type?: string; text?: string }>;
   details?: Record<string, unknown>;
@@ -237,9 +245,10 @@ async function reviewWithModel(options: {
   toolName: string;
   filePath?: string;
   diff: string;
+  currentFileContext?: CurrentFileContext;
   trigger?: ReviewTrigger;
 }): Promise<FileEditReviewResult> {
-  const { context, config, reviewer, rules, toolName, filePath, diff, trigger = AFTER_TRIGGER } = options;
+  const { context, config, reviewer, rules, toolName, filePath, diff, currentFileContext, trigger = AFTER_TRIGGER } = options;
   const startedAt = performance.now();
   const base = {
     name: reviewer.name,
@@ -281,7 +290,7 @@ async function reviewWithModel(options: {
       {
         messages: [{
           role: "user",
-          content: [{ type: "text", text: buildMergedReviewPrompt({ toolName, filePath, diff, rules, trigger }) }],
+          content: [{ type: "text", text: buildMergedReviewPrompt({ toolName, filePath, diff, currentFileContext, rules, trigger }) }],
           timestamp: Date.now(),
         }],
       },
@@ -426,6 +435,7 @@ async function reviewToolResult(options: {
     };
   }
 
+  const currentFileContext = buildCurrentFileContext(snapshot.before, snapshot.after, config.maxFileContextChars);
   const reviewerGroups = selectedReviewers
     .map((reviewer) => {
       const loaded = loadReviewRules(reviewer, context.ctx.cwd, config.maxRuleLines);
@@ -462,7 +472,16 @@ async function reviewToolResult(options: {
   ];
   const reviewResults = await Promise.all([
     ...applicableGroups.map((group) =>
-      reviewWithModel({ context, config, reviewer: group.reviewer, rules: group.rules, toolName, filePath: snapshot.filePath, diff }),
+      reviewWithModel({
+        context,
+        config,
+        reviewer: group.reviewer,
+        rules: group.rules,
+        toolName,
+        filePath: snapshot.filePath,
+        diff,
+        currentFileContext,
+      }),
     ),
     ...applicableErrors.map((error) => Promise.resolve(error)),
   ]);
@@ -774,6 +793,7 @@ async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: strin
       i18n.t("enabledConfig", { value: config.enabled ? i18n.t("enabled") : i18n.t("disabled") }),
       i18n.t("timeoutConfig", { value: config.timeoutSeconds }),
       i18n.t("outputConfig", { value: config.maxOutputChars }),
+      i18n.t("fileContextConfig", { value: config.maxFileContextChars }),
       i18n.t("rulesConfig", { value: config.maxRuleLines }),
       ...reviewerChoices,
       i18n.t("addReviewer"),
@@ -781,28 +801,34 @@ async function runReviewConfigUi(ctx: ExtensionCommandContext, configPath: strin
     const choice = await ctx.ui.select(i18n.t("configTitle"), choices);
     if (choice === undefined) return;
 
-    if (choice === choices[0]) {
+    if (choice === choices[CONFIG_ENABLED_CHOICE_INDEX]) {
       config.enabled = !config.enabled;
       await saveFileEditReviewConfig(ctx, config, configPath);
-    } else if (choice === choices[1]) {
+    } else if (choice === choices[CONFIG_TIMEOUT_CHOICE_INDEX]) {
       const value = await inputPositiveInteger(ctx, i18n.t("timeoutInput"), config.timeoutSeconds);
       if (value !== undefined) {
         config.timeoutSeconds = value;
         await saveFileEditReviewConfig(ctx, config, configPath);
       }
-    } else if (choice === choices[2]) {
+    } else if (choice === choices[CONFIG_OUTPUT_CHOICE_INDEX]) {
       const value = await inputPositiveInteger(ctx, i18n.t("outputInput"), config.maxOutputChars);
       if (value !== undefined) {
         config.maxOutputChars = value;
         await saveFileEditReviewConfig(ctx, config, configPath);
       }
-    } else if (choice === choices[3]) {
+    } else if (choice === choices[CONFIG_FILE_CONTEXT_CHOICE_INDEX]) {
+      const value = await inputPositiveInteger(ctx, i18n.t("fileContextInput"), config.maxFileContextChars);
+      if (value !== undefined) {
+        config.maxFileContextChars = value;
+        await saveFileEditReviewConfig(ctx, config, configPath);
+      }
+    } else if (choice === choices[CONFIG_RULES_CHOICE_INDEX]) {
       const value = await inputPositiveInteger(ctx, i18n.t("rulesInput"), config.maxRuleLines);
       if (value !== undefined) {
         config.maxRuleLines = value;
         await saveFileEditReviewConfig(ctx, config, configPath);
       }
-    } else if (choice === choices[4 + config.reviewers.length]) {
+    } else if (choice === choices[CONFIG_REVIEWER_CHOICE_OFFSET + config.reviewers.length]) {
       const added = await addReviewer(ctx, config.reviewers);
       if (added) await saveFileEditReviewConfig(ctx, config, configPath);
     } else if (choice.startsWith("● ") || choice.startsWith("○ ")) {

--- a/packages/pi-tool-supervisor/src/review-utils.ts
+++ b/packages/pi-tool-supervisor/src/review-utils.ts
@@ -2,11 +2,16 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import { createTwoFilesPatch } from "diff";
 
 const i18n = createTranslator(loadCatalog(new URL("../locales/review-utils.json", import.meta.url)));
 
 const DEFAULT_TIMEOUT_SECONDS = 10;
 const DEFAULT_MAX_CHARS = 10_000;
+const DEFAULT_MAX_FILE_CONTEXT_CHARS = 50_000;
+const DIFF_CONTEXT_LINES = 3;
+const FILE_CONTEXT_RADIUS_STEPS = [100, 50, 20, 10, 3, 0] as const;
+const OMITTED_RANGE_START_OFFSET = 2;
 const DEFAULT_MAX_RULE_LINES = 100;
 const CONFIG_DIRECTORY = "pi-tool-supervisor";
 const LEGACY_CONFIG_DIRECTORY = "pi-file-edit-review";
@@ -57,6 +62,7 @@ export interface FileEditReviewConfig {
   reviewers: FileEditReviewReviewerConfig[];
   timeoutSeconds: number;
   maxOutputChars: number;
+  maxFileContextChars: number;
   maxRuleLines: number;
 }
 
@@ -72,6 +78,11 @@ export interface FileEditReviewRule {
   content: string;
   lineCount: number;
   warning?: string;
+}
+
+export interface CurrentFileContext {
+  content: string;
+  truncated: boolean;
 }
 
 export interface FileEditReviewFinding {
@@ -207,6 +218,7 @@ export function loadFileEditReviewConfig(
     reviewers: [],
     timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
     maxOutputChars: DEFAULT_MAX_CHARS,
+    maxFileContextChars: DEFAULT_MAX_FILE_CONTEXT_CHARS,
     maxRuleLines: DEFAULT_MAX_RULE_LINES,
   };
   if (!existsSync(resolvedConfigFile)) {
@@ -262,6 +274,7 @@ export function loadFileEditReviewConfig(
         source.maxOutputChars ?? source.maxChars,
         DEFAULT_MAX_CHARS,
       ),
+      maxFileContextChars: positiveInteger(source.maxFileContextChars, DEFAULT_MAX_FILE_CONTEXT_CHARS),
       maxRuleLines: positiveInteger(source.maxRuleLines, DEFAULT_MAX_RULE_LINES),
     },
     configPath: resolvedConfigFile,
@@ -451,33 +464,7 @@ export function loadReviewRules(
   return { rules, errors };
 }
 
-function lineDiff(before: string, after: string): string {
-  const beforeLines = before.split(/\r?\n/);
-  const afterLines = after.split(/\r?\n/);
-  const prefix = beforeLines.length > 0 && beforeLines[beforeLines.length - 1] === "" ? beforeLines.slice(0, -1) : beforeLines;
-  const suffix = afterLines.length > 0 && afterLines[afterLines.length - 1] === "" ? afterLines.slice(0, -1) : afterLines;
-  const commonStart = prefix.findIndex((line, index) => line !== suffix[index]);
-  const start = commonStart === -1 ? Math.min(prefix.length, suffix.length) : commonStart;
-  let commonEnd = 0;
-  while (
-    commonEnd < prefix.length - start &&
-    commonEnd < suffix.length - start &&
-    prefix[prefix.length - 1 - commonEnd] === suffix[suffix.length - 1 - commonEnd]
-  ) {
-    commonEnd += 1;
-  }
-  const contextBefore = prefix.slice(Math.max(0, start - 3), start);
-  const removed = prefix.slice(start, prefix.length - commonEnd);
-  const added = suffix.slice(start, suffix.length - commonEnd);
-  const contextAfter = prefix.slice(prefix.length - commonEnd, prefix.length - commonEnd + 3);
-  return [
-    ...contextBefore.map((line) => ` ${line}`),
-    ...removed.map((line) => `-${line}`),
-    ...added.map((line) => `+${line}`),
-    ...contextAfter.map((line) => ` ${line}`),
-  ].join("\n");
-}
-
+/** Builds the actual before/after file diff used by file reviewers. */
 export function buildFileEditReviewDiff(
   filePath: string,
   before: string | undefined,
@@ -486,12 +473,81 @@ export function buildFileEditReviewDiff(
 ): string {
   if (before !== undefined && after !== undefined && before === after) return "";
   if (before !== undefined && after !== undefined) {
-    return [`--- a/${filePath}`, `+++ b/${filePath}`, "@@", lineDiff(before, after)].join("\n");
+    return createTwoFilesPatch(
+      `a/${filePath}`,
+      `b/${filePath}`,
+      before,
+      after,
+      undefined,
+      undefined,
+      { context: DIFF_CONTEXT_LINES },
+    ).trimEnd();
   }
   if (after !== undefined) {
-    return [`--- /dev/null`, `+++ b/${filePath}`, "@@", after.split(/\r?\n/).map((line) => `+${line}`).join("\n")].join("\n");
+    const lines = after.split(/\r?\n/);
+    if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+    return [`--- /dev/null`, `+++ b/${filePath}`, `@@ -0,0 +1,${lines.length} @@`, ...lines.map((line) => `+${line}`)].join("\n");
   }
   return fallbackDiff;
+}
+
+/** Builds a numbered post-edit file view, bounded around the first and last changed lines for oversized files. */
+export function buildCurrentFileContext(
+  before: string | undefined,
+  after: string | undefined,
+  maxChars: number,
+): CurrentFileContext | undefined {
+  if (after === undefined) return undefined;
+  const afterLines = after.split(/\r?\n/);
+  if (afterLines.length > 0 && afterLines[afterLines.length - 1] === "") afterLines.pop();
+  const numberedLines = afterLines.map((line, index) => `${index + 1} | ${line}`);
+  const fullContent = numberedLines.join("\n");
+  if (fullContent.length <= maxChars) return { content: fullContent, truncated: false };
+
+  const beforeLines = before?.split(/\r?\n/) ?? [];
+  if (beforeLines.length > 0 && beforeLines[beforeLines.length - 1] === "") beforeLines.pop();
+  const commonStart = beforeLines.findIndex((line, index) => line !== afterLines[index]);
+  const start = commonStart === -1 ? Math.min(beforeLines.length, afterLines.length) : commonStart;
+  let commonEnd = 0;
+  while (
+    commonEnd < beforeLines.length - start &&
+    commonEnd < afterLines.length - start &&
+    beforeLines[beforeLines.length - 1 - commonEnd] === afterLines[afterLines.length - 1 - commonEnd]
+  ) {
+    commonEnd += 1;
+  }
+  const changedEnd = Math.max(start + 1, afterLines.length - commonEnd);
+  const lastLineIndex = Math.max(0, afterLines.length - 1);
+  const firstAnchor = Math.min(start, lastLineIndex);
+  const lastAnchor = Math.min(Math.max(start, changedEnd - 1), lastLineIndex);
+  const anchors = [firstAnchor, lastAnchor];
+  let excerptContent = "";
+  for (const radius of FILE_CONTEXT_RADIUS_STEPS) {
+    const selected = new Set<number>();
+    for (const anchor of anchors) {
+      const from = Math.max(0, anchor - radius);
+      const to = Math.min(afterLines.length, anchor + radius + 1);
+      for (let index = from; index < to; index += 1) selected.add(index);
+    }
+    const selectedLines = [...selected].sort((left, right) => left - right);
+    const excerpt: string[] = [];
+    let previous = -1;
+    for (const index of selectedLines) {
+      if (previous >= 0 && index > previous + 1) {
+        excerpt.push(`... lines ${previous + OMITTED_RANGE_START_OFFSET}-${index} omitted ...`);
+      }
+      excerpt.push(numberedLines[index]);
+      previous = index;
+    }
+    excerptContent = excerpt.join("\n");
+    if (excerptContent.length <= maxChars) return { content: excerptContent, truncated: true };
+  }
+  const truncationMarker = "\n... file context truncated ...";
+  if (maxChars <= truncationMarker.length) {
+    return { content: truncationMarker.slice(0, maxChars), truncated: true };
+  }
+  const boundedContent = `${excerptContent.slice(0, maxChars - truncationMarker.length)}${truncationMarker}`;
+  return { content: boundedContent, truncated: true };
 }
 
 export function buildEditFallbackDiff(params: Record<string, unknown>): string {
@@ -510,6 +566,7 @@ export function buildMergedReviewPrompt(options: {
   toolName: string;
   filePath?: string;
   diff: string;
+  currentFileContext?: CurrentFileContext;
   rules: FileEditReviewRule[];
   trigger?: ReviewTrigger;
 }): string;
@@ -517,10 +574,11 @@ export function buildMergedReviewPrompt(options: {
   toolName: string;
   filePath?: string;
   diff: string;
+  currentFileContext?: CurrentFileContext;
   rules: FileEditReviewRule[];
   trigger?: ReviewTrigger;
 }): string {
-  const { toolName, filePath, diff, rules, trigger = DEFAULT_REVIEW_TRIGGER } = options;
+  const { toolName, filePath, diff, currentFileContext, rules, trigger = DEFAULT_REVIEW_TRIGGER } = options;
   const ruleBlocks = rules.flatMap((rule) => [
     `<rules name="${rule.reviewer.name}">`,
     rule.content,
@@ -544,6 +602,13 @@ export function buildMergedReviewPrompt(options: {
     "<diff>",
     diff,
     "</diff>",
+    ...(currentFileContext ? [
+      "",
+      i18n.t("currentFileGuidance"),
+      `<current-file truncated="${String(currentFileContext.truncated)}">`,
+      currentFileContext.content,
+      "</current-file>",
+    ] : []),
   ].join("\n");
 }
 

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -16,6 +16,7 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildCurrentFileContext,
   buildFileEditReviewDiff,
   buildGenericReviewPrompt,
   buildMergedReviewPrompt,
@@ -45,23 +46,26 @@ test("只加载有效的侧边审查配置，并提供默认参数", async () =>
   assert.equal(loaded.config.enabled, true);
   assert.equal(loaded.config.timeoutSeconds, 10);
   assert.equal(loaded.config.maxOutputChars, 10000);
+  assert.equal(loaded.config.maxFileContextChars, 50000);
   assert.equal(loaded.config.maxRuleLines, 100);
   assert.deepEqual(loaded.config.reviewers[0]?.name, "language");
   assert.deepEqual(loaded.warnings, []);
 });
 
-test("兼容旧 timeoutMs，并支持秒和返回字符上限配置", async () => {
+test("兼容旧 timeoutMs，并支持秒、返回字符和文件上下文上限配置", async () => {
   const directory = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-timeout-"));
   const configFile = join(directory, "config.json");
   await writeFile(configFile, JSON.stringify({
     enabled: true,
     timeoutSeconds: 7,
     maxChars: 3210,
+    maxFileContextChars: 43210,
     reviewers: [{ model: "provider/model", rulesFile: "rules.md" }],
   }));
   const loaded = loadFileEditReviewConfig(configFile);
   assert.equal(loaded.config.timeoutSeconds, 7);
   assert.equal(loaded.config.maxOutputChars, 3210);
+  assert.equal(loaded.config.maxFileContextChars, 43210);
 
   await writeFile(configFile, JSON.stringify({
     enabled: true,
@@ -289,8 +293,20 @@ test("规则文件超过 100 行时返回警告", async () => {
 test("生成实际文件 diff 并解析结构化审查结果", () => {
   const diff = buildFileEditReviewDiff("src/app.ts", "const lang = 'en';\n", "const lang = 'zh';\n");
   assert.match(diff, /--- a\/src\/app\.ts/);
+  assert.match(diff, /@@ -1,1 \+1,1 @@/);
   assert.match(diff, /-const lang = 'en';/);
   assert.match(diff, /\+const lang = 'zh';/);
+  const newFileDiff = buildFileEditReviewDiff("src/new.ts", undefined, "first\nsecond\n");
+  assert.match(newFileDiff, /@@ -0,0 \+1,2 @@/);
+  assert.match(newFileDiff, /\+second$/);
+
+  const beforeLines = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`);
+  const afterLines = [...beforeLines];
+  afterLines[1] = "changed 2";
+  afterLines[17] = "changed 18";
+  const multiHunkDiff = buildFileEditReviewDiff("src/multi.ts", beforeLines.join("\n"), afterLines.join("\n"));
+  assert.equal(multiHunkDiff.match(/^@@/gm)?.length, 2);
+  assert.doesNotMatch(multiHunkDiff, /^[+-]line 10$/m);
 
   const parsed = parseReviewResponse(JSON.stringify({
     passed: false,
@@ -300,6 +316,37 @@ test("生成实际文件 diff 并解析结构化审查结果", () => {
   assert.equal(parsed.passed, false);
   assert.equal(parsed.findings[0]?.line, 3);
   assert.equal(parsed.findings[0]?.ruleGroup, "coding-taste");
+});
+
+test("修改后文件上下文携带真实行号，并围绕大文件变更位置有界截取", () => {
+  const full = buildCurrentFileContext("first\nsecond\n", "first\nchanged\n", 50000);
+  assert.deepEqual(full, { content: "1 | first\n2 | changed", truncated: false });
+
+  const beforeLines = Array.from({ length: 300 }, (_, index) => `line ${index + 1}`);
+  const afterLines = [...beforeLines];
+  afterLines[249] = "changed line";
+  const bounded = buildCurrentFileContext(`${beforeLines.join("\n")}\n`, `${afterLines.join("\n")}\n`, 1000);
+  assert.equal(bounded?.truncated, true);
+  assert.match(bounded?.content ?? "", /250 \| changed line/);
+  assert.ok((bounded?.content.length ?? 0) <= 1000);
+
+  const tiny = buildCurrentFileContext("before\n", `${"x".repeat(100)}\n`, 10);
+  assert.equal(tiny?.truncated, true);
+  assert.ok((tiny?.content.length ?? 0) <= 10);
+});
+
+test("review prompt 同时包含 diff 和带截断标记的修改后文件", () => {
+  const rules = [{ reviewer: { name: "file", model: "p/m", rulesFile: "rules.md" }, absolutePath: "rules.md", content: "只审查修改代码", lineCount: 1 }];
+  const prompt = buildMergedReviewPrompt({
+    toolName: "write",
+    filePath: "src/app.ts",
+    diff: "+const value = 2;",
+    currentFileContext: { content: "8 | const value = 2;", truncated: true },
+    rules,
+  });
+  assert.match(prompt, /<current-file truncated="true">/);
+  assert.match(prompt, /8 \| const value = 2;/);
+  assert.match(prompt, /只报告 diff 中新增或修改代码的问题/);
 });
 
 test("审查结果状态优先级为 rejected、failed、passed", () => {
@@ -999,6 +1046,8 @@ test("edit/write after 使用实际快照 diff，并在无变化时跳过模型"
     assert.equal(changed.details.fileEditReview.status, "passed");
     assert.match(prompts[0], /-const value = 1;/);
     assert.match(prompts[0], /\+const value = 2;/);
+    assert.match(prompts[0], /<current-file truncated=\\"false\\">/);
+    assert.match(prompts[0], /1 \| const value = 2;/);
 
     await handlers.get("tool_call")?.({ toolName: "write", toolCallId: "write-same", input: { path: "example.ts", content: "const value = 2;\n" } }, context);
     const unchanged = await handlers.get("tool_result")?.({ toolName: "write", toolCallId: "write-same", input: { path: "example.ts", content: "const value = 2;\n" }, content: [{ type: "text", text: "unchanged" }], details: {}, isError: false }, context) as { details: { fileEditReview: { status: string } } };


### PR DESCRIPTION
## Problem

File reviewers received only a coarse diff with three context lines and no real line-numbered post-edit file. Multiple distant edits could also mark unchanged middle content as changed, causing missed context and false findings.

## Changes

- attach the actual post-edit file with real line numbers to reviewer prompts
- bound file context with configurable `maxFileContextChars` (default 50,000), using explicit excerpts around the first and last changes for oversized files
- generate standard multi-hunk unified diffs with accurate line ranges
- expose the new setting in `/config:tool-supervisor`
- update English/Chinese docs, config example, skill guidance, and focused tests

## Validation

- `npm --workspace packages/pi-tool-supervisor run check`
- `npm run check` — 11 workspaces, 1121 tests passed, 0 failed
