### PR TITLE
fix: use public npm registry in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3157,7 +3157,7 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmmirror.com/diff/-/diff-8.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
       "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {


### PR DESCRIPTION
## Summary

- fix the root lockfile entry for `diff@8.0.4`
- use `registry.npmjs.org` instead of the local `npmmirror` tarball URL
- allow the release workflow's npm 12 `npm ci` step to run on GitHub Actions

## Root cause

The release workflow failed all `publish-npm` jobs during `npm ci` with `EALLOWREMOTE` because `package-lock.json` resolved `diff@8.0.4` from `https://registry.npmmirror.com/...`.

## Validation

- `npx --yes npm@12.0.2 ci --registry=https://registry.npmjs.org`
- `npm run check`
- verified no `registry.npmmirror.com` URL remains outside ignored dependencies
