### PR TITLE
feat(tool-supervisor): 支持条件模块审查

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2348,7 +2348,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2365,7 +2364,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,7 +2380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,7 +2396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2416,7 +2412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2433,7 +2428,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2450,7 +2444,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2467,7 +2460,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2484,7 +2476,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2501,7 +2492,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,7 +2508,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,7 +2524,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,7 +2540,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2569,7 +2556,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2586,7 +2572,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2603,7 +2588,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2620,7 +2604,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,7 +2620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2654,7 +2636,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2671,7 +2652,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,7 +2668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2705,7 +2684,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2722,7 +2700,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2739,7 +2716,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2756,7 +2732,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2773,7 +2748,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3177,7 +3151,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3282,7 +3255,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3649,7 +3621,6 @@
       "version": "4.23.1",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -3682,6 +3653,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.10.tgz",
+      "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/undici-types": {
@@ -3978,14 +3958,15 @@
       "dependencies": {
         "diff": "^8.0.4",
         "pi-extensions-i18n": "^0.4.0",
-        "pi-extensions-tool-display": "^1.1.0"
+        "pi-extensions-tool-display": "^1.1.0",
+        "tsx": "^4.23.1",
+        "unbash": "^4.0.10"
       },
       "devDependencies": {
         "@earendil-works/pi-ai": "0.80.10",
         "@earendil-works/pi-coding-agent": "0.80.10",
         "@earendil-works/pi-tui": "0.80.10",
         "@types/node": "24.12.4",
-        "tsx": "4.23.1",
         "typescript": "5.9.3"
       },
       "engines": {

--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -8,8 +8,8 @@ An edit tool can complete successfully while the resulting file still violates l
 
 ## How it works
 
-- Each reviewer selects `tools` and a `trigger`: omitted fields default to `edit`/`write` and `after`; `"*"` matches every built-in or custom tool.
-- Before reviewers inspect the proposed input and an explicit rejection blocks the native Pi tool call; reviewer failures remain fail-open and visible.
+- Each reviewer selects `tools`, a `trigger`, and optionally a local `condition` module: omitted fields default to `edit`/`write` + `after`, and `"*"` matches every built-in or custom tool.
+- Before reviewers inspect the proposed input and an explicit rejection blocks the native Pi tool call; model failures remain fail-open and visible, while condition module failures block the before call.
 - Captures the file state before `edit` / `write` and the actual file state after the tool result.
 - Sends the real-line-numbered post-edit file with the diff; files above `maxFileContextChars` use bounded excerpts around the first and last changed lines.
 - Supports multiple reviewers running in parallel, each with its own model and one or more rule files.
@@ -65,13 +65,14 @@ Start from [`config.example.json`](./config.example.json):
         "/absolute/path/to/rules.md"
       ],
       "tools": ["edit", "write"],
-      "trigger": "after"
+      "trigger": "after",
+      "condition": "/absolute/path/to/condition.ts"
     }
   ]
 }
 ```
 
-Each reviewer must have a `provider/model` reference and either `rulesFile` or `rulesFiles`. Relative rule-file paths are resolved from the current project working directory.
+Each reviewer must have a `provider/model` reference and either `rulesFile` or `rulesFiles`. Relative rule-file and condition-module paths are resolved from the current project working directory.
 
 | Setting | Meaning |
 | --- | --- |
@@ -79,7 +80,8 @@ Each reviewer must have a `provider/model` reference and either `rulesFile` or `
 | `timeoutSeconds` | Maximum time allowed for each reviewer model call. |
 | `maxFileContextChars` | Maximum post-edit file context sent to reviewers. The default is 50,000 characters; oversized files use bounded, explicitly marked excerpts around changed lines. |
 | `maxRuleLines` | Maximum rule-file size accepted for a single review rule. |
-| `reviewers` | Reviewer name, model, rule files, `tools`, and `trigger`. Missing lifecycle fields keep the legacy `edit`/`write` + `after` behavior. |
+| `condition` | Optional local TypeScript/ESM module path. Its default export receives the native Pi tool event, `ExtensionContext`, and `ToolConditionHelpers`; returning `false` skips this reviewer without a model call. |
+| `reviewers` | Reviewer name, model, rule files, `tools`, `trigger`, and optional condition module. Missing lifecycle fields keep the legacy `edit`/`write` + `after` behavior. |
 
 Rule-file front matter can scope a rule to particular files or consumers:
 
@@ -97,9 +99,41 @@ consumers:
 
 `filePatterns` uses a simplified glob syntax: `*` does not cross `/`, `**` does, and `**/` at any position matches zero or more directory levels. Backslashes are normalized to `/`, and a leading `./` is ignored.
 
+### Condition modules
+
+A reviewer may set `condition` to a local TypeScript or ESM module path. Relative paths resolve from the current project working directory, and `~` is expanded using the Pi home directory. The module must export a default synchronous or asynchronous function:
+
+```ts
+import type {
+  ExtensionContext,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import type { ToolConditionHelpers } from "pi-tool-supervisor";
+
+export default function condition(
+  event: ToolCallEvent,
+  ctx: ExtensionContext,
+  helpers: ToolConditionHelpers,
+): boolean {
+  if (event.toolName !== "bash") return false;
+  const command = event.input.command;
+  if (typeof command !== "string") return false;
+
+  // The native event and context are available for custom policy.
+  const ast = helpers.parseBash(command);
+  return ast.errors?.length === 0 && ast.commands.some((statement) =>
+    statement.command.type === "Command" && statement.command.name?.value === "mvn",
+  );
+}
+```
+
+The first argument is the original `tool_call` event for `before` reviewers or the original `tool_result` event for `after` reviewers. The second argument is the native `ExtensionContext`, with the same capabilities available to other Pi extensions. A third helper argument provides `parseBash(source)` without requiring the condition module to resolve supervisor internals.
+
+A condition returning `false` skips the reviewer without loading its rules or calling its model. A module load error, execution error, non-boolean result, or timeout is visible; `before` treats it as a failed gate and blocks the tool. Use `trigger: "before"` when a rejected review must prevent execution; `after` remains diagnostic only.
+
 ## Review semantics
 
-- A before reviewer rejection blocks the native tool call and emits a standalone audit with the complete reason; before failures/skips are fail-open but remain visible on the next tool result.
+- A before reviewer rejection blocks the native tool call and emits a standalone audit with the complete reason; model failures/skips remain fail-open and visible on the next tool result. Condition module load or execution failures are treated as a failed gate and block the before call.
 - An after rejection is diagnostic only and never rolls back a completed tool call; a failed tool skips after review and preserves the original error.
 - If the parent Agent request is interrupted, every in-flight reviewer model request is cancelled together; reviewers not yet started are skipped, and parent cancellation is reported as skipped rather than as a provider failure.
 - A failed tool call or an unchanged file is skipped.

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -8,8 +8,8 @@
 
 ## 工作方式
 
-- 每个 reviewer 可选择 `tools` 与 `trigger`；省略时保持旧默认：`edit`/`write` + `after`，`"*"` 匹配全部内建和自定义工具。
-- before reviewer 审查执行前输入，明确拒绝会通过 Pi 原生机制阻断调用；审查失败仍 fail-open 且可见。
+- 每个 reviewer 可选择 `tools`、`trigger`，并可选配置本地 `condition` 模块；省略时保持旧默认：`edit`/`write` + `after`，`"*"` 匹配全部内建和自定义工具。
+- before reviewer 审查执行前输入，明确拒绝会通过 Pi 原生机制阻断调用；模型审查失败仍 fail-open 且可见，condition 模块加载或执行失败会阻断 before 调用。
 - 在 `edit` / `write` 前捕获文件状态，在工具返回后读取实际文件状态。
 - 将带真实行号的修改后文件与 diff 一起发送；超过 `maxFileContextChars` 时，截取首次和末次变更附近并明确标记截断。
 - 构建 diff，并只选择规则文件匹配当前变更文件的 reviewer。
@@ -66,13 +66,14 @@ pi install npm:pi-tool-supervisor
         "/absolute/path/to/rules.md"
       ],
       "tools": ["edit", "write"],
-      "trigger": "after"
+      "trigger": "after",
+      "condition": "/absolute/path/to/condition.ts"
     }
   ]
 }
 ```
 
-每个 reviewer 必须提供 `provider/model` 格式的模型，并提供 `rulesFile` 或 `rulesFiles`。相对规则文件路径按当前项目工作目录解析。
+每个 reviewer 必须提供 `provider/model` 格式的模型，并提供 `rulesFile` 或 `rulesFiles`。相对规则文件和 condition 模块路径按当前项目工作目录解析。
 
 | 配置项 | 含义 |
 | --- | --- |
@@ -80,7 +81,8 @@ pi install npm:pi-tool-supervisor
 | `timeoutSeconds` | 每个 reviewer 模型调用的最长等待时间。 |
 | `maxFileContextChars` | 发送给 reviewer 的修改后文件上下文上限，默认 50,000 字符；超大文件仅发送首次和末次变更附近的有界片段并明确标记。 |
 | `maxRuleLines` | 单条审查规则允许读取的最大行数。 |
-| `reviewers` | reviewer 名称、模型、规则文件、`tools` 与 `trigger`；省略生命周期字段时保持旧的 `edit`/`write` + `after` 行为。 |
+| `reviewers` | reviewer 名称、模型、规则文件、`tools`、`trigger` 和可选的 condition 模块；省略生命周期字段时保持旧的 `edit`/`write` + `after` 行为。 |
+| `condition` | 可选的本地 TypeScript/ESM 模块路径。默认导出函数会收到 Pi 原生工具事件、`ExtensionContext` 和 `ToolConditionHelpers`；返回 `false` 时跳过该 reviewer，不调用模型。 |
 
 规则文件可以通过 front matter 限定适用文件或消费者：
 
@@ -98,9 +100,41 @@ consumers:
 
 `filePatterns` 使用简化 glob：`*` 不跨 `/`，`**` 可以跨目录，任意位置的 `**/` 都可匹配零层或多层目录。反斜杠会归一化为 `/`，开头的 `./` 会被忽略。
 
+### Condition 模块
+
+reviewer 可以将 `condition` 设置为本地 TypeScript 或 ESM 模块路径。相对路径按当前项目工作目录解析，`~` 会按 Pi home 目录展开。模块必须默认导出一个同步或异步函数：
+
+```ts
+import type {
+  ExtensionContext,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import type { ToolConditionHelpers } from "pi-tool-supervisor";
+
+export default function condition(
+  event: ToolCallEvent,
+  ctx: ExtensionContext,
+  helpers: ToolConditionHelpers,
+): boolean {
+  if (event.toolName !== "bash") return false;
+  const command = event.input.command;
+  if (typeof command !== "string") return false;
+
+  // 可以直接使用 Pi 原生 event/context；解析器是可选辅助。
+  const ast = helpers.parseBash(command);
+  return ast.errors?.length === 0 && ast.commands.some((statement) =>
+    statement.command.type === "Command" && statement.command.name?.value === "mvn",
+  );
+}
+```
+
+第一个参数是 `before` reviewer 收到的原始 `tool_call` 事件，或 `after` reviewer 收到的原始 `tool_result` 事件。第二个参数是原生 `ExtensionContext`，condition 模块可以使用其他 Pi 插件能使用的 context 能力。第三个参数提供 `parseBash(source)`。
+
+condition 返回 `false` 时跳过该 reviewer，不读取其规则文件，也不调用模型。模块加载失败、执行失败、返回非 boolean 或超时会生成可见错误；`before` 会将其视为审查门禁失败并阻断工具。需要阻断工具时使用 `trigger: "before"`，`after` 仍然只提供诊断。
+
 ## 审查语义
 
-- before reviewer 明确拒绝会阻断 Pi 原生工具调用，并用完整 reason 展示独立审计；before 失败/跳过会放行，但会在后续 tool result 中可见。
+- before reviewer 明确拒绝会阻断 Pi 原生工具调用，并用完整 reason 展示独立审计；模型失败/跳过会放行但保持可见，condition 模块加载或执行失败会阻断 before 调用。
 - after 拒绝只提供诊断，不回滚已完成的工具调用；工具失败时跳过 after 审查并保留原始错误。
 - 如果用户打断上级 Agent 请求，所有尚未完成的 reviewer 模型请求会一起取消，尚未发起的 reviewer 会跳过；上级中断记为 skipped，而不是模型调用失败。
 - 工具调用失败或文件内容没有变化时跳过审查。

--- a/packages/pi-tool-supervisor/SKILL.md
+++ b/packages/pi-tool-supervisor/SKILL.md
@@ -13,16 +13,17 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 - `tools`：精确工具名数组，`["*"]` 匹配全部内建和自定义工具；省略时为 `edit/write`；
 - `trigger`：`before|after`，省略时为 `after`；
+- `condition`：可选本地 TypeScript/ESM 模块路径。模块默认导出函数，收到原生 tool event、`ExtensionContext` 和 `ToolConditionHelpers`；返回 `false` 时跳过 reviewer；
 - reviewer `enabled`；
 - 规则 frontmatter 的 `enabled`、`filePatterns`、`complexity`、`consumers`。
 
-相对规则路径从当前项目 cwd 解析。配置在每次工具调用前重读。
+相对规则文件路径和 condition 模块路径从当前项目 cwd 解析。配置在每次工具调用前重读。
 
 ## 修改
 
 优先使用 `/config:tool-supervisor`；`/pi-tool-supervisor` 是兼容别名。只修改目标 reviewer 和规则：
 
-- `before` 审查工具输入；明确拒绝会阻断原生工具，失败或跳过则 fail-open 但保持可见；
+- `before` 审查工具输入；明确拒绝会阻断原生工具，模型失败或跳过则 fail-open 但保持可见，condition 模块加载或执行失败则阻断 before 调用；
 - `after` 审查工具结果；拒绝只诊断、不回滚，原工具失败时跳过 after；
 - `edit/write` 使用真实文件前后快照、带真实行号的 diff 和修改后文件上下文；超出 `maxFileContextChars` 时只保留首次与末次变更附近的有界片段并明确标记；其他工具使用有界序列化的 input/result；
 - 带 `filePatterns` 的规则只用于文件审查，通用工具规则不要设置 `filePatterns`；
@@ -32,4 +33,4 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 ## 验证
 
-先回读配置和所有规则，确认模型、路径、生命周期与文件匹配。再按目标触发一个最小工具调用：before 拒绝应阻断；after 拒绝应保留原结果并附诊断；模型失败应可见且 fail-open。未运行真实工具/模型审查时报告 `NOT_RUN`，不能用 JSON 可解析冒充已生效。
+先回读配置和所有规则，确认模型、路径、生命周期、condition 模块与文件匹配。再按目标触发一个最小工具调用：before 拒绝应阻断；after 拒绝应保留原结果并附诊断；condition 返回 false 应跳过模型；模型失败应可见且按 fail-open 处理。未运行真实工具/模型审查时报告 `NOT_RUN`，不能用 JSON 可解析冒充已生效。

--- a/packages/pi-tool-supervisor/config.example.json
+++ b/packages/pi-tool-supervisor/config.example.json
@@ -11,7 +11,8 @@
         "/absolute/path/to/rules.md"
       ],
       "tools": ["edit", "write"],
-      "trigger": "after"
+      "trigger": "after",
+      "condition": "/absolute/path/to/condition.ts"
     }
   ]
 }

--- a/packages/pi-tool-supervisor/index.ts
+++ b/packages/pi-tool-supervisor/index.ts
@@ -1,1 +1,12 @@
 export { default } from "./src/index.ts";
+export type {
+  ToolCondition,
+  ToolConditionEvent,
+  ToolConditionHelpers,
+  ToolConditionEvaluation,
+} from "./src/condition-utils.ts";
+export type {
+  ExtensionContext,
+  ToolCallEvent,
+  ToolResultEvent,
+} from "@earendil-works/pi-coding-agent";

--- a/packages/pi-tool-supervisor/locales/index.json
+++ b/packages/pi-tool-supervisor/locales/index.json
@@ -75,6 +75,18 @@
     "zh-CN": "触发阶段",
     "en-US": "Trigger"
   },
+  "conditionConfig": {
+    "zh-CN": "条件模块：{value}",
+    "en-US": "Condition module: {value}"
+  },
+  "conditionNone": {
+    "zh-CN": "始终匹配",
+    "en-US": "Always matches"
+  },
+  "conditionInput": {
+    "zh-CN": "条件模块路径（留空禁用）",
+    "en-US": "Condition module path (empty to disable)"
+  },
   "deleteReviewer": {
     "zh-CN": "删除此审查器",
     "en-US": "Delete this reviewer"
@@ -170,5 +182,13 @@
   "beforeReviewRejectedFallback": {
     "zh-CN": "工具 {toolName} 未通过前置审查。",
     "en-US": "Tool {toolName} did not pass the before review."
+  },
+  "conditionNotMatched": {
+    "zh-CN": "条件未匹配，跳过该审查器。",
+    "en-US": "The condition did not match; this reviewer was skipped."
+  },
+  "conditionFailed": {
+    "zh-CN": "条件模块 {path} 执行失败：{message}",
+    "en-US": "Condition module {path} failed: {message}"
   }
 }

--- a/packages/pi-tool-supervisor/locales/review-utils.json
+++ b/packages/pi-tool-supervisor/locales/review-utils.json
@@ -75,6 +75,10 @@
     "zh-CN": "审查配置 reviewers[{index}].trigger 无效，必须是 before 或 after。",
     "en-US": "Review configuration reviewers[{index}].trigger is invalid; it must be before or after."
   },
+  "invalidConditionConfig": {
+    "zh-CN": "审查配置 reviewers[{index}].condition 无效，必须是非空条件模块路径。",
+    "en-US": "Review configuration reviewers[{index}].condition is invalid; it must be a non-empty condition module path."
+  },
   "cannotSerializeToolInput": {
     "zh-CN": "工具输入无法序列化为 JSON。",
     "en-US": "The tool input could not be serialized to JSON."

--- a/packages/pi-tool-supervisor/package.json
+++ b/packages/pi-tool-supervisor/package.json
@@ -17,7 +17,7 @@
     "SKILL.md"
   ],
   "scripts": {
-    "test": "tsx --test tests/pi-tool-supervisor.test.ts",
+    "test": "tsx --test tests/condition-utils.test.ts tests/condition-integration.test.ts tests/pi-tool-supervisor.test.ts",
     "typecheck": "tsc --noEmit --pretty false",
     "build": "npm run typecheck",
     "check": "npm run typecheck && npm test && npm pack --dry-run --json > /dev/null"
@@ -62,14 +62,15 @@
   "dependencies": {
     "diff": "^8.0.4",
     "pi-extensions-i18n": "^0.4.0",
-    "pi-extensions-tool-display": "^1.1.0"
+    "pi-extensions-tool-display": "^1.1.0",
+    "tsx": "^4.23.1",
+    "unbash": "^4.0.10"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "0.80.10",
     "@earendil-works/pi-coding-agent": "0.80.10",
     "@earendil-works/pi-tui": "0.80.10",
     "@types/node": "24.12.4",
-    "tsx": "4.23.1",
     "typescript": "5.9.3"
   }
 }

--- a/packages/pi-tool-supervisor/src/condition-utils.ts
+++ b/packages/pi-tool-supervisor/src/condition-utils.ts
@@ -1,0 +1,148 @@
+import type {
+  ExtensionContext,
+  ToolCallEvent,
+  ToolResultEvent,
+} from "@earendil-works/pi-coding-agent";
+import { statSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import { tsImport } from "tsx/esm/api";
+import { parse, type ParsedScript } from "unbash";
+import { resolveRulesFilePath } from "./review-utils.ts";
+
+const CONDITION_CACHE_QUERY = "piToolSupervisorCondition";
+const CONDITION_RETURN_ERROR = "Condition module must return a boolean";
+const CONDITION_TIMEOUT_ERROR = "Condition module timed out";
+export const CONDITION_MATCHED_STATUS = "matched" as const;
+export const CONDITION_NOT_MATCHED_STATUS = "not-matched" as const;
+export const CONDITION_ERROR_STATUS = "error" as const;
+
+export type ToolConditionEvent = ToolCallEvent | ToolResultEvent;
+
+/** Helpers exposed to condition modules without requiring them to resolve supervisor dependencies. */
+export interface ToolConditionHelpers {
+  /** Parses Bash without executing it, returning the tolerant AST and parse errors. */
+  parseBash(source: string): ParsedScript;
+}
+
+/** A configured condition receives the native Pi event and extension context unchanged. */
+export type ToolCondition = (
+  event: ToolConditionEvent,
+  ctx: ExtensionContext,
+  helpers: ToolConditionHelpers,
+) => boolean | Promise<boolean>;
+
+export interface ToolConditionEvaluation {
+  status: typeof CONDITION_MATCHED_STATUS | typeof CONDITION_NOT_MATCHED_STATUS | typeof CONDITION_ERROR_STATUS;
+  path?: string;
+  durationMs: number;
+  error?: string;
+}
+
+interface ConditionModuleCacheEntry {
+  fingerprint: string;
+  condition: ToolCondition;
+}
+
+interface EvaluateConditionOptions {
+  conditionPath?: string;
+  cwd: string;
+  event: ToolConditionEvent;
+  ctx: ExtensionContext;
+  timeoutMs: number;
+}
+
+interface InvokeConditionOptions {
+  condition: ToolCondition;
+  event: ToolConditionEvent;
+  ctx: ExtensionContext;
+  timeoutMs: number;
+}
+
+const conditionModuleCache = new Map<string, ConditionModuleCacheEntry>();
+const conditionHelpers: ToolConditionHelpers = Object.freeze({ parseBash: parse });
+
+/** Loads and executes a configured condition module, returning an explicit evaluation state. */
+export async function evaluateToolCondition(
+  options: EvaluateConditionOptions,
+): Promise<ToolConditionEvaluation> {
+  if (!options.conditionPath) {
+    return { status: CONDITION_MATCHED_STATUS, durationMs: 0 };
+  }
+
+  const startedAt = performance.now();
+  const absolutePath = resolveRulesFilePath(options.conditionPath, options.cwd);
+  try {
+    const condition = await loadConditionModule(absolutePath);
+    const matched = await invokeCondition({
+      condition,
+      event: options.event,
+      ctx: options.ctx,
+      timeoutMs: options.timeoutMs,
+    });
+    return {
+      status: matched ? CONDITION_MATCHED_STATUS : CONDITION_NOT_MATCHED_STATUS,
+      path: absolutePath,
+      durationMs: Math.round(performance.now() - startedAt),
+    };
+  } catch (error) {
+    return {
+      status: CONDITION_ERROR_STATUS,
+      path: absolutePath,
+      durationMs: Math.round(performance.now() - startedAt),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/** Resolves a condition module and reloads it when its file fingerprint changes. */
+async function loadConditionModule(absolutePath: string): Promise<ToolCondition> {
+  const stats = statSync(absolutePath);
+  if (!stats.isFile()) throw new Error("Condition module path is not a file");
+
+  const fingerprint = `${stats.mtimeMs}:${stats.size}`;
+  const cached = conditionModuleCache.get(absolutePath);
+  if (cached?.fingerprint === fingerprint) return cached.condition;
+
+  const moduleUrl = `${pathToFileURL(absolutePath).href}?${CONDITION_CACHE_QUERY}=${encodeURIComponent(fingerprint)}`;
+  const loaded: unknown = await tsImport(moduleUrl, import.meta.url);
+  const candidate = getConditionExport(loaded);
+  if (typeof candidate !== "function") throw new Error("Condition module must export a default function");
+
+  const condition = candidate as ToolCondition;
+  conditionModuleCache.set(absolutePath, { fingerprint, condition });
+  return condition;
+}
+
+/** Executes a condition with the configured timeout while preserving the native callback arguments. */
+async function invokeCondition(options: InvokeConditionOptions): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      Promise.resolve().then(() => options.condition(options.event, options.ctx, conditionHelpers)),
+      new Promise<boolean>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(CONDITION_TIMEOUT_ERROR)), options.timeoutMs);
+      }),
+    ]);
+    if (typeof result !== "boolean") throw new Error(CONDITION_RETURN_ERROR);
+    return result;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** Reads the default function across native ESM and TypeScript CJS interop shapes. */
+function getConditionExport(value: unknown): unknown {
+  if (!isRecord(value)) return undefined;
+  const candidates = [value.default, value["module.exports"]];
+  for (const candidate of candidates) {
+    if (typeof candidate === "function") return candidate;
+    if (isRecord(candidate) && typeof candidate.default === "function") return candidate.default;
+  }
+  return undefined;
+}
+
+/** Narrows an unknown module namespace to a record before reading its default export. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -27,6 +27,13 @@ import {
   registerSupervisorToolDisplayMiddleware,
 } from "./tool-display-bridge.ts";
 import {
+  CONDITION_MATCHED_STATUS,
+  CONDITION_NOT_MATCHED_STATUS,
+  evaluateToolCondition,
+  type ToolConditionEvent,
+} from "./condition-utils.ts";
+
+import {
   buildCurrentFileContext,
   buildEditFallbackDiff,
   buildFileEditReviewDiff,
@@ -68,6 +75,11 @@ const CONFIG_TIMEOUT_CHOICE_INDEX = 1;
 const CONFIG_FILE_CONTEXT_CHOICE_INDEX = 2;
 const CONFIG_RULES_CHOICE_INDEX = 3;
 const CONFIG_REVIEWER_CHOICE_OFFSET = 4;
+const REVIEWER_CONDITION_CHOICE_INDEX = 6;
+const REVIEWER_PATTERNS_CHOICE_INDEX = 7;
+const REVIEWER_DELETE_CHOICE_INDEX = 8;
+const CONDITION_NOT_MATCHED_MESSAGE_KEY = "conditionNotMatched";
+const CONDITION_FAILED_MESSAGE_KEY = "conditionFailed";
 type ToolResult = {
   content: Array<{ type?: string; text?: string }>;
   details?: Record<string, unknown>;
@@ -75,6 +87,7 @@ type ToolResult = {
 };
 
 type FileReviewExecutionContext = {
+  event: ToolConditionEvent;
   toolName: string;
   toolCallId: string;
   params: Record<string, unknown>;
@@ -99,6 +112,75 @@ type PendingFileReviewCall = {
   beforeAudit?: FileEditReviewAudit;
   afterReviewers: FileEditReviewReviewerConfig[];
 };
+
+type ReviewerConditionSelection = {
+  matched: FileEditReviewReviewerConfig[];
+  results: FileEditReviewResult[];
+};
+
+interface SelectReviewerConditionsOptions {
+  reviewers: FileEditReviewReviewerConfig[];
+  event: ToolConditionEvent;
+  ctx: ExtensionContext;
+  timeoutMs: number;
+}
+
+/** Builds an audit result for a reviewer whose condition did not run or failed. */
+function buildConditionResult(
+  reviewer: FileEditReviewReviewerConfig,
+  evaluation: Awaited<ReturnType<typeof evaluateToolCondition>>,
+): FileEditReviewResult {
+  const ruleReference = reviewer.rulesFile
+    ? { rulesFile: reviewer.rulesFile }
+    : { rulesFiles: reviewer.rulesFiles };
+  if (evaluation.status === CONDITION_NOT_MATCHED_STATUS) {
+    return {
+      name: reviewer.name,
+      model: reviewer.model,
+      ...ruleReference,
+      status: SKIPPED_STATUS,
+      durationMs: evaluation.durationMs,
+      error: i18n.t(CONDITION_NOT_MATCHED_MESSAGE_KEY),
+    };
+  }
+
+  return {
+    name: reviewer.name,
+    model: reviewer.model,
+    ...ruleReference,
+    status: REJECTED_STATUS,
+    durationMs: evaluation.durationMs,
+    summary: i18n.t(CONDITION_FAILED_MESSAGE_KEY, {
+      path: evaluation.path ?? reviewer.condition ?? "",
+      message: evaluation.error ?? "",
+    }),
+    error: evaluation.error,
+  };
+}
+
+/** Selects reviewers by condition without invoking a model for non-matching inputs. */
+async function selectReviewersByCondition(
+  options: SelectReviewerConditionsOptions,
+): Promise<ReviewerConditionSelection> {
+  const evaluations = await Promise.all(options.reviewers.map(async (reviewer) => ({
+    reviewer,
+    evaluation: await evaluateToolCondition({
+      conditionPath: reviewer.condition,
+      cwd: options.ctx.cwd,
+      event: options.event,
+      ctx: options.ctx,
+      timeoutMs: options.timeoutMs,
+    }),
+  })));
+  return {
+    matched: evaluations
+      .filter(({ evaluation }) => evaluation.status === CONDITION_MATCHED_STATUS)
+      .map(({ reviewer }) => reviewer),
+    results: evaluations
+      .filter(({ evaluation }) => evaluation.status !== CONDITION_MATCHED_STATUS)
+      .map(({ reviewer, evaluation }) => buildConditionResult(reviewer, evaluation)),
+  };
+}
 
 /** Extracts a file path when the selected tool exposes one. */
 function getPath(params: Record<string, unknown>): string | undefined {
@@ -320,7 +402,7 @@ async function reviewToolResult(options: {
   beforeAudit?: FileEditReviewAudit;
 }): Promise<ToolResult> {
   const { context, toolName, config, configPath, configWarnings, snapshot, fallbackDiff, result, afterReviewers, beforeAudit } = options;
-  const selectedReviewers = afterReviewers ?? config.reviewers.filter((reviewer) => reviewer.enabled !== false && reviewerTrigger(reviewer) === AFTER_TRIGGER && reviewerMatchesTool(reviewer, toolName));
+  const configuredAfterReviewers = afterReviewers ?? config.reviewers.filter((reviewer) => reviewer.enabled !== false && reviewerTrigger(reviewer) === AFTER_TRIGGER && reviewerMatchesTool(reviewer, toolName));
   const beforeReviewers = beforeAudit?.reviewers ?? [];
   const startedAt = performance.now();
   if (context.signal?.aborted) {
@@ -353,7 +435,7 @@ async function reviewToolResult(options: {
   } satisfies Pick<FileEditReviewAudit, "filePath" | "toolName" | "warnings">;
 
   if (isFailedToolResult(result)) {
-    const skippedAfter = selectedReviewers.map((reviewer) => ({
+    const skippedAfter = configuredAfterReviewers.map((reviewer) => ({
       name: reviewer.name,
       model: reviewer.model,
       status: SKIPPED_STATUS,
@@ -390,6 +472,15 @@ async function reviewToolResult(options: {
     };
   }
 
+  const conditionSelection = await selectReviewersByCondition({
+    reviewers: configuredAfterReviewers,
+    event: context.event,
+    ctx: context.ctx,
+    timeoutMs: config.timeoutSeconds * MILLISECONDS_PER_SECOND,
+  });
+  const selectedReviewers = conditionSelection.matched;
+  const conditionResults = conditionSelection.results;
+
   const currentFileContext = buildCurrentFileContext(snapshot.before, snapshot.after, config.maxFileContextChars);
   const reviewerGroups = selectedReviewers
     .map((reviewer) => {
@@ -404,14 +495,16 @@ async function reviewToolResult(options: {
   const applicableGroups = reviewerGroups.filter((group) => group.rules.length > 0 || group.errors.length > 0);
   const applicableErrors = applicableGroups.flatMap((group) => group.errors);
   if (applicableGroups.length === 0 && applicableErrors.length === 0) {
-    if (!beforeAudit) return result;
+    const hasConditionRejection = conditionResults.some((reviewer) => reviewer.status === REJECTED_STATUS);
+    if (!beforeAudit && !hasConditionRejection) return result;
+    const reviewers = [...beforeReviewers, ...conditionResults];
     const audit: FileEditReviewAudit = {
       ...auditBase,
-      status: getOverallReviewStatus(beforeReviewers),
+      status: getOverallReviewStatus(reviewers),
       trigger: AFTER_TRIGGER,
-      reviewers: beforeReviewers,
+      reviewers,
       durationMs: Math.round(performance.now() - startedAt),
-      warnings: [...configWarnings, ...(beforeAudit.warnings ?? [])],
+      warnings: [...configWarnings, ...(beforeAudit?.warnings ?? [])],
     };
     const diagnostic = createReviewDiagnostic(audit, configPath);
     return {
@@ -426,6 +519,7 @@ async function reviewToolResult(options: {
     ...applicableGroups.flatMap((group) => group.rules.flatMap((rule) => rule.warning ? [rule.warning] : [])),
   ];
   const reviewResults = await Promise.all([
+    ...conditionResults,
     ...applicableGroups.map((group) =>
       reviewWithModel({
         context,
@@ -470,12 +564,30 @@ async function runBeforeReview(options: {
   fallbackDiff: string;
 }): Promise<FileEditReviewAudit | undefined> {
   const { context, loaded, filePath, fallbackDiff } = options;
-  const reviewers = loaded.config.reviewers.filter((reviewer) =>
+  const configuredReviewers = loaded.config.reviewers.filter((reviewer) =>
     reviewer.enabled !== false && reviewerTrigger(reviewer) === BEFORE_TRIGGER && reviewerMatchesTool(reviewer, context.toolName),
   );
-  if (reviewers.length === 0) return undefined;
+  if (configuredReviewers.length === 0) return undefined;
   const startedAt = performance.now();
-  const results: FileEditReviewResult[] = [];
+  const conditionSelection = await selectReviewersByCondition({
+    reviewers: configuredReviewers,
+    event: context.event,
+    ctx: context.ctx,
+    timeoutMs: loaded.config.timeoutSeconds * MILLISECONDS_PER_SECOND,
+  });
+  const reviewers = conditionSelection.matched;
+  const results: FileEditReviewResult[] = [...conditionSelection.results];
+  if (reviewers.length === 0) {
+    return {
+      status: getOverallReviewStatus(results),
+      filePath,
+      toolName: context.toolName,
+      trigger: BEFORE_TRIGGER,
+      reviewers: results,
+      durationMs: Math.round(performance.now() - startedAt),
+      warnings: withReviewAbortedWarning([...loaded.warnings], context.signal),
+    };
+  }
   const isFileTool = context.toolName === EDIT_TOOL || context.toolName === WRITE_TOOL;
   const selectedFilePath = isFileTool ? getPath(context.params) : undefined;
   const serializedPayload = selectedFilePath
@@ -549,11 +661,25 @@ async function prepareFileReviewCall(
 async function processGenericReviewResult(context: FileReviewExecutionContext, pending: PendingFileReviewCall, result: ToolResult): Promise<ToolResult> {
   if (pending.afterReviewers.length === 0 && !pending.beforeAudit) return result;
   const startedAt = performance.now();
-  const reviewers = pending.afterReviewers;
-  const results: FileEditReviewResult[] = isFailedToolResult(result)
-    ? reviewers.map((reviewer) => ({ name: reviewer.name, model: reviewer.model, status: SKIPPED_STATUS, durationMs: 0, error: i18n.t("failedAfterReview") }))
-    : [];
-  if (!isFailedToolResult(result)) {
+  const configuredReviewers = pending.afterReviewers;
+  const results: FileEditReviewResult[] = [];
+  if (isFailedToolResult(result)) {
+    results.push(...configuredReviewers.map((reviewer) => ({
+      name: reviewer.name,
+      model: reviewer.model,
+      status: SKIPPED_STATUS,
+      durationMs: 0,
+      error: i18n.t("failedAfterReview"),
+    })));
+  } else {
+    const conditionSelection = await selectReviewersByCondition({
+      reviewers: configuredReviewers,
+      event: context.event,
+      ctx: context.ctx,
+      timeoutMs: pending.loaded.config.timeoutSeconds * MILLISECONDS_PER_SECOND,
+    });
+    results.push(...conditionSelection.results);
+    const reviewers = conditionSelection.matched;
     const serializedPayload = safeSerialize(
       { input: pending.params, result: { content: result.content, details: result.details, isError: result.isError } },
       MAX_REVIEW_PAYLOAD_CHARS,
@@ -566,7 +692,9 @@ async function processGenericReviewResult(context: FileReviewExecutionContext, p
         results.push({ name: reviewer.name, model: reviewer.model, status: "failed", durationMs: 0, error: serializedPayload.error });
       } else if (rules.length > 0) {
         results.push(await reviewWithModel({ context, config: pending.loaded.config, reviewer, rules, toolName: context.toolName, diff: serializedPayload.text ?? "", trigger: AFTER_TRIGGER }));
-      } else if (loadedRules.errors.length === 0) results.push({ name: reviewer.name, model: reviewer.model, status: "skipped", durationMs: 0, error: i18n.t("noApplicableGenericRules") });
+      } else if (loadedRules.errors.length === 0) {
+        results.push({ name: reviewer.name, model: reviewer.model, status: "skipped", durationMs: 0, error: i18n.t("noApplicableGenericRules") });
+      }
     }
   }
   const reviewersWithBefore = [...(pending.beforeAudit?.reviewers ?? []), ...results];
@@ -663,6 +791,7 @@ async function editReviewer(
       i18n.t("rules", { value: rulesFiles.join(", ") }),
       i18n.t("tools", { value: (reviewer.tools ?? DEFAULT_REVIEW_TOOLS).join(", ") }),
       i18n.t("triggerConfig", { value: reviewerTrigger(reviewer) }),
+      i18n.t("conditionConfig", { value: reviewer.condition ?? i18n.t("conditionNone") }),
       i18n.t("patterns", { value: reviewer.filePatterns?.join(", ") || i18n.t("allFiles") }),
       i18n.t("deleteReviewer"),
       i18n.t("back"),
@@ -690,10 +819,17 @@ async function editReviewer(
     } else if (choice === choices[5]) {
       const value = await ctx.ui.select(i18n.t("triggerInput"), REVIEW_TRIGGERS);
       if (value) reviewer.trigger = value as ReviewTrigger;
-    } else if (choice === choices[6]) {
+    } else if (choice === choices[REVIEWER_CONDITION_CHOICE_INDEX]) {
+      const value = await ctx.ui.input(i18n.t("conditionInput"), reviewer.condition ?? "");
+      if (value !== undefined) {
+        const condition = value.trim();
+        if (condition) reviewer.condition = condition;
+        else delete reviewer.condition;
+      }
+    } else if (choice === choices[REVIEWER_PATTERNS_CHOICE_INDEX]) {
       const value = await inputList(ctx, i18n.t("listInputOptional"), reviewer.filePatterns ?? [], false);
       if (value !== undefined) reviewer.filePatterns = value;
-    } else if (choice === choices[7]) {
+    } else if (choice === choices[REVIEWER_DELETE_CHOICE_INDEX]) {
       const confirmed = await ctx.ui.confirm(
         i18n.t("deleteTitle"),
         i18n.t("deleteMessage", { name: reviewer.name }),
@@ -812,6 +948,7 @@ export default function piSupervisorExtension(pi: ExtensionAPI) {
   registerSupervisorFallbackRenderer(pi);
   pi.on("tool_call", async (event, ctx) => {
     const context: FileReviewExecutionContext = {
+      event,
       toolName: event.toolName,
       toolCallId: event.toolCallId,
       params: event.input,
@@ -832,6 +969,7 @@ export default function piSupervisorExtension(pi: ExtensionAPI) {
     pendingCalls.delete(event.toolCallId);
     const result = await processFileReviewResult(
       {
+        event,
         toolName: event.toolName,
         toolCallId: event.toolCallId,
         params: pending.params,

--- a/packages/pi-tool-supervisor/src/review-utils.ts
+++ b/packages/pi-tool-supervisor/src/review-utils.ts
@@ -40,6 +40,8 @@ export interface FileEditReviewReviewerConfig {
   tools?: string[];
   /** 省略时兼容旧配置：工具执行完成后审查。 */
   trigger?: ReviewTrigger;
+  /** Optional local module that decides whether this reviewer applies. */
+  condition?: string;
 }
 
 export interface FileEditReviewRuleMetadata {
@@ -183,6 +185,11 @@ function normalizeReviewer(value: unknown, index: number, warnings: string[] = [
   const tools = rawTools.map((tool) => String(tool).trim());
   const normalizedTools = tools.includes(ALL_TOOLS) ? [ALL_TOOLS] : [...new Set(tools)];
   if (tools.includes(ALL_TOOLS) && tools.length > 1) warnings.push(i18n.t("wildcardToolsConfig", { index }));
+  const condition = source.condition === undefined ? undefined : stringValue(source.condition);
+  if (source.condition !== undefined && !condition) {
+    warnings.push(i18n.t("invalidConditionConfig", { index }));
+    return undefined;
+  }
   const trigger = source.trigger === undefined ? "after" : source.trigger;
   if (!REVIEW_TRIGGERS.includes(trigger as ReviewTrigger)) {
     warnings.push(i18n.t("invalidTriggerConfig", { index }));
@@ -196,6 +203,7 @@ function normalizeReviewer(value: unknown, index: number, warnings: string[] = [
     filePatterns,
     tools: normalizedTools,
     trigger: trigger as ReviewTrigger,
+    ...(condition ? { condition } : {}),
   };
 }
 

--- a/packages/pi-tool-supervisor/tests/condition-integration.test.ts
+++ b/packages/pi-tool-supervisor/tests/condition-integration.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { default as piSupervisorExtension } from "../src/index.ts";
+
+const CONDITION_MODULE_TYPE = JSON.stringify({ type: "module" });
+
+type TestHandler = (...args: unknown[]) => unknown;
+
+/** Writes a condition module with an explicit ESM package boundary. */
+async function createConditionModule(source: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-condition-integration-"));
+  const path = join(directory, "condition.ts");
+  await writeFile(join(directory, "package.json"), CONDITION_MODULE_TYPE, "utf8");
+  await writeFile(path, source, "utf8");
+  return path;
+}
+
+/** Creates a temporary supervisor configuration and returns its paths. */
+async function createSupervisorConfig(
+  condition: string,
+): Promise<{ agentDir: string; rulePath: string }> {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-agent-"));
+  const rulePath = join(agentDir, "rules.md");
+  await writeFile(rulePath, "# Tool rule\n\n1. Check the tool input.\n", "utf8");
+  const configDirectory = join(agentDir, "extensions", "pi-tool-supervisor");
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(join(configDirectory, "config.json"), JSON.stringify({
+    enabled: true,
+    reviewers: [{
+      name: "condition-reviewer",
+      model: "condition-provider/model",
+      rulesFile: rulePath,
+      tools: ["custom-tool"],
+      trigger: "before",
+      condition,
+    }],
+  }), "utf8");
+  return { agentDir, rulePath };
+}
+
+/** Creates a minimal native-shaped extension context for lifecycle tests. */
+function createContext(
+  cwd: string,
+  modelRegistry: Record<string, unknown>,
+): ExtensionContext {
+  return { cwd, modelRegistry } as unknown as ExtensionContext;
+}
+
+/** Registers the supervisor against a handler-capturing Pi test double. */
+function registerTestExtension(): Map<string, TestHandler> {
+  const handlers = new Map<string, TestHandler>();
+  const pi = {
+    getAllTools: () => [],
+    registerCommand: () => undefined,
+    registerEntryRenderer: () => undefined,
+    appendEntry: () => undefined,
+    on: (event: string, handler: TestHandler) => handlers.set(event, handler),
+  } as unknown as ExtensionAPI;
+  piSupervisorExtension(pi);
+  return handlers;
+}
+
+test("condition false 时不调用模型并允许 before 工具继续执行", async () => {
+  const conditionPath = await createConditionModule("export default (event, ctx) => event.type === \"tool_call\" && ctx.cwd === \"/project\" && event.input.allow === true;\n");
+  const { agentDir } = await createSupervisorConfig(conditionPath);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const faux = registerFauxProvider({ provider: "condition-provider", models: [{ id: "model" }] });
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    faux.setResponses([fauxAssistantMessage(JSON.stringify({ passed: false, summary: "should not run", findings: [] }))]);
+    const handlers = registerTestExtension();
+    const context = createContext("/project", {
+      find: () => { throw new Error("condition false must skip model lookup"); },
+    });
+    const input = { allow: false };
+    const before = await handlers.get("tool_call")?.({
+      type: "tool_call",
+      toolName: "custom-tool",
+      toolCallId: "condition-skip",
+      input,
+    }, context);
+    assert.equal(before, undefined);
+
+    const result = await handlers.get("tool_result")?.({
+      type: "tool_result",
+      toolName: "custom-tool",
+      toolCallId: "condition-skip",
+      input,
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+      isError: false,
+    }, context) as { details: { fileEditReview: { reviewers: Array<{ status: string }> } } };
+    assert.deepEqual(result.details.fileEditReview.reviewers.map((reviewer) => reviewer.status), ["skipped"]);
+    assert.equal(faux.state.callCount, 0);
+    await handlers.get("session_shutdown")?.();
+  } finally {
+    faux.unregister();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("condition true 时将原生 event/context 交给 reviewer，before rejected 会阻断工具", async () => {
+  const conditionPath = await createConditionModule("export default (event, ctx, helpers) => event.type === \"tool_call\" && event.toolName === \"custom-tool\" && event.input.allow === true && ctx.cwd === \"/project\" && helpers.parseBash(\"echo ok\").commands.length === 1;\n");
+  const { agentDir } = await createSupervisorConfig(conditionPath);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const faux = registerFauxProvider({ provider: "condition-provider", models: [{ id: "model" }] });
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    faux.setResponses([fauxAssistantMessage(JSON.stringify({
+      passed: false,
+      summary: "输入不符合条件规则",
+      findings: [{ message: "禁止执行该工具" }],
+    }))]);
+    const handlers = registerTestExtension();
+    const context = createContext("/project", {
+      find: () => faux.getModel(),
+      getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test", headers: {}, env: {} }),
+    });
+    const block = await handlers.get("tool_call")?.({
+      type: "tool_call",
+      toolName: "custom-tool",
+      toolCallId: "condition-block",
+      input: { allow: true },
+    }, context) as { block?: boolean; reason?: string };
+
+    assert.equal(block.block, true);
+    assert.match(block.reason ?? "", /输入不符合条件规则/);
+    assert.equal(faux.state.callCount, 1);
+    await handlers.get("session_shutdown")?.();
+  } finally {
+    faux.unregister();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("condition 模块加载失败时 before 会阻断工具且不调用模型", async () => {
+  const { agentDir } = await createSupervisorConfig("missing-condition.ts");
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    const handlers = registerTestExtension();
+    const context = createContext("/project", {
+      find: () => { throw new Error("condition failure must block before model lookup"); },
+    });
+    const block = await handlers.get("tool_call")?.({
+      type: "tool_call",
+      toolName: "custom-tool",
+      toolCallId: "condition-error",
+      input: { allow: true },
+    }, context) as { block?: boolean; reason?: string };
+
+    assert.equal(block.block, true);
+    assert.match(block.reason ?? "", /条件模块|Condition module/);
+    await handlers.get("session_shutdown")?.();
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});
+
+test("condition module 可以在 after 阶段读取原生 tool_result event", async () => {
+  const conditionPath = await createConditionModule("export default (event, ctx) => event.type === \"tool_result\" && event.toolName === \"custom-tool\" && event.input.value === 2 && event.isError === false && ctx.cwd === \"/project\";\n");
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-agent-after-"));
+  const rulePath = join(agentDir, "rules.md");
+  await writeFile(rulePath, "# Tool rule\n", "utf8");
+  const configDirectory = join(agentDir, "extensions", "pi-tool-supervisor");
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(join(configDirectory, "config.json"), JSON.stringify({
+    enabled: true,
+    reviewers: [{
+      name: "after-condition-reviewer",
+      model: "condition-provider/model",
+      rulesFile: rulePath,
+      tools: ["custom-tool"],
+      trigger: "after",
+      condition: conditionPath,
+    }],
+  }), "utf8");
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const faux = registerFauxProvider({ provider: "condition-provider", models: [{ id: "model" }] });
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
+    faux.setResponses([fauxAssistantMessage(JSON.stringify({ passed: true, summary: "ok", findings: [] }))]);
+    const handlers = registerTestExtension();
+    const context = createContext("/project", {
+      find: () => faux.getModel(),
+      getApiKeyAndHeaders: async () => ({ ok: true, apiKey: "test", headers: {}, env: {} }),
+    });
+    const input = { value: 2 };
+    await handlers.get("tool_call")?.({
+      type: "tool_call",
+      toolName: "custom-tool",
+      toolCallId: "condition-after",
+      input,
+    }, context);
+    const result = await handlers.get("tool_result")?.({
+      type: "tool_result",
+      toolName: "custom-tool",
+      toolCallId: "condition-after",
+      input,
+      content: [{ type: "text", text: "ok" }],
+      details: {},
+      isError: false,
+    }, context) as { details: { fileEditReview: { status: string } } };
+
+    assert.equal(result.details.fileEditReview.status, "passed");
+    assert.equal(faux.state.callCount, 1);
+    await handlers.get("session_shutdown")?.();
+  } finally {
+    faux.unregister();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+});

--- a/packages/pi-tool-supervisor/tests/condition-utils.test.ts
+++ b/packages/pi-tool-supervisor/tests/condition-utils.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ExtensionContext,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import {
+  CONDITION_ERROR_STATUS,
+  CONDITION_MATCHED_STATUS,
+  CONDITION_NOT_MATCHED_STATUS,
+  evaluateToolCondition,
+} from "../src/condition-utils.ts";
+
+const CONDITION_TIMEOUT_MS = 100;
+const CONDITION_TIMEOUT_TEST_MS = 5;
+
+/** Writes an isolated condition module and returns its absolute path. */
+async function createConditionModule(source: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "pi-tool-condition-"));
+  const path = join(directory, "condition.ts");
+  await writeFile(path, source, "utf8");
+  return path;
+}
+
+/** Creates the smallest context shape required by a condition module test. */
+function createContext(cwd: string): ExtensionContext {
+  return { cwd } as unknown as ExtensionContext;
+}
+
+/** Creates a native-shaped tool call event for direct condition evaluation. */
+function createToolCall(command: string): ToolCallEvent {
+  return {
+    type: "tool_call",
+    toolCallId: "condition-test",
+    toolName: "bash",
+    input: { command },
+  } as ToolCallEvent;
+}
+
+test("没有配置 condition 时默认匹配", async () => {
+  const evaluation = await evaluateToolCondition({
+    cwd: "/project",
+    event: createToolCall("echo ok"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_MS,
+  });
+
+  assert.equal(evaluation.status, CONDITION_MATCHED_STATUS);
+  assert.equal(evaluation.durationMs, 0);
+});
+
+test("condition module 接收原生 event、ExtensionContext 和 Bash helper", async () => {
+  const conditionPath = await createConditionModule(`
+export default (event, ctx, helpers) =>
+  event.toolName === "bash" &&
+  event.input.command === "mvn test" &&
+  ctx.cwd === "/project" &&
+  helpers.parseBash(event.input.command).commands.length === 1;
+`);
+
+  const evaluation = await evaluateToolCondition({
+    conditionPath,
+    cwd: "/project",
+    event: createToolCall("mvn test"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_MS,
+  });
+
+  assert.equal(evaluation.status, CONDITION_MATCHED_STATUS);
+  assert.equal(evaluation.path, conditionPath);
+});
+
+test("condition 返回 false 时跳过 reviewer", async () => {
+  const conditionPath = await createConditionModule("export default () => false;\n");
+  const evaluation = await evaluateToolCondition({
+    conditionPath,
+    cwd: "/project",
+    event: createToolCall("echo ok"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_MS,
+  });
+
+  assert.equal(evaluation.status, CONDITION_NOT_MATCHED_STATUS);
+  assert.equal(evaluation.error, undefined);
+});
+
+test("condition module 文件变化后按指纹重新加载", async () => {
+  const conditionPath = await createConditionModule("export default () => false;\n");
+  const options = {
+    conditionPath,
+    cwd: "/project",
+    event: createToolCall("echo ok"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_MS,
+  };
+  const first = await evaluateToolCondition(options);
+  await writeFile(conditionPath, "export default () => true;\n", "utf8");
+  const second = await evaluateToolCondition(options);
+
+  assert.equal(first.status, CONDITION_NOT_MATCHED_STATUS);
+  assert.equal(second.status, CONDITION_MATCHED_STATUS);
+});
+
+test("condition module 非 boolean 返回值会形成显式错误", async () => {
+  const conditionPath = await createConditionModule("export default () => \"yes\";\n");
+  const evaluation = await evaluateToolCondition({
+    conditionPath,
+    cwd: "/project",
+    event: createToolCall("echo ok"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_MS,
+  });
+
+  assert.equal(evaluation.status, CONDITION_ERROR_STATUS);
+  assert.match(evaluation.error ?? "", /boolean/);
+});
+
+test("condition module 超时会形成显式错误", async () => {
+  const conditionPath = await createConditionModule("export default () => new Promise(() => {});\n");
+  const evaluation = await evaluateToolCondition({
+    conditionPath,
+    cwd: "/project",
+    event: createToolCall("echo ok"),
+    ctx: createContext("/project"),
+    timeoutMs: CONDITION_TIMEOUT_TEST_MS,
+  });
+
+  assert.equal(evaluation.status, CONDITION_ERROR_STATUS);
+  assert.match(evaluation.error ?? "", /timed out/);
+});

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -78,7 +78,8 @@ test("reviewer lifecycle 配置保留旧默认并校验通配工具与非法字�
   const configFile = join(directory, "config.json");
   await writeFile(configFile, JSON.stringify({ enabled: true, reviewers: [
     { model: "provider/model", rulesFile: "rules.md" },
-    { model: "provider/model", rulesFile: "rules.md", tools: ["*", "bash"], trigger: "before" },
+    { model: "provider/model", rulesFile: "rules.md", tools: ["*", "bash"], trigger: "before", condition: "conditions/bash.ts" },
+
     { model: "provider/model", rulesFile: "rules.md", tools: ["bash"], trigger: "invalid" },
   ] }));
   const loaded = loadFileEditReviewConfig(configFile);
@@ -86,8 +87,22 @@ test("reviewer lifecycle 配置保留旧默认并校验通配工具与非法字�
   assert.equal(loaded.config.reviewers[0]?.trigger, "after");
   assert.deepEqual(loaded.config.reviewers[1]?.tools, ["*"]);
   assert.equal(loaded.config.reviewers[1]?.trigger, "before");
+  assert.equal(loaded.config.reviewers[1]?.condition, "conditions/bash.ts");
   assert.match(loaded.warnings.join(" "), /忽略其他工具名/);
   assert.match(loaded.warnings.join(" "), /trigger 无效/);
+});
+
+test("非法 condition 配置不会被静默当成无条件 reviewer", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pi-tool-supervisor-condition-config-"));
+  const configFile = join(directory, "config.json");
+  await writeFile(configFile, JSON.stringify({
+    enabled: true,
+    reviewers: [{ model: "provider/model", rulesFile: "rules.md", condition: 42 }],
+  }));
+
+  const loaded = loadFileEditReviewConfig(configFile);
+  assert.equal(loaded.config.reviewers.length, 0);
+  assert.match(loaded.warnings.join(" "), /condition/);
 });
 
 test("generic 规则只接受无 filePatterns 的规则", async () => {


### PR DESCRIPTION
## 变更说明

- 为 `pi-tool-supervisor` 的 reviewer 增加可选 `condition` 模块路径。
- condition 模块默认导出函数，直接接收原生 `ToolCallEvent` / `ToolResultEvent`、`ExtensionContext` 和 `ToolConditionHelpers`。
- 支持 TypeScript/ESM 条件模块、动态重载、超时、异常处理和 Bash `parseBash` 辅助。
- 条件不匹配时跳过规则文件和模型调用；`before` 条件模块失败或审查 rejected 时阻断工具。
- 更新中英文 README、SKILL、配置示例、i18n 和测试。

## 兼容性

- 未配置 `condition` 的 reviewer 行为保持不变。
- `after` 审查仍只提供诊断，不回滚已完成的工具调用。

## 验证

- `npm run check`
- 11 个 workspace typecheck 通过
- 全部 1,135 项测试通过，0 失败
- 本机解耦与 i18n 门禁通过
- Package config check 通过
