### PR TITLE
fix(tool-display): preserve active tool selection

### DIFF
--- a/packages/pi-extensions-tool-display/README.md
+++ b/packages/pi-extensions-tool-display/README.md
@@ -14,6 +14,8 @@ It is also a standalone Pi extension. Install or include this package in Pi's pa
 
 This package owns the display protocol and generic component composition only. Each feature extension continues to own its domain-specific audit extraction, copy, status, and layout.
 
+Built-in overrides only replace tools that Pi has already activated; `registerToolOverrides` does not enable inactive built-in tools.
+
 ## Upstream attribution
 
 The display integration is designed to work with the MIT-licensed [`MasuRii/pi-tool-display`](https://github.com/MasuRii/pi-tool-display), the original full-featured Pi tool-display project. We thank MasuRii for that work.

--- a/packages/pi-extensions-tool-display/README.zh-CN.md
+++ b/packages/pi-extensions-tool-display/README.zh-CN.md
@@ -14,6 +14,8 @@
 
 这个包负责实际工具展示、展示协议和通用组件组合。具体业务的审计数据提取、文案、状态和布局仍由调用方维护，避免把不同扩展耦合在一起。
 
+内建工具覆盖只替换 Pi 当前已经激活的工具；`registerToolOverrides` 不会启用原本未激活的内建工具。
+
 ## 上游引用
 
 本包的展示集成设计用于兼容 MIT 许可的 [`MasuRii/pi-tool-display`](https://github.com/MasuRii/pi-tool-display)，这是 Pi 生态中原始的完整工具展示项目。感谢 MasuRii 的工作。

--- a/packages/pi-extensions-tool-display/src/index.ts
+++ b/packages/pi-extensions-tool-display/src/index.ts
@@ -13,6 +13,7 @@ import {
   type ToolDisplayCapabilities,
 } from "./capabilities.js";
 import { registerToolDisplayOverrides } from "./tool-overrides.js";
+import { logToolDisplayDebug } from "./debug-logger.js";
 import { disposeAll, resetDisposed } from "./disposable.js";
 import { registerThinkingLabeling } from "./thinking-label.js";
 import registerNativeUserMessageBox from "./user-message-box-native.js";
@@ -23,6 +24,12 @@ import {
 } from "./types.js";
 
 export * from "./result-render-middleware.js";
+
+const TOOL_DISPLAY_RELOAD_ACTIVE_TOOLS_KEY = Symbol.for("pi-tool-display.reloadActiveTools.v1");
+const BUILT_IN_TOOL_OVERRIDE_NAME_SET = new Set<string>(BUILT_IN_TOOL_OVERRIDE_NAMES);
+type GlobalWithToolDisplayReloadState = typeof globalThis & {
+  [TOOL_DISPLAY_RELOAD_ACTIVE_TOOLS_KEY]?: string[];
+};
 
 function ownershipChanged(
   previous: ToolDisplayConfig,
@@ -65,10 +72,21 @@ export function ensureToolDisplayHost(
   if (initializedHosts.has(pi)) return;
   initializedHosts.add(pi);
 
+  const globalReloadState = globalThis as GlobalWithToolDisplayReloadState;
+  const activeBuiltInToolNamesBeforeReload = globalReloadState[TOOL_DISPLAY_RELOAD_ACTIVE_TOOLS_KEY];
+  delete globalReloadState[TOOL_DISPLAY_RELOAD_ACTIVE_TOOLS_KEY];
+
   resetDisposed();
 
   pi.on("session_shutdown", (event: { reason: string }) => {
     if (event.reason === "reload") {
+      try {
+        globalReloadState[TOOL_DISPLAY_RELOAD_ACTIVE_TOOLS_KEY] = pi
+          .getActiveTools()
+          .filter((toolName) => BUILT_IN_TOOL_OVERRIDE_NAME_SET.has(toolName));
+      } catch (error) {
+        logToolDisplayDebug("Failed to preserve active built-in tools for reload.", error);
+      }
       disposeAll();
       initializedHosts.delete(pi);
     }
@@ -112,7 +130,7 @@ export function ensureToolDisplayHost(
   };
 
   if (initial.config.enabled) {
-    registerToolDisplayOverrides(pi, getEffectiveConfig);
+    registerToolDisplayOverrides(pi, getEffectiveConfig, activeBuiltInToolNamesBeforeReload);
     registerNativeUserMessageBox(pi, getConfig);
     registerThinkingLabeling(pi);
   }

--- a/packages/pi-extensions-tool-display/src/tool-overrides.ts
+++ b/packages/pi-extensions-tool-display/src/tool-overrides.ts
@@ -1668,9 +1668,20 @@ function tryGetAllTools(pi: ExtensionAPI, debugMessage: string): unknown[] | und
   }
 }
 
+// Return undefined until Pi binds the extension action methods.
+function tryGetActiveToolNames(pi: ExtensionAPI, debugMessage: string): string[] | undefined {
+  try {
+    return pi.getActiveTools();
+  } catch (error) {
+    logToolDisplayDebug(debugMessage, error);
+    return undefined;
+  }
+}
+
 export function registerToolDisplayOverrides(
   pi: ExtensionAPI,
   getConfig: ConfigGetter,
+  activeToolNamesDuringLoad?: readonly string[],
 ): void {
   clearBuiltInToolCache();
   const toolDisplayApi = installToolDisplayApi(getConfig);
@@ -1688,7 +1699,7 @@ export function registerToolDisplayOverrides(
   const registeredBuiltInToolOverrides = new Set<BuiltInToolOverrideName>();
 
   const isExternallyOwnedBuiltInTool = (toolName: BuiltInToolOverrideName): boolean => {
-    const allTools = tryGetAllTools(pi, "Built-in tool override ownership discovery unavailable during extension load; registering renderer for pre-bind history rendering.");
+    const allTools = tryGetAllTools(pi, "Built-in tool override ownership discovery unavailable; skipping conflicting owners.");
     if (!allTools) {
       return false;
     }
@@ -1780,7 +1791,37 @@ export function registerToolDisplayOverrides(
     return { scope: getSearchScope(args), limitSuffix: args.limit !== undefined ? ` (limit ${args.limit})` : "" };
   };
 
-  registerIfOwned("read", () => {
+  const builtInToolRegistrations = new Map<BuiltInToolOverrideName, () => void>();
+
+  // Record each built-in replacement until Pi exposes its active tool selection.
+  const recordBuiltInToolRegistration = (
+    toolName: BuiltInToolOverrideName,
+    register: () => void,
+  ): void => {
+    builtInToolRegistrations.set(toolName, register);
+  };
+
+  // Retry deferred replacements against Pi's current active tool selection.
+  const registerActiveBuiltInToolOverrides = (
+    knownActiveToolNames?: readonly string[],
+  ): void => {
+    const activeToolNames = knownActiveToolNames ?? tryGetActiveToolNames(
+      pi,
+      "Built-in tool activation discovery unavailable; skipping display overrides.",
+    );
+    if (!activeToolNames) {
+      return;
+    }
+
+    const activeTools = new Set(activeToolNames);
+    for (const [toolName, register] of builtInToolRegistrations) {
+      if (activeTools.has(toolName)) {
+        registerIfOwned(toolName, register);
+      }
+    }
+  };
+
+  recordBuiltInToolRegistration("read", () => {
     registerRuntimeTool(pi, {
       name: "read",
       label: "read",
@@ -1795,7 +1836,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("grep", () => {
+  recordBuiltInToolRegistration("grep", () => {
     registerRuntimeTool(pi, {
       name: "grep",
     label: "grep",
@@ -1816,7 +1857,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("find", () => {
+  recordBuiltInToolRegistration("find", () => {
     registerRuntimeTool(pi, {
       name: "find",
     label: "find",
@@ -1834,7 +1875,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("ls", () => {
+  recordBuiltInToolRegistration("ls", () => {
     registerRuntimeTool(pi, {
       name: "ls",
     label: "ls",
@@ -1850,7 +1891,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("edit", () => {
+  recordBuiltInToolRegistration("edit", () => {
     registerRuntimeTool(pi, {
       name: "edit",
     label: "edit",
@@ -1872,7 +1913,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("write", () => {
+  recordBuiltInToolRegistration("write", () => {
     registerRuntimeTool(pi, {
       name: "write",
     label: "write",
@@ -1945,7 +1986,7 @@ export function registerToolDisplayOverrides(
     });
   });
 
-  registerIfOwned("bash", () => {
+  recordBuiltInToolRegistration("bash", () => {
     registerRuntimeTool(pi, {
       name: "bash",
     label: "bash",
@@ -2023,6 +2064,8 @@ export function registerToolDisplayOverrides(
     },
     });
   });
+
+  registerActiveBuiltInToolOverrides(activeToolNamesDuringLoad);
 
   const wrappedCustomToolNames = new Set<string>();
   registerCleanup(() => wrappedCustomToolNames.clear());
@@ -2229,11 +2272,13 @@ export function registerToolDisplayOverrides(
 
   pi.on("session_start", async () => {
     clearWriteExecutionMeta(writeExecutionMetaByToolCallId);
+    registerActiveBuiltInToolOverrides();
     registerMcpToolOverrides();
     scheduleMcpToolOverrideDiscovery();
   });
   pi.on("before_agent_start", async () => {
     clearWriteExecutionMeta(writeExecutionMetaByToolCallId);
+    registerActiveBuiltInToolOverrides();
     registerMcpToolOverrides();
     scheduleMcpToolOverrideDiscovery();
   });

--- a/packages/pi-extensions-tool-display/tests/active-tools.integration.test.ts
+++ b/packages/pi-extensions-tool-display/tests/active-tools.integration.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+	createAgentSession,
+	DefaultResourceLoader,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import initializeToolDisplayExtension from "../src/index.ts";
+import { DEFAULT_TOOL_DISPLAY_CONFIG } from "../src/types.ts";
+
+const DEFAULT_ACTIVE_TOOL_NAMES = ["read", "bash", "edit", "write"];
+const DEFAULT_INACTIVE_TOOL_NAMES = ["grep", "find", "ls"];
+
+test("tool-display preserves Pi's default active tool selection", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-tool-display-active-tools-"));
+	const agentDir = join(cwd, "agent");
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+		extensionFactories: [
+			(pi) => initializeToolDisplayExtension(pi, { config: DEFAULT_TOOL_DISPLAY_CONFIG }),
+		],
+	});
+	await resourceLoader.reload();
+
+	const { session } = await createAgentSession({
+		cwd,
+		agentDir,
+		resourceLoader,
+		sessionManager: SessionManager.inMemory(cwd),
+	});
+
+	try {
+		assert.deepEqual(session.getActiveToolNames(), DEFAULT_ACTIVE_TOOL_NAMES);
+
+		await session.bindExtensions({ shutdownHandler: () => {} });
+
+		assert.deepEqual(session.getActiveToolNames(), DEFAULT_ACTIVE_TOOL_NAMES);
+		const toolsByName = new Map(session.getAllTools().map((tool) => [tool.name, tool]));
+		for (const toolName of DEFAULT_ACTIVE_TOOL_NAMES) {
+			assert.equal(toolsByName.get(toolName)?.sourceInfo.source, "inline");
+		}
+		for (const toolName of DEFAULT_INACTIVE_TOOL_NAMES) {
+			assert.equal(toolsByName.get(toolName)?.sourceInfo.source, "builtin");
+		}
+
+		let inspectedReloadRegistry = false;
+		await session.reload({
+			beforeSessionStart: () => {
+				inspectedReloadRegistry = true;
+				assert.deepEqual(session.getActiveToolNames(), DEFAULT_ACTIVE_TOOL_NAMES);
+				const reloadToolsByName = new Map(session.getAllTools().map((tool) => [tool.name, tool]));
+				for (const toolName of DEFAULT_ACTIVE_TOOL_NAMES) {
+					assert.equal(reloadToolsByName.get(toolName)?.sourceInfo.source, "inline");
+				}
+				for (const toolName of DEFAULT_INACTIVE_TOOL_NAMES) {
+					assert.equal(reloadToolsByName.get(toolName)?.sourceInfo.source, "builtin");
+				}
+			},
+		});
+
+		assert.equal(inspectedReloadRegistry, true);
+		assert.deepEqual(session.getActiveToolNames(), DEFAULT_ACTIVE_TOOL_NAMES);
+	} finally {
+		session.dispose();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});

--- a/packages/pi-extensions-tool-display/tests/custom-tool-overrides.test.ts
+++ b/packages/pi-extensions-tool-display/tests/custom-tool-overrides.test.ts
@@ -79,6 +79,10 @@ function createExtensionApiStub(allTools: RuntimeTool[] = []): {
 				}));
 			return [...defaultBuiltIns, ...allTools];
 		},
+		// Keep custom-rendering tests focused by exposing every built-in as active.
+		getActiveTools(): string[] {
+			return ["read", "grep", "find", "ls", "bash", "edit", "write"];
+		},
 	} as unknown as ExtensionAPI;
 
 	return { api, registeredTools, runtimeTools: allTools, eventHandlers };

--- a/packages/pi-extensions-tool-display/tests/index-integration.test.ts
+++ b/packages/pi-extensions-tool-display/tests/index-integration.test.ts
@@ -38,6 +38,7 @@ function createApiStub(
     registerCommand: (name: string, cmd: unknown) => void;
     on: (event: string, handler: (...args: unknown[]) => unknown) => void;
     getAllTools: () => unknown[];
+    getActiveTools: () => string[];
     getCommands: () => Array<{ name: string }>;
   }> = {},
 ): {
@@ -65,6 +66,10 @@ function createApiStub(
     },
     getAllTools(): unknown[] {
       return overrides.getAllTools?.() ?? [];
+    },
+    // Keep existing entry-point tests focused by exposing every built-in as active.
+    getActiveTools(): string[] {
+      return overrides.getActiveTools?.() ?? ["read", "grep", "find", "ls", "bash", "edit", "write"];
     },
     getCommands(): Array<{ name: string }> {
       return overrides.getCommands?.() ?? [];

--- a/packages/pi-extensions-tool-display/tests/reload-behavior.test.ts
+++ b/packages/pi-extensions-tool-display/tests/reload-behavior.test.ts
@@ -57,6 +57,7 @@ function createApiStub(
     registerCommand: (name: string, cmd: unknown) => void;
     on: (event: string, handler: (...args: unknown[]) => unknown) => void;
     getAllTools: () => unknown[];
+    getActiveTools: () => string[];
     getCommands: () => Array<{ name: string }>;
   }> = {},
 ): {
@@ -84,6 +85,10 @@ function createApiStub(
     },
     getAllTools(): unknown[] {
       return overrides.getAllTools?.() ?? [];
+    },
+    // Keep reload tests focused by exposing every built-in as active.
+    getActiveTools(): string[] {
+      return overrides.getActiveTools?.() ?? ["read", "grep", "find", "ls", "bash", "edit", "write"];
     },
     getCommands(): Array<{ name: string }> {
       return overrides.getCommands?.() ?? [];
@@ -119,6 +124,10 @@ function createExtensionApiStub(allTools: unknown[] = []): {
     },
     getAllTools(): unknown[] {
       return allTools;
+    },
+    // Keep deferred-registration tests focused by exposing every built-in as active.
+    getActiveTools(): string[] {
+      return ["read", "grep", "find", "ls", "bash", "edit", "write"];
     },
   } as unknown as ExtensionAPI;
 

--- a/packages/pi-extensions-tool-display/tests/result-render-middleware.test.ts
+++ b/packages/pi-extensions-tool-display/tests/result-render-middleware.test.ts
@@ -41,6 +41,10 @@ function createApiStub(): { api: ExtensionAPI; tools: RegisteredTool[] } {
         sourceInfo: { source: "builtin", path: `<builtin:${name}>` },
       }));
     },
+    // Keep middleware tests focused by exposing every built-in as active.
+    getActiveTools(): string[] {
+      return ["read", "edit", "grep", "find", "ls", "bash", "write"];
+    },
   } as unknown as ExtensionAPI;
   return { api, tools };
 }

--- a/packages/pi-extensions-tool-display/tests/tool-overrides-config.test.ts
+++ b/packages/pi-extensions-tool-display/tests/tool-overrides-config.test.ts
@@ -77,6 +77,10 @@ function createExtensionApiStub(allTools: Array<RegisteredToolLike & Record<stri
 		getAllTools(): unknown[] {
 			return withDefaultReadEditOwners(allTools);
 		},
+		// Keep legacy renderer tests focused by exposing every built-in as active.
+		getActiveTools(): string[] {
+			return ["read", "grep", "find", "ls", "bash", "edit", "write"];
+		},
 	} as unknown as ExtensionAPI;
 
 	return { api, registeredTools, runtimeTools: allTools, eventHandlers };

--- a/packages/pi-extensions-tool-display/tests/tool-overrides-registration.test.ts
+++ b/packages/pi-extensions-tool-display/tests/tool-overrides-registration.test.ts
@@ -19,6 +19,7 @@ import {
 import { DEFAULT_TOOL_DISPLAY_CONFIG } from "../src/types.ts";
 
 const TOOL_DISPLAY_PENDING_DECORATIONS_KEY = Symbol.for("pi-tool-display.pendingDecorations.v1");
+const ALL_BUILT_IN_TOOL_NAMES = ["read", "grep", "find", "ls", "bash", "edit", "write"];
 
 interface RegisteredToolLike {
 	name: string;
@@ -68,7 +69,11 @@ function withDefaultReadEditOwners(tools: unknown[] = []): unknown[] {
 	return [...defaults, ...tools];
 }
 
-function createExtensionApiStub(allTools: unknown[] = []): {
+// Build an extension API stub whose activeToolNames mirrors Pi's current selection.
+function createExtensionApiStub(
+	allTools: unknown[] = [],
+	activeToolNames: string[] = ALL_BUILT_IN_TOOL_NAMES,
+): {
 	api: ExtensionAPI;
 	registeredTools: RegisteredToolLike[];
 	eventHandlers: ToolEventHandlers;
@@ -84,6 +89,10 @@ function createExtensionApiStub(allTools: unknown[] = []): {
 		},
 		getAllTools(): unknown[] {
 			return withDefaultReadEditOwners(allTools);
+		},
+		// Let each test control which built-ins Pi has already activated.
+		getActiveTools(): string[] {
+			return [...activeToolNames];
 		},
 	} as unknown as ExtensionAPI;
 
@@ -130,18 +139,45 @@ test("registerToolDisplayOverrides copies built-in prompt metadata onto overridd
 	assert.deepEqual(byName.get("bash")?.promptGuidelines, (builtInTools.bash as unknown as RegisteredToolLike).promptGuidelines);
 });
 
-test("registerToolDisplayOverrides registers built-in display renderers during extension load for pre-bind history rendering", () => {
+test("registerToolDisplayOverrides registers active built-in display renderers immediately when activation is available", () => {
 	const { api, registeredTools } = createExtensionApiStub();
 
 	registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
 
 	const byName = new Map(registeredTools.map((tool) => [tool.name, tool]));
-	for (const name of ["read", "grep", "find", "ls", "bash", "edit", "write"] as const) {
+	for (const name of ALL_BUILT_IN_TOOL_NAMES) {
 		const registeredTool = byName.get(name);
-		assert.ok(registeredTool, `expected '${name}' to be available before session_start`);
-		assert.equal(typeof registeredTool.renderCall, "function", `${name} has renderCall before session_start`);
-		assert.equal(typeof registeredTool.renderResult, "function", `${name} has renderResult before session_start`);
+		assert.ok(registeredTool, `expected '${name}' to be available`);
+		assert.equal(typeof registeredTool.renderCall, "function", `${name} has renderCall`);
+		assert.equal(typeof registeredTool.renderResult, "function", `${name} has renderResult`);
 	}
+});
+
+test("registerToolDisplayOverrides skips built-ins that Pi has not activated", async () => {
+	const activeToolNames = ["read", "bash", "edit", "write"];
+	const { api, registeredTools, eventHandlers } = createExtensionApiStub([], activeToolNames);
+
+	registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
+	await eventHandlers.session_start?.();
+	await eventHandlers.before_agent_start?.();
+
+	assert.deepEqual(
+		registeredTools.map((tool) => tool.name).sort(),
+		[...activeToolNames].sort(),
+	);
+});
+
+test("registerToolDisplayOverrides wraps built-ins activated later in the session", async () => {
+	const activeToolNames = ["read"];
+	const { api, registeredTools, eventHandlers } = createExtensionApiStub([], activeToolNames);
+
+	registerToolDisplayOverrides(api, () => DEFAULT_TOOL_DISPLAY_CONFIG);
+	assert.deepEqual(registeredTools.map((tool) => tool.name), ["read"]);
+
+	activeToolNames.push("grep");
+	await eventHandlers.before_agent_start?.();
+
+	assert.deepEqual(registeredTools.map((tool) => tool.name).sort(), ["grep", "read"]);
 });
 
 test("registerToolDisplayOverrides clones built-in parameter schemas so Pi TUI keeps extension renderers active", async () => {


### PR DESCRIPTION
## Problem

`pi-extensions-tool-display` registered replacements for every supported built-in tool during extension loading. Pi treats registered extension tools as active, so default-inactive tools such as `grep`, `find`, and `ls` became available even when the user had not enabled them.

## Changes

- Gate built-in display overrides with `pi.getActiveTools()`.
- Defer initial registration until Pi exposes the active tool set.
- Preserve the active built-in snapshot across `/reload` so history is rebuilt with display renderers without activating inactive tools.
- Re-evaluate active tools before each agent start so tools enabled later can be wrapped.
- Add a real `AgentSession` integration test covering startup and reload ownership/activation behavior.
- Document that `registerToolOverrides` changes display ownership only and does not enable inactive built-ins.

## Validation

- `npm run check`
  - 11 workspace typechecks passed
  - 1138 tests passed, 0 failed
  - package config check passed
  - local-binding and i18n checks passed
- Independent code review: approved, no must-fix findings.

## Scope

- Package: `pi-extensions-tool-display`
- Plan: session task, no persisted plan file
- Release/deployment steps: none
