### PR TITLE
feat: 新增嵌套技能插件

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           - dir: packages/pi-session-resources
           - dir: packages/pi-dynamic-workflows
           - dir: packages/pi-interactive-subagents
+          - dir: packages/pi-nested-skills
     steps:
       - uses: actions/checkout@v4
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -9,5 +9,6 @@
   "packages/pi-session-tools": "0.5.5",
   "packages/pi-session-resources": "0.3.0",
   "packages/pi-dynamic-workflows": "1.2.1",
-  "packages/pi-interactive-subagents": "3.12.0"
+  "packages/pi-interactive-subagents": "3.12.0",
+  "packages/pi-nested-skills": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Each package owns its entrypoint, tests, configuration example, localization res
 
 ## Package boundaries
 
+- `pi-nested-skills` is independently installable; see `packages/pi-nested-skills/README.md` for its configuration, behavior, and tests.
+
 - `pi-distill` discovers active tools with object parameter schemas and observes their results through Pi's native `tool_call` and `tool_result` events. It does not register duplicate tools.
 - `pi-tool-supervisor` reviews the actual before/after diff of `edit` and `write` against configured rule files. It reports findings but is not an operating-system sandbox or an edit rollback mechanism.
 - `pi-extensions-tool-display` owns the actual Pi tool-display host, built-in tool renderer overrides, and the shared result-rendering middleware protocol. Feature packages register domain-specific panels through it.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Each package is independently installable and keeps its detailed behavior, confi
 
 | Package | Description | Documentation |
 | --- | --- | --- |
+| [`pi-nested-skills`](./packages/pi-nested-skills) | Nested skill discovery, aliases and completion from configured roots. | [English](./packages/pi-nested-skills/README.md) · [中文](./packages/pi-nested-skills/README.zh-CN.md) |
 | [`pi-distill`](./packages/pi-distill) | Compacts verbose output from every active object-schema tool before it consumes the context window. | [English](./packages/pi-distill/README.md) · [中文](./packages/pi-distill/README.zh-CN.md) |
 | [`pi-tool-supervisor`](./packages/pi-tool-supervisor) | Reviews selected tools before or after execution against matching rules, with diff-aware handling for `edit` and `write`. | [English](./packages/pi-tool-supervisor/README.md) · [中文](./packages/pi-tool-supervisor/README.zh-CN.md) |
 | [`pi-metrics`](./packages/pi-metrics) | Shows a live session elapsed timer in the working spinner plus per-turn and total run summaries. | [English](./packages/pi-metrics/README.md) · [中文](./packages/pi-metrics/README.zh-CN.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,7 @@
 
 | 包 | 说明 | 文档 |
 | --- | --- | --- |
+| [`pi-nested-skills`](./packages/pi-nested-skills) | 从配置目录发现嵌套技能，提供别名调用和补全。 | [English](./packages/pi-nested-skills/README.md) · [中文](./packages/pi-nested-skills/README.zh-CN.md) |
 | [`pi-distill`](./packages/pi-distill) | 在所有已启用 object-schema 工具的超长输出占满上下文前进行提炼。 | [English](./packages/pi-distill/README.md) · [中文](./packages/pi-distill/README.zh-CN.md) |
 | [`pi-tool-supervisor`](./packages/pi-tool-supervisor) | 根据匹配规则在工具执行前后进行审查，并对 `edit`、`write` 使用真实 diff。 | [English](./packages/pi-tool-supervisor/README.md) · [中文](./packages/pi-tool-supervisor/README.zh-CN.md) |
 | [`pi-metrics`](./packages/pi-metrics) | 在 working spinner 实时显示会话全程耗时，并给出每轮耗时与总耗时小结。 | [English](./packages/pi-metrics/README.md) · [中文](./packages/pi-metrics/README.zh-CN.md) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,7 +1013,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3528,6 +3528,10 @@
       "resolved": "packages/pi-models-discovery",
       "link": true
     },
+    "node_modules/pi-nested-skills": {
+      "resolved": "packages/pi-nested-skills",
+      "link": true
+    },
     "node_modules/pi-session-resources": {
       "resolved": "packages/pi-session-resources",
       "link": true
@@ -3891,6 +3895,27 @@
       "peerDependencies": {
         "@earendil-works/pi-ai": ">=0.80.0 <0.81.0",
         "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0"
+      }
+    },
+    "packages/pi-nested-skills": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "pi-extensions-i18n": "^0.4.0"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "0.80.10",
+        "@earendil-works/pi-tui": "0.80.10",
+        "@types/node": "24.12.4",
+        "tsx": "4.23.1",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+        "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
       }
     },
     "packages/pi-session-resources": {

--- a/packages/pi-nested-skills/README.md
+++ b/packages/pi-nested-skills/README.md
@@ -1,0 +1,78 @@
+# pi-nested-skills
+
+A Pi extension that discovers skills recursively and provides convenient aliases for nested skill directories.
+
+[中文文档](./README.zh-CN.md)
+
+## Features
+
+- Recursively discovers `SKILL.md` files below one or more configurable skill roots.
+- Supports package-style aliases such as `/development:code-reviewer` and `/design:icons.favicon`.
+- Keeps Pi's native skill loader responsible for frontmatter validation and skill-body expansion; this package does not duplicate `read` compatibility or skill expansion.
+- Extends the native slash-command completion list and preserves built-in Pi command suggestions.
+- Provides `/skills` to list discovered aliases.
+- Contributes discovered skill files through Pi's `resources_discover` event.
+- Uses `pi-extensions-i18n` for all user-visible messages.
+
+## Install
+
+```bash
+pi install npm:pi-nested-skills
+```
+
+Then run `/reload` in Pi.
+
+## Configure skill roots
+
+Start from [`config.example.json`](./config.example.json) and write it to:
+
+```text
+<pi-agent-dir>/extensions/pi-nested-skills/config.json
+```
+
+`<pi-agent-dir>` is Pi's configured agent directory, normally `~/.pi/agent`. The `PI_CODING_AGENT_DIR` override is respected by Pi and by this extension.
+
+```json
+{
+  "skillRoots": [
+    "~/shared-skills",
+    "skills"
+  ]
+}
+```
+
+A relative root is resolved relative to the Pi agent directory. Each direct child of a root is treated as a skill package, and every visible descendant containing `SKILL.md` is discovered. A root containing `SKILL.md` itself is also accepted as one package.
+
+Environment fallback:
+
+```text
+PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
+```
+
+The file configuration takes precedence over the environment, and the environment takes precedence over the default `<pi-agent-dir>/skills` root. `PI_NESTED_SKILLS_DIR` remains a compatibility alias for one root.
+
+## Aliases and native expansion
+
+For a skill at `development/code-reviewer/SKILL.md`, the extension offers:
+
+```text
+/development:code-reviewer [arguments]
+/skill:development.code-reviewer [arguments]
+```
+
+The input hook converts the alias to Pi's native `/skill:<frontmatter-name>` form. Pi then reads the skill body and resolves relative references using its normal skill mechanism. If a frontmatter name is shared by multiple discovered skills, the name-only native form is not guessed; use an unambiguous package/path alias.
+
+Use `/skills` to inspect the complete list. Type `/` to search the merged native and nested-skill completion candidates.
+
+## Portability and privacy
+
+The package does not access credentials, make network requests, start processes, or assume a particular home directory. It follows Pi's agent-directory setting and accepts explicit roots for project or team layouts.
+
+## Requirements
+
+- Node.js 22 or newer.
+- Pi `>=0.80.0 <0.81.0`.
+
+## License
+
+MIT — see the repository license.

--- a/packages/pi-nested-skills/README.zh-CN.md
+++ b/packages/pi-nested-skills/README.zh-CN.md
@@ -1,0 +1,78 @@
+# pi-nested-skills
+
+Pi 的嵌套技能扩展：递归发现多级 `SKILL.md`，并为嵌套技能提供快捷别名、列表和补全。
+
+[English](./README.md)
+
+## 功能
+
+- 递归扫描一个或多个可配置技能根目录下的 `SKILL.md`。
+- 支持 `/development:code-reviewer`、`/design:icons.favicon` 等技能包别名。
+- 保留 Pi 原生技能加载器负责 frontmatter 校验和正文展开；不重复实现 `read` 兼容层或技能展开。
+- 将嵌套技能补全合并到 Pi 原生斜杠命令补全中，不影响内置命令。
+- 提供 `/skills` 列出发现到的全部别名。
+- 通过 Pi 的 `resources_discover` 事件注册发现到的技能文件。
+- 所有用户可见文案都通过 `pi-extensions-i18n` 提供中英文版本。
+
+## 安装
+
+```bash
+pi install npm:pi-nested-skills
+```
+
+然后在 Pi 中执行 `/reload`。
+
+## 配置技能根目录
+
+复制 [`config.example.json`](./config.example.json)，写入：
+
+```text
+<Pi agent 目录>/extensions/pi-nested-skills/config.json
+```
+
+`<Pi agent 目录>` 是 Pi 配置的 agent 目录，通常为 `~/.pi/agent`。扩展遵循 Pi 的 `PI_CODING_AGENT_DIR` 设置。
+
+```json
+{
+  "skillRoots": [
+    "~/shared-skills",
+    "skills"
+  ]
+}
+```
+
+相对路径以 Pi agent 目录为基准。根目录的每个直接子目录视为一个技能包，扩展会递归发现其中所有可见目录下的 `SKILL.md`。如果根目录本身包含 `SKILL.md`，也会把它作为一个技能包处理。
+
+环境变量兜底：
+
+```text
+PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
+```
+
+配置文件优先于环境变量，环境变量优先于默认的 `<Pi agent 目录>/skills`。`PI_NESTED_SKILLS_DIR` 作为单根目录的兼容别名保留。
+
+## 别名与原生展开
+
+对于 `development/code-reviewer/SKILL.md`，扩展提供：
+
+```text
+/development:code-reviewer [参数]
+/skill:development.code-reviewer [参数]
+```
+
+输入事件会把别名转换为 Pi 原生的 `/skill:<frontmatter-name>` 形式，再由 Pi 读取技能正文，并按原生机制解析相对引用。如果多个技能共用同一个 frontmatter name，扩展不会猜测无路径的名称；请使用明确的技能包/路径别名。
+
+使用 `/skills` 查看完整列表。输入 `/` 可在同一个列表中搜索 Pi 内置命令和嵌套技能。
+
+## 可移植性与隐私
+
+本包不读取凭据、不发起网络请求、不启动进程，也不假设固定的用户目录。它遵循 Pi 的 agent 目录配置，并支持显式指定项目或团队技能目录。
+
+## 要求
+
+- Node.js 22 或更高版本。
+- Pi `>=0.80.0 <0.81.0`。
+
+## 许可证
+
+MIT — 详见仓库许可证。

--- a/packages/pi-nested-skills/SKILL.md
+++ b/packages/pi-nested-skills/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: configure-pi-nested-skills
+description: "配置与排查 pi-nested-skills 的技能根目录、递归发现、别名调用和补全。Use when configuring nested skill roots, aliases, discovery, or completion."
+---
+
+# 配置 pi-nested-skills
+
+## 诊断
+
+读取实际 Pi agent 目录下的：
+
+```text
+extensions/pi-nested-skills/config.json
+```
+
+默认路径是 `~/.pi/agent/extensions/pi-nested-skills/config.json`；设置 `PI_CODING_AGENT_DIR` 时跟随 Pi 的 agent 目录。配置字段只有 `skillRoots`，可以是一个路径字符串或路径字符串数组。
+
+技能根目录下的一级目录视为技能包；扩展会递归查找其中的 `SKILL.md`。如果根目录本身直接包含 `SKILL.md`，则把这个目录作为一个技能包处理。
+
+## 修改
+
+优先复制包内 [`config.example.json`](./config.example.json)，再修改 `skillRoots`。路径可以是绝对路径、`~/` 路径，或相对于 Pi agent 目录的路径。
+
+也可以使用环境变量：
+
+```text
+PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
+```
+
+配置文件优先于环境变量；环境变量优先于默认的 Pi agent `skills` 目录。`PI_NESTED_SKILLS_DIR` 作为旧单目录名称保留兼容读取。
+
+别名形式为 `/技能包:子目录.子目录`，例如 `/development:code-reviewer` 或 `/design:icons.favicon`。也支持 `/skill:技能包.子目录`；扩展会把它转换为 Pi 原生 `/skill:<name>`，由 Pi 负责技能正文展开。
+
+## 验证
+
+- 执行 `/skills` 查看递归发现的别名。
+- 在输入框输入 `/`，确认补全同时保留 Pi 内置命令和嵌套技能。
+- 手动调用一个嵌套别名并带参数，确认参数仍传给原生技能展开。
+- 配置空目录、缺失目录或无 description 的 `SKILL.md` 时，确认 Pi/扩展明确报告诊断；不要把无法加载的技能静默显示为可用。
+- 不要复制 Pi 原生 `read` 路径处理或技能正文展开逻辑。

--- a/packages/pi-nested-skills/config.example.json
+++ b/packages/pi-nested-skills/config.example.json
@@ -1,0 +1,5 @@
+{
+  "skillRoots": [
+    "skills"
+  ]
+}

--- a/packages/pi-nested-skills/index.ts
+++ b/packages/pi-nested-skills/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./src/index.ts";
+export * from "./src/index.ts";

--- a/packages/pi-nested-skills/locales/index.json
+++ b/packages/pi-nested-skills/locales/index.json
@@ -1,0 +1,30 @@
+{
+  "commandDescription": {
+    "zh-CN": "列出所有可用的嵌套技能及其命令",
+    "en-US": "List all available nested skills and their commands"
+  },
+  "title": {
+    "zh-CN": "## 可用嵌套技能命令\n",
+    "en-US": "## Available nested skill commands\n"
+  },
+  "footer": {
+    "zh-CN": "在聊天中输入上述命令即可手动调用对应技能。",
+    "en-US": "Enter one of the commands above in chat to invoke the corresponding skill."
+  },
+  "noSkills": {
+    "zh-CN": "技能根目录中没有发现可用技能：{roots}",
+    "en-US": "No usable skills were found in the configured roots: {roots}"
+  },
+  "noRoots": {
+    "zh-CN": "未配置根目录",
+    "en-US": "no configured roots"
+  },
+  "configWarning": {
+    "zh-CN": "嵌套技能配置警告：{reason}",
+    "en-US": "Nested skills configuration warning: {reason}"
+  },
+  "scanWarning": {
+    "zh-CN": "扫描技能目录失败：{path}（{reason}）",
+    "en-US": "Failed to scan skill path: {path} ({reason})"
+  }
+}

--- a/packages/pi-nested-skills/package.json
+++ b/packages/pi-nested-skills/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "pi-nested-skills",
+  "version": "0.1.0",
+  "description": "Pi extension for recursive nested-skill discovery and aliases",
+  "type": "module",
+  "main": "./index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "src",
+    "locales",
+    "config.example.json",
+    "README.md",
+    "README.zh-CN.md",
+    "SKILL.md",
+    "tsconfig.json"
+  ],
+  "scripts": {
+    "test": "tsx --test tests/*.test.ts",
+    "typecheck": "tsc --noEmit --pretty false",
+    "build": "npm run typecheck",
+    "check": "npm run typecheck && npm test && npm pack --dry-run --json > /dev/null"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts",
+      "../pi-extensions-i18n/index.ts"
+    ],
+    "skills": [
+      "./SKILL.md"
+    ]
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT",
+  "author": "maplezzk",
+  "homepage": "https://github.com/maplezzk/pi-extensions/tree/main/packages/pi-nested-skills",
+  "bugs": "https://github.com/maplezzk/pi-extensions/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maplezzk/pi-extensions.git",
+    "directory": "packages/pi-nested-skills"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "keywords": [
+    "pi-package",
+    "pi",
+    "pi-extension",
+    "coding-agent",
+    "skills",
+    "nested-skills",
+    "autocomplete"
+  ],
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
+    "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
+  },
+  "dependencies": {
+    "pi-extensions-i18n": "^0.4.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.80.10",
+    "@earendil-works/pi-tui": "0.80.10",
+    "@types/node": "24.12.4",
+    "tsx": "4.23.1",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/pi-nested-skills/src/config.ts
+++ b/packages/pi-nested-skills/src/config.ts
@@ -1,0 +1,149 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export const CONFIG_FILE_NAME = "config.json";
+export const CONFIG_DIRECTORY_NAME = "pi-nested-skills";
+export const SKILL_ROOTS_ENV = "PI_NESTED_SKILLS_ROOTS";
+export const LEGACY_SKILLS_DIR_ENV = "PI_NESTED_SKILLS_DIR";
+
+export interface NestedSkillsConfig {
+  /** 包含技能包目录的根目录列表。 */
+  skillRoots: string[];
+}
+
+export type ConfigSource = "file" | "environment" | "default";
+
+export interface LoadedNestedSkillsConfig {
+  config: NestedSkillsConfig;
+  source: ConfigSource;
+  /** 配置文件或环境变量存在但无法使用时的明确诊断。 */
+  warnings: string[];
+  /** 是否由用户显式提供过根目录配置。 */
+  explicit: boolean;
+}
+
+interface ConfigObject {
+  skillRoots?: unknown;
+  /** 早期试用版本使用的单数名称，读取时保留兼容性。 */
+  skillsDir?: unknown;
+}
+
+/** 返回实际 Pi agent 目录下的扩展配置文件路径。 */
+export function configPath(agentDir = getAgentDir()): string {
+  return join(agentDir, "extensions", CONFIG_DIRECTORY_NAME, CONFIG_FILE_NAME);
+}
+
+/** 默认使用 Pi 的标准全局技能目录；需要兼容其他技能树时可通过配置覆盖。 */
+export function defaultSkillRoots(agentDir = getAgentDir()): string[] {
+  return [join(agentDir, "skills")];
+}
+
+function expandHomePath(value: string, homeDirectory = homedir()): string {
+  if (value === "~") return homeDirectory;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return join(homeDirectory, value.slice(2));
+  }
+  return value;
+}
+
+/** 将配置中的绝对、~/ 和相对 Pi agent 目录路径统一为绝对路径。 */
+export function resolveSkillRoot(
+  value: string,
+  agentDir: string,
+  homeDirectory = homedir(),
+): string {
+  const expanded = expandHomePath(value.trim(), homeDirectory);
+  return isAbsolute(expanded) ? expanded : resolve(agentDir, expanded);
+}
+
+function normalizeRootValues(value: unknown): string[] | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (!Array.isArray(value)) return undefined;
+
+  const roots: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.trim() === "") return undefined;
+    roots.push(item.trim());
+  }
+  return roots;
+}
+
+function readConfigFile(path: string): { value?: string[]; warning?: string } {
+  if (!existsSync(path)) return {};
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as ConfigObject;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { warning: `Invalid configuration object in ${path}.` };
+    }
+
+    const configured = parsed.skillRoots === undefined ? parsed.skillsDir : parsed.skillRoots;
+    if (configured === undefined) return {};
+    const roots = normalizeRootValues(configured);
+    if (roots === undefined) {
+      return { warning: `Configuration field "skillRoots" must be a string or an array of strings in ${path}.` };
+    }
+    return { value: roots };
+  } catch (error) {
+    return {
+      warning: `Failed to read ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+function environmentRoots(env: NodeJS.ProcessEnv): string[] | undefined {
+  const raw = env[SKILL_ROOTS_ENV] ?? env[LEGACY_SKILLS_DIR_ENV];
+  if (raw === undefined) return undefined;
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+/**
+ * 读取技能根目录配置：配置文件 > 环境变量 > Pi 标准默认目录。
+ * 相对路径以 agent 目录为基准，避免把当前工作目录或维护者机器路径写进配置。
+ */
+export function loadConfig(
+  agentDir = getAgentDir(),
+  env: NodeJS.ProcessEnv = process.env,
+): LoadedNestedSkillsConfig {
+  const path = configPath(agentDir);
+  const fileResult = readConfigFile(path);
+  const warnings = fileResult.warning ? [fileResult.warning] : [];
+
+  if (fileResult.value !== undefined) {
+    return {
+      config: {
+        skillRoots: fileResult.value.map((value) => resolveSkillRoot(value, agentDir)),
+      },
+      source: "file",
+      warnings,
+      explicit: true,
+    };
+  }
+
+  const envValue = environmentRoots(env);
+  if (envValue !== undefined) {
+    return {
+      config: {
+        skillRoots: envValue.map((value) => resolveSkillRoot(value, agentDir)),
+      },
+      source: "environment",
+      warnings,
+      explicit: true,
+    };
+  }
+
+  return {
+    config: { skillRoots: defaultSkillRoots(agentDir) },
+    source: "default",
+    warnings,
+    explicit: false,
+  };
+}

--- a/packages/pi-nested-skills/src/index.ts
+++ b/packages/pi-nested-skills/src/index.ts
@@ -1,0 +1,263 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { fuzzyFilter } from "@earendil-works/pi-tui";
+import type { AutocompleteItem, AutocompleteProvider } from "@earendil-works/pi-tui";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
+import { loadConfig, type LoadedNestedSkillsConfig } from "./config.ts";
+import { scanSkillRoots, type NestedSkill, type SkillScanResult } from "./skills.ts";
+
+const messages = loadCatalog(new URL("../locales/index.json", import.meta.url));
+const i18n = createTranslator(messages);
+
+const COMMAND_NAME = "skills";
+const COMMAND_ALIASES = [COMMAND_NAME] as const;
+const SKILL_COMMAND_PREFIX = "skill:";
+const INPUT_SOURCES = new Set(["interactive", "rpc"]);
+
+type SkillCommandContext = ExtensionCommandContext;
+
+interface SkillCandidate {
+  alias: string;
+  skill: NestedSkill;
+}
+
+interface SkillIndex {
+  readonly skills: NestedSkill[];
+  readonly skillPaths: string[];
+  readonly warnings: SkillScanResult["warnings"];
+  readonly aliases: Map<string, NestedSkill>;
+  readonly names: Map<string, NestedSkill | null>;
+}
+
+/** 将扫描结果转换为稳定的别名索引，并标记 frontmatter name 冲突。 */
+function buildSkillIndex(scan: SkillScanResult): SkillIndex {
+  const aliases = new Map<string, NestedSkill>();
+  const names = new Map<string, NestedSkill | null>();
+
+  for (const skill of scan.skills) {
+    const alias = skillAlias(skill);
+    if (!aliases.has(alias)) aliases.set(alias, skill);
+
+    const existing = names.get(skill.skillName);
+    if (existing === undefined) names.set(skill.skillName, skill);
+    else if (existing !== skill) names.set(skill.skillName, null);
+  }
+
+  return {
+    skills: scan.skills,
+    skillPaths: scan.skillPaths,
+    warnings: scan.warnings,
+    aliases,
+    names,
+  };
+}
+
+/** 返回用户输入和补全展示使用的别名，不改变 frontmatter 中的原生技能名称。 */
+export function skillAlias(skill: Pick<NestedSkill, "packName" | "skillDir">): string {
+  return skill.skillDir ? `${skill.packName}:${skill.skillDir}` : skill.packName;
+}
+
+/** 将 /skill:pack.path、/pack:path 等形式解析为一个已扫描技能。 */
+export function resolveSkillAlias(raw: string, index: Pick<SkillIndex, "aliases" | "names">): NestedSkill | undefined {
+  const candidates = new Set<string>();
+  const addCandidate = (candidate: string): void => {
+    const normalized = candidate.trim();
+    if (normalized) candidates.add(normalized);
+  };
+
+  addCandidate(raw);
+  if (raw.startsWith(SKILL_COMMAND_PREFIX)) {
+    const body = raw.slice(SKILL_COMMAND_PREFIX.length);
+    addCandidate(body);
+
+    // /skill:pack.path.to.skill 使用第一个点分隔技能包和嵌套路径。
+    const firstDot = body.indexOf(".");
+    if (firstDot > 0) addCandidate(`${body.slice(0, firstDot)}:${body.slice(firstDot + 1)}`);
+  } else {
+    // 也接受不带 skill: 前缀的点号路径，方便旧别名和手工输入互通。
+    const firstDot = raw.indexOf(".");
+    if (firstDot > 0) addCandidate(`${raw.slice(0, firstDot)}:${raw.slice(firstDot + 1)}`);
+  }
+
+  for (const candidate of candidates) {
+    const direct = index.aliases.get(candidate);
+    if (direct) return direct;
+  }
+
+  // /skill:<frontmatter name> 交给索引映射；冲突名称不猜测，避免调用错误技能。
+  if (!raw.startsWith(SKILL_COMMAND_PREFIX)) return undefined;
+  const named = index.names.get(raw.slice(SKILL_COMMAND_PREFIX.length));
+  return named ?? undefined;
+}
+
+/** 将原生 /skill:<name> 调用交给 Pi 自己展开，避免复制技能正文展开逻辑。 */
+export function transformSkillInput(
+  text: string,
+  index: Pick<SkillIndex, "aliases" | "names">,
+): string | undefined {
+  const match = text.match(/^\/([^\s]+)(?:\s+([\s\S]*))?$/);
+  if (!match) return undefined;
+
+  const skill = resolveSkillAlias(match[1], index);
+  if (!skill || index.names.get(skill.skillName) !== skill) return undefined;
+
+  const args = match[2]?.trim();
+  return `/skill:${skill.skillName}${args ? ` ${args}` : ""}`;
+}
+
+function skillCandidates(index: SkillIndex): SkillCandidate[] {
+  return [...index.aliases.entries()].map(([alias, skill]) => ({ alias, skill }));
+}
+
+function nativeSkillValue(alias: string): string {
+  const separator = alias.indexOf(":");
+  return separator === -1
+    ? `${SKILL_COMMAND_PREFIX}${alias}`
+    : `${SKILL_COMMAND_PREFIX}${alias.slice(0, separator)}.${alias.slice(separator + 1)}`;
+}
+
+function createAutocompleteProvider(
+  current: AutocompleteProvider,
+  index: SkillIndex,
+): AutocompleteProvider {
+  return {
+    async getSuggestions(lines, cursorLine, cursorCol, options) {
+      const base = await current.getSuggestions(lines, cursorLine, cursorCol, options);
+      const beforeCursor = (lines[cursorLine] ?? "").slice(0, cursorCol);
+      const match = beforeCursor.match(/^\/([^\s]*)$/);
+      if (!match) return base;
+
+      const query = match[1].startsWith(SKILL_COMMAND_PREFIX)
+        ? match[1].slice(SKILL_COMMAND_PREFIX.length)
+        : match[1];
+      const items = fuzzyFilter(
+        skillCandidates(index),
+        query,
+        ({ alias, skill }) => `${alias} ${skill.skillName} ${skill.description}`,
+      ).map(({ alias, skill }): AutocompleteItem => ({
+        value: nativeSkillValue(alias),
+        label: alias,
+        description: skill.description || skill.skillName,
+      }));
+
+      if (items.length === 0) return base;
+      const existingValues = new Set((base?.items ?? []).map((item) => item.value));
+      const merged = [
+        ...(base?.items ?? []),
+        ...items.filter((item) => !existingValues.has(item.value)),
+      ];
+      return { prefix: beforeCursor, items: merged };
+    },
+
+    applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+      return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
+    },
+
+    shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+      return current.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true;
+    },
+  };
+}
+
+function commandItems(index: SkillIndex): AutocompleteItem[] {
+  return skillCandidates(index).map(({ alias, skill }) => ({
+    value: alias,
+    label: alias,
+    description: skill.description || skill.skillName,
+  }));
+}
+
+function formatSkillsMessage(index: SkillIndex): string {
+  const lines = [i18n.t("title")];
+  const grouped = new Map<string, NestedSkill[]>();
+  for (const skill of index.skills) {
+    const skills = grouped.get(skill.packName) ?? [];
+    skills.push(skill);
+    grouped.set(skill.packName, skills);
+  }
+
+  for (const [pack, skills] of grouped) {
+    lines.push(`### ${pack}\n`);
+    for (const skill of skills) {
+      const description = skill.description ? ` - ${skill.description}` : "";
+      const alias = skillAlias(skill);
+      const indent = "  ".repeat(Math.max(skill.depth - 1, 0));
+      lines.push(`${indent}- \`/${alias}\` ${description}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("---", i18n.t("footer"));
+  return lines.join("\n");
+}
+
+function registerSkillsCommand(pi: ExtensionAPI, index: SkillIndex): void {
+  const command = {
+    description: i18n.t("commandDescription"),
+    getArgumentCompletions: (): AutocompleteItem[] => commandItems(index),
+    handler: async (_args: string, _ctx: SkillCommandContext) => {
+      await pi.sendUserMessage(formatSkillsMessage(index), { deliverAs: "followUp" });
+    },
+  };
+
+  for (const name of COMMAND_ALIASES) pi.registerCommand(name, command);
+}
+
+function notifyDiagnostics(ctx: ExtensionContext, loaded: LoadedNestedSkillsConfig, index: SkillIndex): void {
+  if (!ctx.hasUI) return;
+  for (const warning of loaded.warnings) {
+    ctx.ui.notify(i18n.t("configWarning", { reason: warning }), "warning");
+  }
+  for (const warning of index.warnings) {
+    ctx.ui.notify(
+      i18n.t("scanWarning", { path: warning.path, reason: warning.reason }),
+      "warning",
+    );
+  }
+  if (loaded.explicit && index.skills.length === 0) {
+    ctx.ui.notify(
+      i18n.t("noSkills", { roots: loaded.config.skillRoots.join(", ") || i18n.t("noRoots") }),
+      "warning",
+    );
+  }
+}
+
+/** 注册递归技能别名，同时把实际技能正文交给 Pi 原生技能加载和展开流程。 */
+export default function nestedSkillsExtension(pi: ExtensionAPI): void {
+  const loaded = loadConfig();
+  const scan = scanSkillRoots(loaded.config.skillRoots);
+  const index = buildSkillIndex(scan);
+
+  pi.on("resources_discover", () => ({
+    // 每个 SKILL.md 单独交给原生 loader，绕过“父目录含 SKILL.md 后停止递归”的规则，
+    // 同时保留 Pi 原生的 frontmatter 校验、正文展开和资源来源信息。
+    skillPaths: index.skillPaths,
+  }));
+
+  pi.on("input", (event) => {
+    if (!INPUT_SOURCES.has(event.source)) return { action: "continue" as const };
+    const transformed = transformSkillInput(event.text, index);
+    if (!transformed) return { action: "continue" as const };
+    return {
+      action: "transform" as const,
+      text: transformed,
+      images: event.images,
+    };
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    notifyDiagnostics(ctx, loaded, index);
+    if (index.aliases.size === 0) return;
+    ctx.ui.addAutocompleteProvider((current) => createAutocompleteProvider(current, index));
+  });
+
+  registerSkillsCommand(pi, index);
+}
+
+export { buildSkillIndex, createAutocompleteProvider, formatSkillsMessage };
+export type { SkillIndex };
+export * from "./config.ts";
+export * from "./skills.ts";

--- a/packages/pi-nested-skills/src/skills.ts
+++ b/packages/pi-nested-skills/src/skills.ts
@@ -1,0 +1,271 @@
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+
+const SKILL_FILE_NAME = "SKILL.md";
+const PATH_SEPARATOR = ".";
+
+export interface NestedSkill {
+  /** 根目录下的技能包名称。 */
+  packName: string;
+  /** 技能包内的目录标识，嵌套层级用点号连接。 */
+  skillDir: string;
+  /** SKILL.md frontmatter 中的技能名称。 */
+  skillName: string;
+  /** SKILL.md frontmatter 中的技能说明。 */
+  description: string;
+  /** SKILL.md 的绝对路径。 */
+  skillPath: string;
+  /** 从技能包目录开始计算的层级，顶层为 1。 */
+  depth: number;
+}
+
+export interface SkillScanWarning {
+  path: string;
+  reason: string;
+}
+
+export interface SkillScanResult {
+  /** 交给 Pi 原生 loader 的全部 SKILL.md 文件路径。 */
+  skillPaths: string[];
+  /** 具有有效 description、可用于别名和补全的技能。 */
+  skills: NestedSkill[];
+  warnings: SkillScanWarning[];
+}
+
+export interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+}
+
+/** 跳过隐藏目录、依赖目录和特殊目录，行为与 Pi 技能发现保持一致。 */
+export function isVisibleSkillDirectory(name: string): boolean {
+  return !name.startsWith(".") && name !== "node_modules" && name !== ".DS_Store";
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const first = trimmed[0];
+  const last = trimmed.at(-1);
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * 读取技能所需的两个 frontmatter 字段。
+ * 完整的技能解析和正文展开仍由 Pi 原生 loader 负责；这里仅建立别名索引。
+ */
+export function parseSkillFrontmatter(content: string): SkillFrontmatter {
+  const match = content.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) return {};
+
+  const result: SkillFrontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const field = line.match(/^(name|description):\s*(.*)$/);
+    if (!field) continue;
+    const value = unquote(field[2]);
+    if (field[1] === "name") result.name = value;
+    else result.description = value;
+  }
+  return result;
+}
+
+function resolveRealPath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function readSkillFile(
+  skillPath: string,
+  packName: string,
+  packDir: string,
+  segments: string[],
+  warnings: SkillScanWarning[],
+): NestedSkill | undefined {
+  let content: string;
+  try {
+    content = readFileSync(skillPath, "utf8");
+  } catch (error) {
+    warnings.push({
+      path: skillPath,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+
+  const frontmatter = parseSkillFrontmatter(content);
+  const description = frontmatter.description?.trim() ?? "";
+  if (!description) {
+    // 仍把文件交给 Pi 原生 loader，让 Pi 的标准诊断负责报告格式问题。
+    return undefined;
+  }
+
+  const relativeDir = relative(packDir, dirname(skillPath));
+  const relativeSegments = relativeDir
+    ? relativeDir.split(/[\\/]/).filter(Boolean)
+    : segments;
+  const skillDir = relativeSegments.join(PATH_SEPARATOR);
+
+  return {
+    packName,
+    skillDir,
+    skillName: frontmatter.name?.trim() || basename(skillPath.replace(/[\\/]SKILL\.md$/, "")),
+    description,
+    skillPath,
+    depth: Math.max(relativeSegments.length, 1),
+  };
+}
+
+function scanPack(
+  packDir: string,
+  packName: string,
+  packRoot: string,
+  segments: string[],
+  result: SkillScanResult,
+  visitedDirectories: Set<string>,
+  visitedFiles: Set<string>,
+): void {
+  const realDirectory = resolveRealPath(packDir);
+  if (visitedDirectories.has(realDirectory)) return;
+  visitedDirectories.add(realDirectory);
+
+  let entries;
+  try {
+    entries = readdirSync(packDir, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+  } catch (error) {
+    result.warnings.push({
+      path: packDir,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  const skillPath = join(packDir, SKILL_FILE_NAME);
+  if (existsSync(skillPath)) {
+    const realSkillPath = resolveRealPath(skillPath);
+    if (!visitedFiles.has(realSkillPath)) {
+      visitedFiles.add(realSkillPath);
+      result.skillPaths.push(skillPath);
+      const skill = readSkillFile(skillPath, packName, packRoot, segments, result.warnings);
+      if (skill) result.skills.push(skill);
+    }
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (!isVisibleSkillDirectory(entry.name)) continue;
+
+    const childPath = join(packDir, entry.name);
+    try {
+      if (!statSync(childPath).isDirectory()) continue;
+    } catch (error) {
+      result.warnings.push({
+        path: childPath,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    scanPack(
+      childPath,
+      packName,
+      packRoot,
+      [...segments, entry.name],
+      result,
+      visitedDirectories,
+      visitedFiles,
+    );
+  }
+}
+
+function scanRoot(
+  root: string,
+  result: SkillScanResult,
+  visitedDirectories: Set<string>,
+  visitedFiles: Set<string>,
+): void {
+  if (!existsSync(root)) {
+    result.warnings.push({ path: root, reason: "directory does not exist" });
+    return;
+  }
+
+  let rootIsDirectory = false;
+  try {
+    rootIsDirectory = lstatSync(root).isDirectory();
+  } catch (error) {
+    result.warnings.push({
+      path: root,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (!rootIsDirectory) {
+    result.warnings.push({ path: root, reason: "skill root is not a directory" });
+    return;
+  }
+
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+  } catch (error) {
+    result.warnings.push({
+      path: root,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  // 支持把单个技能目录直接作为 root，同时保留“root 下是多个技能包”的约定。
+  if (entries.some((entry) => entry.name === SKILL_FILE_NAME)) {
+    scanPack(root, basename(root), root, [], result, visitedDirectories, visitedFiles);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    if (!isVisibleSkillDirectory(entry.name)) continue;
+    const packPath = join(root, entry.name);
+    try {
+      if (!statSync(packPath).isDirectory()) continue;
+    } catch (error) {
+      result.warnings.push({
+        path: packPath,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+    scanPack(packPath, entry.name, packPath, [], result, visitedDirectories, visitedFiles);
+  }
+}
+
+/** 递归发现多个技能根目录下的全部嵌套技能。 */
+export function scanSkillRoots(roots: readonly string[]): SkillScanResult {
+  const result: SkillScanResult = {
+    skillPaths: [],
+    skills: [],
+    warnings: [],
+  };
+  const visitedDirectories = new Set<string>();
+  const visitedFiles = new Set<string>();
+
+  for (const root of roots) {
+    scanRoot(root, result, visitedDirectories, visitedFiles);
+  }
+  return result;
+}

--- a/packages/pi-nested-skills/tests/config.test.ts
+++ b/packages/pi-nested-skills/tests/config.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import {
+  configPath,
+  defaultSkillRoots,
+  loadConfig,
+  resolveSkillRoot,
+} from "../src/config.ts";
+
+function makeAgentDir(): string {
+  return mkdtempSync(join(tmpdir(), "pi-nested-skills-agent-"));
+}
+
+test("uses the Pi agent skills directory by default", () => {
+  const agentDir = makeAgentDir();
+  try {
+    assert.deepEqual(defaultSkillRoots(agentDir), [join(agentDir, "skills")]);
+    const loaded = loadConfig(agentDir, {});
+    assert.deepEqual(loaded.config.skillRoots, [join(agentDir, "skills")]);
+    assert.equal(loaded.source, "default");
+    assert.equal(loaded.explicit, false);
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("resolves environment roots and lets file configuration override them", () => {
+  const agentDir = makeAgentDir();
+  try {
+    const fromEnvironment = loadConfig(agentDir, {
+      PI_NESTED_SKILLS_ROOTS: "~/shared,project-skills",
+    });
+    assert.deepEqual(fromEnvironment.config.skillRoots, [
+      join(process.env.HOME ?? "/tmp", "shared"),
+      join(agentDir, "project-skills"),
+    ]);
+    assert.equal(fromEnvironment.source, "environment");
+
+    mkdirSync(join(agentDir, "extensions", "pi-nested-skills"), { recursive: true });
+    writeFileSync(
+      configPath(agentDir),
+      JSON.stringify({ skillRoots: ["configured-skills"] }),
+    );
+    const fromFile = loadConfig(agentDir, { PI_NESTED_SKILLS_ROOTS: "ignored" });
+    assert.deepEqual(fromFile.config.skillRoots, [join(agentDir, "configured-skills")]);
+    assert.equal(fromFile.source, "file");
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("accepts the legacy single-directory configuration and reports malformed files", () => {
+  const agentDir = makeAgentDir();
+  try {
+    mkdirSync(join(agentDir, "extensions", "pi-nested-skills"), { recursive: true });
+    writeFileSync(configPath(agentDir), JSON.stringify({ skillsDir: "legacy" }));
+    assert.deepEqual(loadConfig(agentDir, {}).config.skillRoots, [join(agentDir, "legacy")]);
+
+    writeFileSync(configPath(agentDir), "not-json");
+    const malformed = loadConfig(agentDir, {});
+    assert.equal(malformed.source, "default");
+    assert.equal(malformed.warnings.length, 1);
+  } finally {
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("expands home and agent-relative paths", () => {
+  assert.equal(resolveSkillRoot("~", "/agent", "/home/test"), "/home/test");
+  assert.equal(resolveSkillRoot("~/skills", "/agent", "/home/test"), "/home/test/skills");
+  assert.equal(resolveSkillRoot("skills", "/agent", "/home/test"), "/agent/skills");
+});

--- a/packages/pi-nested-skills/tests/index.test.ts
+++ b/packages/pi-nested-skills/tests/index.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  buildSkillIndex,
+  resolveSkillAlias,
+  transformSkillInput,
+} from "../src/index.ts";
+import { scanSkillRoots } from "../src/skills.ts";
+
+function createIndex() {
+  const root = mkdtempSync(join(tmpdir(), "pi-nested-skills-index-"));
+  mkdirSync(join(root, "development", "code-reviewer"), { recursive: true });
+  writeFileSync(
+    join(root, "development", "code-reviewer", "SKILL.md"),
+    "---\nname: code-reviewer\ndescription: Review code\n---\nbody\n",
+  );
+  mkdirSync(join(root, "development", "database", "sql"), { recursive: true });
+  writeFileSync(
+    join(root, "development", "database", "sql", "SKILL.md"),
+    "---\nname: sql-generator\ndescription: Generate SQL\n---\nbody\n",
+  );
+  return { root, index: buildSkillIndex(scanSkillRoots([root])) };
+}
+
+test("resolves package aliases and converts them to Pi native skill commands", () => {
+  const { root, index } = createIndex();
+  try {
+    assert.equal(resolveSkillAlias("development:code-reviewer", index)?.skillName, "code-reviewer");
+    assert.equal(resolveSkillAlias("skill:development.database.sql", index)?.skillName, "sql-generator");
+    assert.equal(transformSkillInput("/development:code-reviewer check this", index), "/skill:code-reviewer check this");
+    assert.equal(transformSkillInput("/skill:development.database.sql", index), "/skill:sql-generator");
+    assert.equal(transformSkillInput("/unknown", index), undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("does not guess an ambiguous frontmatter name", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-nested-skills-collision-"));
+  try {
+    for (const pack of ["one", "two"]) {
+      mkdirSync(join(root, pack, "skill"), { recursive: true });
+      writeFileSync(
+        join(root, pack, "skill", "SKILL.md"),
+        "---\nname: shared-name\ndescription: Shared skill\n---\nbody\n",
+      );
+    }
+    const index = buildSkillIndex(scanSkillRoots([root]));
+    assert.equal(resolveSkillAlias("skill:shared-name", index), undefined);
+    assert.equal(transformSkillInput("/one:skill", index), undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("registers resources, input transformation, command and completion hooks", async () => {
+  const { root } = createIndex();
+  try {
+    const events = new Map<string, (...args: unknown[]) => unknown>();
+    const commands = new Map<string, unknown>();
+    let autocompleteFactory: ((current: unknown) => unknown) | undefined;
+    const pi = {
+      on(name: string, handler: unknown) {
+        events.set(name, handler as (...args: unknown[]) => unknown);
+      },
+      registerCommand(name: string, command: unknown) {
+        commands.set(name, command);
+      },
+      sendUserMessage: async () => {},
+    } as unknown as ExtensionAPI;
+
+    process.env.PI_NESTED_SKILLS_ROOTS = root;
+    const context = {
+      hasUI: true,
+      ui: {
+        notify() {},
+        addAutocompleteProvider(factory: (current: unknown) => unknown) {
+          autocompleteFactory = factory;
+        },
+      },
+    } as unknown as ExtensionContext;
+
+    const { default: extension } = await import("../src/index.ts");
+    extension(pi);
+
+    const discover = events.get("resources_discover");
+    assert.ok(discover);
+    const discovered = discover({}, context) as { skillPaths: string[] };
+    assert.equal(discovered.skillPaths.length, 2);
+
+    const input = events.get("input");
+    assert.ok(input);
+    assert.deepEqual(input({ text: "/development:code-reviewer", source: "interactive" }, context), {
+      action: "transform",
+      text: "/skill:code-reviewer",
+      images: undefined,
+    });
+
+    const sessionStart = events.get("session_start");
+    assert.ok(sessionStart);
+    sessionStart({}, context);
+    assert.ok(autocompleteFactory);
+    assert.ok(commands.has("skills"));
+  } finally {
+    delete process.env.PI_NESTED_SKILLS_ROOTS;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-nested-skills/tests/skills.test.ts
+++ b/packages/pi-nested-skills/tests/skills.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import {
+  parseSkillFrontmatter,
+  scanSkillRoots,
+} from "../src/skills.ts";
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), "pi-nested-skills-test-"));
+}
+
+function writeSkill(path: string, name: string, description = "A test skill"): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(
+    join(path, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+  );
+}
+
+test("parses simple quoted and unquoted frontmatter fields", () => {
+  assert.deepEqual(
+    parseSkillFrontmatter(
+      "---\nname: nested-skill\ndescription: \"A nested skill\"\n---\nbody",
+    ),
+    { name: "nested-skill", description: "A nested skill" },
+  );
+  assert.deepEqual(parseSkillFrontmatter("# no frontmatter"), {});
+});
+
+test("discovers direct and deeply nested skills with dot aliases", () => {
+  const root = makeRoot();
+  try {
+    writeSkill(join(root, "development", "code-reviewer"), "code-reviewer");
+    writeSkill(join(root, "development", "database", "sql"), "sql-generator");
+    writeSkill(join(root, "design"), "design-root");
+    writeSkill(join(root, ".hidden", "ignored"), "ignored");
+
+    const result = scanSkillRoots([root]);
+    assert.deepEqual(result.skills.map((skill) => [skill.packName, skill.skillDir, skill.skillName]), [
+      ["design", "", "design-root"],
+      ["development", "code-reviewer", "code-reviewer"],
+      ["development", "database.sql", "sql-generator"],
+    ]);
+    assert.equal(result.skillPaths.length, 3);
+    assert.equal(result.warnings.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("accepts a root that is itself a skill directory and reports missing roots", () => {
+  const skillRoot = makeRoot();
+  const missingRoot = join(skillRoot, "missing");
+  try {
+    writeSkill(skillRoot, "standalone");
+    const result = scanSkillRoots([skillRoot, missingRoot]);
+    assert.equal(result.skills[0]?.packName, skillRoot.split(/[\\/]/).at(-1));
+    assert.equal(result.skills[0]?.skillDir, "");
+    assert.equal(result.warnings[0]?.path, missingRoot);
+  } finally {
+    rmSync(skillRoot, { recursive: true, force: true });
+  }
+});
+
+test("keeps the skill path for Pi native loading even when description is missing", () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, "pack", "broken"), { recursive: true });
+    writeFileSync(join(root, "pack", "broken", "SKILL.md"), "---\nname: broken\n---\n");
+    const result = scanSkillRoots([root]);
+    assert.equal(result.skillPaths.length, 1);
+    assert.equal(result.skills.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-nested-skills/tsconfig.json
+++ b/packages/pi-nested-skills/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "types": ["node"]
+  },
+  "include": ["index.ts", "src/**/*.ts", "tests/**/*.ts"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,7 @@
     "packages/pi-session-tools": {},
     "packages/pi-session-resources": {},
     "packages/pi-dynamic-workflows": {},
-    "packages/pi-interactive-subagents": {}
+    "packages/pi-interactive-subagents": {},
+    "packages/pi-nested-skills": {}
   }
 }


### PR DESCRIPTION
## 内容

支持可配置技能根目录、递归发现、子技能别名、补全和 /skills，不绑定个人技能目录。

- 仅包含本插件源码、测试、双语文档和必要的包/发布登记。
- 不含图片理解插件、fork 或 reflect 迁移。
- 本 PR 不切换本机安装，不自动合并或发布。

## 验证

- `npm run check`：通过，1155 项测试通过。
- `npm run check -w pi-nested-skills`：通过（类型检查、测试、pack dry-run）。
- 真实 Pi/终端/模型运行未验证，测试使用 fixture/fake adapter。
