### PR TITLE
fix: 子代理传递终端归属并避免覆盖共享标题

### DIFF
--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -505,3 +505,14 @@ The sub-agent status supervision and turn-only interruption features were inspir
 ## License
 
 MIT
+
+
+## Naming composition
+
+Subagents do not depend on `pi-naming`. Terminal creation supplies an initial surface label where supported; this extension does not schedule delayed title overwrites or rename the parent's terminal when `/plan` runs. Agent identity and activity remain visible in the subagent widget.
+
+Each launch (Pi or Claude) and Pi resume writes fresh `PI_TERMINAL_RENAME_CONTEXT` ownership data through `pi-terminal-mux`, replacing inherited values. This allows a cooperating naming extension to update only the child's explicitly owned terminal target, never the shared workspace. Shared or unverified window/tab targets remain unchanged.
+
+To use automatic titles or `/rename` in Pi children, explicitly add the installed `pi-naming` entrypoint to `subagentExtensions`. Merely installing both packages in the parent does not enable extensions in isolated child sessions. Naming uses the same terminal-mux protocol and does not import this package.
+
+Publication requires a terminal-mux dependency version providing the ownership API.

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -72,3 +72,14 @@ zellij --session pi   # 然后运行 pi
 ## 许可证
 
 MIT
+
+
+## 与命名插件组合
+
+子代理插件不依赖 `pi-naming`。终端创建时在支持的范围内设置初始 surface 名称；不安排延迟覆盖标题，也不因 `/plan` 修改父终端名称。子代理身份与活动状态仍在 widget 中显示。
+
+每次启动（Pi 或 Claude）以及 Pi 恢复时，通过 `pi-terminal-mux` 写入新的 `PI_TERMINAL_RENAME_CONTEXT` 归属信息，覆盖继承值。配合命名插件时，只允许更新子代理明确拥有的终端目标，不修改共享 workspace。共享或无法确认独占的 window/tab 保持不变。
+
+如需在 Pi 子代理中使用自动标题或 `/rename`，将已安装的 `pi-naming` 入口显式加入 `subagentExtensions`。仅在父会话安装两个包不会开启隔离子会话的扩展。naming 通过相同的 mux 协议协作，不导入本包。
+
+发布时 terminal-mux 依赖版本必须包含归属 API。

--- a/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
@@ -25,9 +25,8 @@ import {
   isMuxAvailable,
   sendEscape,
   shellEscape,
-  renameCurrentTab,
-  renameWorkspace,
-  renameAgent,
+  createSurfaceRenameContext,
+  TERMINAL_RENAME_CONTEXT_ENV,
   readScreen,
   getLastSplitSource,
   clearLastSplitSource,
@@ -1119,7 +1118,14 @@ function registerMuxConfigCommand(pi: ExtensionAPI): void {
   }
 }
 
+/** 每次启动或恢复都用新 surface 重建归属，不能继承父进程的改名范围。 */
+function buildTerminalRenameEnvironment(surface: string, backend = getMuxBackend()): string {
+  const context = createSurfaceRenameContext(surface, backend);
+  return `${TERMINAL_RENAME_CONTEXT_ENV}=${shellEscape(JSON.stringify(context))}`;
+}
+
 export const __test__ = {
+  buildTerminalRenameEnvironment,
   borderLine,
   parseMuxConfigRequest,
   getShellReadyDelayMs,
@@ -1198,6 +1204,7 @@ async function launchSubagent(
   // For new surfaces, pause briefly so the shell is ready before sending the command.
   const surfacePreCreated = !!options?.surface;
   const surface = options?.surface ?? createSurface(params.name);
+  const renameEnvironment = buildTerminalRenameEnvironment(surface);
   const splitFrom = surfacePreCreated ? undefined : (getLastSplitSource() ?? undefined);
   if (!surfacePreCreated) clearLastSplitSource();
   if (!surfacePreCreated) {
@@ -1236,7 +1243,7 @@ async function launchSubagent(
     const sentinelFile = `/tmp/pi-claude-${id}-done`;
     const pluginDir = join(SUBAGENTS_DIR, "plugin");
 
-    const cmdParts: string[] = [];
+    const cmdParts: string[] = [renameEnvironment];
     cmdParts.push(`PI_CLAUDE_SENTINEL=${shellEscape(sentinelFile)}`);
     cmdParts.push("claude");
     cmdParts.push("--dangerously-skip-permissions");
@@ -1340,7 +1347,7 @@ async function launchSubagent(
   }
 
   // Build env prefix: denied tools + subagent identity + config dir propagation
-  const envParts: string[] = [];
+  const envParts: string[] = [renameEnvironment];
 
   // If the target cwd has its own .pi/agent/, use that as the config root.
   // Otherwise propagate the current/global agent dir.
@@ -1412,12 +1419,6 @@ async function launchSubagent(
       `# Surface: ${surface}`,
     ].join("\n"),
   });
-
-  // 延迟重命名 agent 标题（左侧侧栏），需要等 pi 启动被 herdr 检测到
-  const agentName = params.name;
-  const agentSurface = surface;
-  setTimeout(() => renameAgent(agentSurface, agentName), 3000);
-  setTimeout(() => renameAgent(agentSurface, agentName), 5000);
 
   const running: RunningSubagent = {
     id,
@@ -2036,6 +2037,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const entryCountBefore = getNewEntries(params.sessionPath, 0).length;
 
         const surface = createSurface(name);
+        const renameEnvironment = buildTerminalRenameEnvironment(surface);
         await new Promise<void>((resolve) => setTimeout(resolve, getShellReadyDelayMs()));
 
         // Build pi resume command
@@ -2065,7 +2067,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         }
 
         // Build env prefix — propagate PI_CODING_AGENT_DIR for config isolation
-        const resumeEnvParts: string[] = [];
+        const resumeEnvParts: string[] = [renameEnvironment];
         const { allowSubagentSpawning } = loadSubagentSpawningConfig();
         if (process.env.PI_CODING_AGENT_DIR) {
           resumeEnvParts.push(`PI_CODING_AGENT_DIR=${shellEscape(process.env.PI_CODING_AGENT_DIR)}`);
@@ -2073,6 +2075,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         resumeEnvParts.push(`PI_SUBAGENT_NAME=${shellEscape(name)}`);
         resumeEnvParts.push(`PI_SUBAGENT_SESSION=${shellEscape(params.sessionPath)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ID=${shellEscape(id)}`);
+        resumeEnvParts.push(`PI_SUBAGENT_SURFACE=${shellEscape(surface)}`);
         resumeEnvParts.push(`PI_SUBAGENT_ACTIVITY_FILE=${shellEscape(activityFile)}`);
         resumeEnvParts.push(
           `PI_DENY_TOOLS=${shellEscape([...resolveDenyTools(null, allowSubagentSpawning)].join(","))}`,
@@ -2378,17 +2381,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       if (!task) {
         ctx.ui.notify("Usage: /plan <what to build>", "warning");
         return;
-      }
-
-      // Rename workspace and tab to show this is a planning session
-      if (isMuxAvailable()) {
-        try {
-          const label = task.length > 40 ? task.slice(0, 40) + "..." : task;
-          renameWorkspace(`🎯 ${label}`);
-          renameCurrentTab(`🎯 Plan: ${label}`);
-        } catch {
-          // non-critical -- do not block the plan
-        }
       }
 
       // Load the plan skill from the subagents extension directory

--- a/packages/pi-interactive-subagents/test/test.ts
+++ b/packages/pi-interactive-subagents/test/test.ts
@@ -4,6 +4,8 @@ import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { TERMINAL_RENAME_CONTEXT_ENV, readSurfaceRenameContext } from "pi-terminal-mux";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import * as subagentsModule from "../pi-extension/subagents/index.ts";
 
@@ -2586,5 +2588,30 @@ describe("cmux.ts", () => {
       const result = isWezTermAvailable();
       assert.equal(typeof result, "boolean");
     });
+  });
+});
+
+
+describe("terminal rename ownership", () => {
+  it("launch and resume environment replaces inherited ownership with the new surface", () => {
+    const inherited = { version: 1, backend: "cmux", surface: "parent", ownedTarget: { target: "tab", id: "parent" } };
+    for (const surface of ["child-launch", "child-resume", "child-'quoted"]) {
+      const assignment = subagentsModule.__test__.buildTerminalRenameEnvironment(surface, "cmux");
+      const script = `${assignment} ${shellEscape(process.execPath)} -e ${shellEscape(`process.stdout.write(process.env.${TERMINAL_RENAME_CONTEXT_ENV})`)}`;
+      const output = execFileSync("sh", ["-c", script], {
+        encoding: "utf8", env: { ...process.env, [TERMINAL_RENAME_CONTEXT_ENV]: JSON.stringify(inherited) },
+      });
+      const context = readSurfaceRenameContext({ [TERMINAL_RENAME_CONTEXT_ENV]: output });
+      assert.equal(context?.surface, surface);
+      assert.deepEqual(context?.ownedTarget, { target: "tab", id: surface });
+    }
+  });
+
+  it("shared or headless surfaces never grant a workspace or shared tab", () => {
+    for (const backend of ["tmux", "wezterm", "otty", "orca", null] as const) {
+      const assignment = subagentsModule.__test__.buildTerminalRenameEnvironment("child", backend);
+      assert.ok(assignment.includes('"ownedTarget":null'));
+      assert.ok(!assignment.includes('"target":"workspace"'));
+    }
   });
 });


### PR DESCRIPTION
## 问题

子会话需要明确的终端归属，不能因为更新标题覆盖父 workspace 或共享 tab，也不能在命名插件已经命名后由延迟回调再次覆盖。

## 改动

- Pi/Claude 启动及 Pi 恢复均通过 terminal-mux 生成新的 `PI_TERMINAL_RENAME_CONTEXT`，覆盖继承的父归属；恢复时也传递新 surface ID。
- 删除延迟 Herdr agent 改名与 `/plan` 修改父 workspace/tab 的逻辑。保留创建时支持的初始 surface 名称与 widget 身份/状态。
- 不依赖 pi-naming 或 session-tools。需要在子进程启用 naming 时仍由用户通过 subagentExtensions 显式加载，保持扩展隔离。
- 补充归属传递测试和双语使用说明。

## 验证

- 本分支全仓 1166 项测试通过；子代理包 131 项测试、类型检查和 pack dry-run 通过。
- 与 #139 在临时 worktree 合并：全仓 1194 项测试通过。
- 3 条 launcher → naming → mux 命令级组合 smoke 通过，覆盖主会话、独占 cmux 子 surface、共享 tmux 子 pane；无真实模型或终端副作用。
- 真实 Pi/终端/模型运行 NOT_RUN，未切换本机安装。

## 依赖

基于 #134，只依赖其公共 mux API，不依赖 #139。#134 合并后改 base 为 main 并运行 CI。发布前通过 release-please 对齐实际包含归属 API 的 mux 版本与依赖下限；当前 ^0.4.1 不能视为已发布此 API。

本 PR 不执行远程合并或发布。
