### PR TITLE
feat: 统一插件配置文件与斜杠命令

### DIFF
--- a/packages/pi-metrics/README.md
+++ b/packages/pi-metrics/README.md
@@ -11,9 +11,19 @@ Session metrics for the [Pi coding agent](https://github.com/earendil-works/pi):
 - When the agent fully settles (`agent_settled` — including auto-retries, compaction continuations, or Esc interruption), a final line shows the **total elapsed time from message send to stop** (`⏱ Total elapsed 18.9s`).
 - After each LLM turn, a notification reports TPS, TTFT, token counts, generation time, stalls, and blended cost when available.
 - Telemetry is persisted as `tps` custom session entries and restored after session resume or `/tree` navigation.
-- Metrics are exposed through session entries and notifications; this package does not register export slash commands.
+- Metrics are exposed through session entries and notifications. Use `/config:metrics enable|disable` to persist whether the metrics handlers are active, or pass the complete JSON configuration; `/config:metrics` without arguments opens an editor.
 
-## Migration from pi-tps
+## Configuration
+
+The configuration file is `<pi-agent-dir>/extensions/pi-metrics/config.json`:
+
+```json
+{
+  "enabled": true
+}
+```
+
+Use `/config:metrics enable` or `/config:metrics disable` to update it, and run `/reload` after manually editing the file. See [`config.example.json`](./config.example.json).
 
 The TPS implementation is maintained in this package. Remove the standalone `npm:@monotykamary/pi-tps` entry from Pi settings before enabling this package, otherwise both extensions will record duplicate `tps` entries and notifications.
 

--- a/packages/pi-metrics/README.zh-CN.md
+++ b/packages/pi-metrics/README.zh-CN.md
@@ -11,7 +11,19 @@
 - AI 完全停止时（`agent_settled`，覆盖自动重试、compaction 续跑以及 Esc 中断）追加一行**从发出消息到停止的总耗时**（`⏱ 总耗时 18.9s`）。
 - 每轮 LLM 调用结束后显示 TPS、TTFT、token 数、生成耗时、stall 和可用的综合成本。
 - Telemetry 以 `tps` custom session entry 持久化，并在恢复 session 或 `/tree` 后恢复显示。
-- Metrics 通过 session entry 和通知提供；本包不再注册导出类斜杠命令。
+- Metrics 通过 session entry 和通知提供。使用 `/config:metrics enable|disable` 持久化控制指标处理器，也可以传入完整 JSON；不带参数的 `/config:metrics` 会打开编辑输入。
+
+## 配置
+
+配置文件为 `<Pi agent 目录>/extensions/pi-metrics/config.json`：
+
+```json
+{
+  "enabled": true
+}
+```
+
+使用 `/config:metrics enable` 或 `/config:metrics disable` 修改配置；手动修改文件后执行 `/reload`。可参考 [`config.example.json`](./config.example.json)。
 
 ## 从 pi-tps 迁移
 

--- a/packages/pi-metrics/SKILL.md
+++ b/packages/pi-metrics/SKILL.md
@@ -5,7 +5,7 @@ description: "启用与排查 pi-metrics 的耗时、TPS、TTFT、token 和成�
 
 # 配置 pi-metrics
 
-`pi-metrics` 当前没有配置文件或配置命令；不要编造开关、阈值或导出命令。配置动作仅限安装、启用或禁用该 package，以及共享语言设置。
+配置文件为 `<Pi agent 目录>/extensions/pi-metrics/config.json`，字段只有 `enabled`，默认是 `true`。可以使用 `/config:metrics enable|disable` 修改并持久化，也可以传入完整 JSON；省略参数时进入交互编辑。手动修改配置文件后执行 `/reload`。
 
 ## 诊断与修改
 

--- a/packages/pi-metrics/config.example.json
+++ b/packages/pi-metrics/config.example.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/packages/pi-metrics/locales/index.json
+++ b/packages/pi-metrics/locales/index.json
@@ -38,5 +38,29 @@
   "tpsRate": {
     "zh-CN": "${value}/M",
     "en-US": "${value}/M"
+  },
+  "configCommandDescription": {
+    "zh-CN": "配置指标显示（enable、disable 或 JSON）",
+    "en-US": "Configure metrics display (enable, disable, or JSON)"
+  },
+  "configCommandInput": {
+    "zh-CN": "输入 pi-metrics 配置 JSON（输入 reset 恢复默认值）",
+    "en-US": "Enter pi-metrics configuration JSON (or reset for defaults)"
+  },
+  "configCommandInteractiveOnly": {
+    "zh-CN": "无交互界面时请直接传入 enable、disable 或配置 JSON。",
+    "en-US": "Pass enable, disable, or configuration JSON when no interactive UI is available."
+  },
+  "configCommandSaved": {
+    "zh-CN": "指标配置已保存：{path}。请执行 /reload 使配置生效。",
+    "en-US": "Metrics configuration saved to {path}. Run /reload to apply it."
+  },
+  "configCommandInvalid": {
+    "zh-CN": "指标配置无效：{error}",
+    "en-US": "Invalid metrics configuration: {error}"
+  },
+  "configLoadFailed": {
+    "zh-CN": "指标配置读取失败：{path}（{error}）。当前继续启用指标。",
+    "en-US": "Failed to read metrics configuration: {path} ({error}). Metrics remain enabled."
   }
 }

--- a/packages/pi-metrics/src/config.ts
+++ b/packages/pi-metrics/src/config.ts
@@ -1,0 +1,52 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const EXTENSIONS_DIRECTORY = "extensions";
+const PACKAGE_NAME = "pi-metrics";
+const CONFIG_FILE_NAME = "config.json";
+const UTF8_ENCODING = "utf8";
+const FILE_NOT_FOUND_CODE = "ENOENT";
+
+export interface MetricsConfig {
+  enabled: boolean;
+}
+
+export const DEFAULT_METRICS_CONFIG: MetricsConfig = { enabled: true };
+
+/** 返回 pi-metrics 配置文件路径。 */
+export function configPath(agentDir = getAgentDir()): string {
+  return join(agentDir, EXTENSIONS_DIRECTORY, PACKAGE_NAME, CONFIG_FILE_NAME);
+}
+
+/** 解析并校验 pi-metrics 配置。 */
+export function parseConfig(value: unknown): MetricsConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("configuration must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  for (const key of Object.keys(raw)) {
+    if (key !== "enabled") throw new Error(`unknown configuration field: ${key}`);
+  }
+  if (raw.enabled !== undefined && typeof raw.enabled !== "boolean") {
+    throw new Error("enabled must be a boolean");
+  }
+  return { enabled: (raw.enabled as boolean | undefined) ?? DEFAULT_METRICS_CONFIG.enabled };
+}
+
+/** 读取配置文件；缺少文件时使用默认启用状态。 */
+export function loadConfig(path = configPath()): MetricsConfig {
+  try {
+    return parseConfig(JSON.parse(readFileSync(path, UTF8_ENCODING)));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === FILE_NOT_FOUND_CODE) return { ...DEFAULT_METRICS_CONFIG };
+    throw error;
+  }
+}
+
+/** 将经过校验的配置写入配置文件。 */
+export function saveConfig(config: MetricsConfig, path = configPath()): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, UTF8_ENCODING);
+  return path;
+}

--- a/packages/pi-metrics/src/index.ts
+++ b/packages/pi-metrics/src/index.ts
@@ -1,12 +1,101 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { createTranslator, loadCatalog } from "pi-extensions-i18n";
 import turnElapsed from "./turn-elapsed.ts";
 import tps from "./tps.ts";
+import { configPath, loadConfig, parseConfig, saveConfig, type MetricsConfig } from "./config.ts";
 
+const messages = loadCatalog(new URL("../locales/index.json", import.meta.url));
+const i18n = createTranslator(messages);
+const CONFIG_COMMAND_ALIASES = ["config:metrics", "metrics-config", "pi-metrics-config"] as const;
+const CONFIG_RESET_COMMAND = "reset";
+const ENABLE_COMMAND = "enable";
+const DISABLE_COMMAND = "disable";
+const NOTICE_WARNING = "warning" as const;
+const NOTICE_INFO = "info" as const;
+const NOTICE_ERROR = "error" as const;
+
+/** 注册配置命令，允许通过 JSON 参数或交互式输入持久化 metrics 配置。 */
+function registerConfigCommand(pi: ExtensionAPI): void {
+  const command = {
+    description: i18n.t("configCommandDescription"),
+    /** Completes the supported enable, disable and reset actions. */
+    getArgumentCompletions: () => [
+      { value: ENABLE_COMMAND, label: ENABLE_COMMAND },
+      { value: DISABLE_COMMAND, label: DISABLE_COMMAND },
+      { value: CONFIG_RESET_COMMAND, label: CONFIG_RESET_COMMAND },
+    ],
+    /** Parses and persists a complete JSON configuration or a short action. */
+    handler: async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+      let value = args.trim();
+      if (!value) {
+        if (!ctx.hasUI) {
+          ctx.ui.notify(i18n.t("configCommandInteractiveOnly"), NOTICE_WARNING);
+          return;
+        }
+        let current: MetricsConfig;
+        try {
+          current = loadConfig();
+        } catch (error) {
+          ctx.ui.notify(i18n.t("configCommandInvalid", {
+            error: error instanceof Error ? error.message : String(error),
+          }), NOTICE_ERROR);
+          return;
+        }
+        const input = await ctx.ui.input(i18n.t("configCommandInput"), JSON.stringify(current));
+        if (input === undefined) return;
+        value = input.trim();
+      }
+
+      try {
+        const config = value === ENABLE_COMMAND
+          ? parseConfig({ enabled: true })
+          : value === DISABLE_COMMAND
+            ? parseConfig({ enabled: false })
+            : value === CONFIG_RESET_COMMAND
+              ? parseConfig({})
+              : parseConfig(JSON.parse(value));
+        const path = saveConfig(config);
+        ctx.ui.notify(i18n.t("configCommandSaved", { path }), NOTICE_INFO);
+      } catch (error) {
+        ctx.ui.notify(i18n.t("configCommandInvalid", {
+          error: error instanceof Error ? error.message : String(error),
+        }), NOTICE_ERROR);
+      }
+    },
+  };
+  for (const name of CONFIG_COMMAND_ALIASES) pi.registerCommand(name, command);
+}
+
+/** 注册耗时和 TPS 指标事件；配置关闭时不注册指标处理器。 */
 export default function piHud(pi: ExtensionAPI): void {
+  registerConfigCommand(pi);
+  let config: MetricsConfig;
+  let configError: unknown;
+  try {
+    config = loadConfig();
+  } catch (error) {
+    config = { enabled: true };
+    configError = error;
+  }
+  if (configError !== undefined) {
+    pi.on("session_start", (_event, ctx: ExtensionContext) => {
+      ctx.ui.notify(i18n.t("configLoadFailed", {
+        path: configPath(),
+        error: configError instanceof Error ? configError.message : String(configError),
+      }), NOTICE_WARNING);
+    });
+  }
+  if (!config.enabled) return;
   turnElapsed(pi);
   tps(pi);
 }
 
+export { configPath, loadConfig, parseConfig, saveConfig } from "./config.ts";
+export type { MetricsConfig } from "./config.ts";
 export { default as turnElapsed } from "./turn-elapsed.ts";
 export { default as tps } from "./tps.ts";
 export * from "./format-utils.ts";

--- a/packages/pi-metrics/tests/config.test.ts
+++ b/packages/pi-metrics/tests/config.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import { loadConfig, parseConfig, saveConfig } from "../src/config.ts";
+
+test("uses enabled metrics by default and persists file configuration", () => {
+  const directory = mkdtempSync(join(tmpdir(), "pi-metrics-config-"));
+  const path = join(directory, "extensions", "pi-metrics", "config.json");
+  try {
+    assert.deepEqual(loadConfig(path), { enabled: true });
+    saveConfig(parseConfig({ enabled: false }), path);
+    assert.deepEqual(loadConfig(path), { enabled: false });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects unknown and invalid fields", () => {
+  assert.throws(() => parseConfig({ unknown: true }), /unknown configuration field/);
+  assert.throws(() => parseConfig({ enabled: "yes" }), /enabled must be a boolean/);
+});

--- a/packages/pi-naming/README.md
+++ b/packages/pi-naming/README.md
@@ -14,6 +14,7 @@ Available through npm after publication. Run `/reload` after installation or con
 
 - **Automatic naming**: the first real user input in a new, unnamed session generates a title in the background and applies it to the allowed session, workspace and tab targets.
 - **`/rename [name]`**: supply an explicit name, or omit it to generate one from user messages on the current branch. Uses the same targets and execution path as automatic naming.
+- **`/config:naming`**: edit the complete JSON configuration interactively, or pass JSON directly; use `reset` to restore defaults.
 - Manual generation considers all user input on the current branch and names the main task. Explicit later corrections or goal changes take precedence; procedural follow-ups such as “continue”, “verify”, or “commit” should not overshadow the topic. Other branches, assistant replies and tool output are excluded. Automatic naming still attempts only once on the first input, not after every turn.
 - Automatic results do not overwrite an existing name. Manual commands supersede pending requests; session switches and reloads discard old results and errors.
 - Each target is independent. Unsupported, disabled, unidentified or failed terminal targets are reported without preventing session naming or other target updates. Non-UI modes receive Pi messages instead of silent failures.
@@ -63,7 +64,7 @@ For longer English titles use `maxLength: 60`, `preferredLength: 40`, `language:
 - tmux/WezTerm/Otty/Orca splits do not prove exclusive window/tab ownership. Unverified targets are skipped with an explanation rather than expanding the operation's scope.
 - With `pi-interactive-subagents`, explicitly include this package's entrypoint in `subagentExtensions`. Installing it in the parent does not bypass child extension isolation.
 
-Ordinary sessions still respect mux backend opt-ins: `PI_SUBAGENT_RENAME_TMUX_WINDOW=1`, `PI_SUBAGENT_RENAME_TMUX_SESSION=1`, `PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`. Missing target IDs never fall back to current focus or the first tab. Actual targets can be panes, tabs, windows, workspaces or sessions and are reported in results.
+Ordinary sessions use the configured terminal-mux defaults. The following terminal-mux variables remain only as compatibility inputs for older launchers: `PI_SUBAGENT_RENAME_TMUX_WINDOW=1`, `PI_SUBAGENT_RENAME_TMUX_SESSION=1`, `PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`. Missing target IDs never fall back to current focus or the first tab. Actual targets can be panes, tabs, windows, workspaces or sessions and are reported in results.
 
 Before publication, align the terminal-mux dependency minimum with a published version providing the target ownership API.
 

--- a/packages/pi-naming/README.zh-CN.md
+++ b/packages/pi-naming/README.zh-CN.md
@@ -14,6 +14,7 @@ pi install npm:pi-naming
 
 - **首条消息自动命名**：新建且未命名的 session 收到首条真实用户输入后，后台生成标题，同步允许修改的 session、workspace 和 tab。
 - **`/rename [名称]`**：显式指定名称，或省略名称、根据当前分支用户消息生成标题。与自动命名使用相同的目标配置和执行逻辑。
+- **`/config:naming`**：交互编辑完整 JSON 配置，也可以直接传入 JSON；输入 `reset` 恢复默认值。
 - 手动生成时综合当前分支的全部用户输入，围绕主要任务命名；后续明确纠正或目标变更优先，“继续”“验证一下”“提交”等流程性跟进不应盖过主题。不会读取其他分支、assistant 回复或工具输出。自动命名仍仅在首条输入时尝试一次，不随每轮对话更新。
 - 不覆盖已有名称的自动命名结果。手动命令优先于尚未完成的旧请求；会话切换或 reload 后丢弃旧结果和错误。
 - 各目标独立执行。终端不支持、被禁用、缺少归属信息或改名失败均明确报告，不阻止 session 和其他可用目标改名。无交互 UI 时通过 Pi 消息报告。
@@ -63,7 +64,7 @@ pi install npm:pi-naming
 - tmux/WezTerm/Otty/Orca 分屏不代表独占 window/tab，归属无法确认时跳过并说明原因，不扩大操作范围。
 - 使用 `pi-interactive-subagents` 时，需在它的 `subagentExtensions` 中显式加载本包入口；仅在主会话安装本包不会绕过子代理的扩展隔离设置。
 
-普通会话仍遵守 mux 后端的显式开关：`PI_SUBAGENT_RENAME_TMUX_WINDOW=1`、`PI_SUBAGENT_RENAME_TMUX_SESSION=1`、`PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`。终端目标缺少 ID 时不会使用当前焦点或第一个 tab 代替。实际目标可能是 pane、tab、window、workspace 或 session，结果中会说明。
+普通会话使用配置文件中的 mux 默认值。以下终端变量仅作为旧版启动器的兼容输入保留：`PI_SUBAGENT_RENAME_TMUX_WINDOW=1`、`PI_SUBAGENT_RENAME_TMUX_SESSION=1`、`PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`。终端目标缺少 ID 时不会使用当前焦点或第一个 tab 代替。实际目标可能是 pane、tab、window、workspace 或 session，结果中会说明。
 
 发布前，terminal-mux 依赖下限必须对齐实际提供目标归属 API 的已发布版本。
 

--- a/packages/pi-naming/SKILL.md
+++ b/packages/pi-naming/SKILL.md
@@ -5,9 +5,9 @@ description: 配置 Pi 统一 /rename、首条消息命名和终端目标归属�
 
 # 配置 pi-naming / Configure pi-naming
 
-配置文件为 `<pi-agent-dir>/extensions/pi-naming/config.json`，遵守 `PI_CODING_AGENT_DIR`，修改后 `/reload`。字段和默认值见 [中文说明](./README.zh-CN.md)、[English](./README.md)、[配置示例](./config.example.json)。
+配置文件为 `<pi-agent-dir>/extensions/pi-naming/config.json`，遵守 `PI_CODING_AGENT_DIR`。可以使用 `/config:naming` 交互编辑，也可以传入完整 JSON；输入 `reset` 恢复默认值，保存后 `/reload`。字段和默认值见 [中文说明](./README.zh-CN.md)、[English](./README.md)、[配置示例](./config.example.json)。
 
-Read `<pi-agent-dir>/extensions/pi-naming/config.json`, respecting `PI_CODING_AGENT_DIR`; reload after changes. See the linked documentation and example for fields and defaults.
+Read `<pi-agent-dir>/extensions/pi-naming/config.json`, respecting `PI_CODING_AGENT_DIR`. Use `/config:naming` for interactive editing or pass complete JSON; use `reset` for defaults and reload after saving. See the linked documentation and example for fields and defaults.
 
 - `automaticNaming` / `manualNaming` 控制自动输入和 `/rename [名称]`，`targets` 分别控制 session/workspace/tab。Control automatic input and `/rename [name]`; `targets` selects session/workspace/tab.
 - `title` 控制长度、语言、补充提示和超时；模型鉴权复用 Pi。Controls length, language, instructions and timeout; model authentication comes from Pi.

--- a/packages/pi-naming/locales/index.json
+++ b/packages/pi-naming/locales/index.json
@@ -114,5 +114,25 @@
   "piSessionTarget": {
     "zh-CN": "Pi 会话",
     "en-US": "Pi session"
+  },
+  "configCommandDescription": {
+    "zh-CN": "配置命名插件（参数为 JSON，省略参数时进入编辑）",
+    "en-US": "Configure naming (pass JSON, or omit it to edit interactively)"
+  },
+  "configCommandInput": {
+    "zh-CN": "输入完整的命名配置 JSON（输入 reset 恢复默认值）",
+    "en-US": "Enter the complete naming configuration JSON (or reset for defaults)"
+  },
+  "configCommandInteractiveOnly": {
+    "zh-CN": "无交互界面时请直接传入配置 JSON。",
+    "en-US": "Pass configuration JSON directly when no interactive UI is available."
+  },
+  "configCommandSaved": {
+    "zh-CN": "命名配置已保存：{path}。请执行 /reload 使配置生效。",
+    "en-US": "Naming configuration saved to {path}. Run /reload to apply it."
+  },
+  "configCommandInvalid": {
+    "zh-CN": "命名配置无效：{error}",
+    "en-US": "Invalid naming configuration: {error}"
   }
 }

--- a/packages/pi-naming/src/config.ts
+++ b/packages/pi-naming/src/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { i18n } from "./i18n.ts";
 
@@ -91,9 +91,25 @@ export function parseConfig(value: unknown): NamingConfig {
   };
 }
 
+/** 返回当前 Pi agent 目录下的命名配置路径。 */
+export function configPath(
+  agentDir = getAgentDir(),
+): string {
+  return join(agentDir, EXTENSIONS_DIR, PACKAGE_NAME, CONFIG_FILENAME);
+}
+
+/** 将经过校验的配置完整写入配置文件，供配置斜杠命令使用。 */
+export function saveConfig(
+  config: NamingConfig,
+  path = configPath(),
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+}
+
 /** 仅缺少配置文件时采用默认值，读取和解析错误交给入口报告。 */
 export function loadConfig(
-  path = join(getAgentDir(), EXTENSIONS_DIR, PACKAGE_NAME, CONFIG_FILENAME),
+  path = configPath(),
 ): NamingConfig {
   try {
     return parseConfig(JSON.parse(readFileSync(path, "utf8")));

--- a/packages/pi-naming/src/index.ts
+++ b/packages/pi-naming/src/index.ts
@@ -1,10 +1,12 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { TerminalRenameOutcome, TerminalRenameTarget, ResolveRenameOptions } from "pi-terminal-mux";
-import { loadConfig, type NamingConfig } from "./config.ts";
+import { configPath, loadConfig, parseConfig, saveConfig, type NamingConfig } from "./config.ts";
 import { i18n } from "./i18n.ts";
 import { getCurrentSessionUserMessages, requestSessionNameWithTimeout, type SessionNameRequester } from "./session-name.ts";
 
 const RENAME_COMMAND = "rename";
+const CONFIG_COMMAND_ALIASES = ["config:naming", "naming-config", "pi-naming-config"] as const;
+const CONFIG_RESET_COMMAND = "reset";
 const MESSAGE_TYPE = "pi-naming";
 
 export interface TerminalNamingAdapter {
@@ -28,6 +30,54 @@ function report(pi: ExtensionAPI, ctx: ExtensionContext, notice: { message: stri
   const { message, level } = notice;
   if (ctx.hasUI) ctx.ui.notify(message, level);
   else pi.sendMessage({ customType: MESSAGE_TYPE, content: message, display: true }, { triggerTurn: false });
+}
+
+/** 注册配置命令，允许通过 JSON 参数或交互式输入持久化命名配置。 */
+function registerNamingConfigCommand(pi: ExtensionAPI): void {
+  const command = {
+    description: i18n.t("configCommandDescription"),
+    getArgumentCompletions: () => null,
+    handler: async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+      let value = args.trim();
+      if (!value) {
+        if (!ctx.hasUI) {
+          report(pi, ctx, { message: i18n.t("configCommandInteractiveOnly"), level: "warning" });
+          return;
+        }
+        let current: NamingConfig;
+        try {
+          current = loadConfig();
+        } catch (error) {
+          report(pi, ctx, {
+            message: i18n.t("configCommandInvalid", { error: errorMessage(error) }),
+            level: "error",
+          });
+          return;
+        }
+        const input = await ctx.ui.input(
+          i18n.t("configCommandInput"),
+          JSON.stringify(current),
+        );
+        if (input === undefined) return;
+        value = input.trim();
+      }
+
+      try {
+        const config = value === CONFIG_RESET_COMMAND ? parseConfig({}) : parseConfig(JSON.parse(value));
+        saveConfig(config);
+        report(pi, ctx, {
+          message: i18n.t("configCommandSaved", { path: configPath() }),
+          level: "info",
+        });
+      } catch (error) {
+        report(pi, ctx, {
+          message: i18n.t("configCommandInvalid", { error: errorMessage(error) }),
+          level: "error",
+        });
+      }
+    },
+  };
+  for (const name of CONFIG_COMMAND_ALIASES) pi.registerCommand(name, command);
 }
 
 /** 按配置组合统一的自动/手动入口，可注入模型和终端替身做组合测试。 */
@@ -139,6 +189,7 @@ export async function registerNaming(
 
 /** 配置错误在 session_start 报告，不注册不完整的命名功能。 */
 export default async function namingExtension(pi: ExtensionAPI): Promise<void> {
+  registerNamingConfigCommand(pi);
   let config: NamingConfig;
   try { config = loadConfig(); }
   catch (error) {

--- a/packages/pi-nested-skills/README.md
+++ b/packages/pi-nested-skills/README.md
@@ -11,6 +11,7 @@ A Pi extension that discovers skills recursively and provides convenient aliases
 - Keeps Pi's native skill loader responsible for frontmatter validation and skill-body expansion; this package does not duplicate `read` compatibility or skill expansion.
 - Extends the native slash-command completion list and preserves built-in Pi command suggestions.
 - Provides `/skills` to list discovered aliases.
+- Provides `/config:nested-skills` to edit the skill roots; pass JSON directly or omit it for interactive editing, and use `reset` for the default `skills` root.
 - Contributes discovered skill files through Pi's `resources_discover` event.
 - Uses `pi-extensions-i18n` for all user-visible messages.
 
@@ -43,13 +44,7 @@ Start from [`config.example.json`](./config.example.json) and write it to:
 
 A relative root is resolved relative to the Pi agent directory. Each direct child of a root is treated as a skill package, and every visible descendant containing `SKILL.md` is discovered. A root containing `SKILL.md` itself is also accepted as one package.
 
-Environment fallback:
-
-```text
-PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
-```
-
-The file configuration takes precedence over the environment, and the environment takes precedence over the default `<pi-agent-dir>/skills` root. `PI_NESTED_SKILLS_DIR` remains a compatibility alias for one root.
+Use `/config:nested-skills` to edit this configuration. The command accepts the complete JSON object as an argument; without arguments it opens an interactive editor. Run `/reload` after saving.
 
 ## Aliases and native expansion
 

--- a/packages/pi-nested-skills/README.zh-CN.md
+++ b/packages/pi-nested-skills/README.zh-CN.md
@@ -11,6 +11,7 @@ Pi 的嵌套技能扩展：递归发现多级 `SKILL.md`，并为嵌套技能提
 - 保留 Pi 原生技能加载器负责 frontmatter 校验和正文展开；不重复实现 `read` 兼容层或技能展开。
 - 将嵌套技能补全合并到 Pi 原生斜杠命令补全中，不影响内置命令。
 - 提供 `/skills` 列出发现到的全部别名。
+- 提供 `/config:nested-skills` 配置技能根目录；可以直接传入 JSON，也可以省略参数进入交互编辑，输入 `reset` 恢复默认的 `skills` 根目录。
 - 通过 Pi 的 `resources_discover` 事件注册发现到的技能文件。
 - 所有用户可见文案都通过 `pi-extensions-i18n` 提供中英文版本。
 
@@ -43,13 +44,7 @@ pi install npm:pi-nested-skills
 
 相对路径以 Pi agent 目录为基准。根目录的每个直接子目录视为一个技能包，扩展会递归发现其中所有可见目录下的 `SKILL.md`。如果根目录本身包含 `SKILL.md`，也会把它作为一个技能包处理。
 
-环境变量兜底：
-
-```text
-PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
-```
-
-配置文件优先于环境变量，环境变量优先于默认的 `<Pi agent 目录>/skills`。`PI_NESTED_SKILLS_DIR` 作为单根目录的兼容别名保留。
+使用 `/config:nested-skills` 修改配置。命令参数为完整 JSON；省略参数时打开交互编辑。保存后执行 `/reload`。
 
 ## 别名与原生展开
 

--- a/packages/pi-nested-skills/SKILL.md
+++ b/packages/pi-nested-skills/SKILL.md
@@ -21,13 +21,7 @@ extensions/pi-nested-skills/config.json
 
 优先复制包内 [`config.example.json`](./config.example.json)，再修改 `skillRoots`。路径可以是绝对路径、`~/` 路径，或相对于 Pi agent 目录的路径。
 
-也可以使用环境变量：
-
-```text
-PI_NESTED_SKILLS_ROOTS=~/shared-skills,skills
-```
-
-配置文件优先于环境变量；环境变量优先于默认的 Pi agent `skills` 目录。`PI_NESTED_SKILLS_DIR` 作为旧单目录名称保留兼容读取。
+也可以使用 `/config:nested-skills` 修改配置；命令可以直接接收完整 JSON，省略参数时进入交互编辑。保存后执行 `/reload`。
 
 别名形式为 `/技能包:子目录.子目录`，例如 `/development:code-reviewer` 或 `/design:icons.favicon`。也支持 `/skill:技能包.子目录`；扩展会把它转换为 Pi 原生 `/skill:<name>`，由 Pi 负责技能正文展开。
 

--- a/packages/pi-nested-skills/locales/index.json
+++ b/packages/pi-nested-skills/locales/index.json
@@ -26,5 +26,25 @@
   "scanWarning": {
     "zh-CN": "扫描技能目录失败：{path}（{reason}）",
     "en-US": "Failed to scan skill path: {path} ({reason})"
+  },
+  "configCommandDescription": {
+    "zh-CN": "配置嵌套技能根目录（参数为 JSON，省略参数时进入编辑）",
+    "en-US": "Configure nested skill roots (pass JSON, or omit it to edit interactively)"
+  },
+  "configCommandInput": {
+    "zh-CN": "输入技能根目录配置 JSON（输入 reset 恢复为 skills）",
+    "en-US": "Enter skill root configuration JSON (or reset to use skills)"
+  },
+  "configCommandInteractiveOnly": {
+    "zh-CN": "无交互界面时请直接传入配置 JSON。",
+    "en-US": "Pass configuration JSON directly when no interactive UI is available."
+  },
+  "configCommandSaved": {
+    "zh-CN": "嵌套技能配置已保存：{path}。请执行 /reload 使配置生效。",
+    "en-US": "Nested skill configuration saved to {path}. Run /reload to apply it."
+  },
+  "configCommandInvalid": {
+    "zh-CN": "嵌套技能配置无效：{error}",
+    "en-US": "Invalid nested skill configuration: {error}"
   }
 }

--- a/packages/pi-nested-skills/src/config.ts
+++ b/packages/pi-nested-skills/src/config.ts
@@ -1,24 +1,22 @@
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 
 export const CONFIG_FILE_NAME = "config.json";
 export const CONFIG_DIRECTORY_NAME = "pi-nested-skills";
-export const SKILL_ROOTS_ENV = "PI_NESTED_SKILLS_ROOTS";
-export const LEGACY_SKILLS_DIR_ENV = "PI_NESTED_SKILLS_DIR";
 
 export interface NestedSkillsConfig {
   /** 包含技能包目录的根目录列表。 */
   skillRoots: string[];
 }
 
-export type ConfigSource = "file" | "environment" | "default";
+export type ConfigSource = "file" | "default";
 
 export interface LoadedNestedSkillsConfig {
   config: NestedSkillsConfig;
   source: ConfigSource;
-  /** 配置文件或环境变量存在但无法使用时的明确诊断。 */
+  /** 配置文件存在但无法使用时的明确诊断。 */
   warnings: string[];
   /** 是否由用户显式提供过根目录配置。 */
   explicit: boolean;
@@ -73,6 +71,21 @@ function normalizeRootValues(value: unknown): string[] | undefined {
   return roots;
 }
 
+/** 校验配置命令提交的 JSON，并保留早期配置文件的 skillsDir 兼容字段。 */
+export function parseConfig(value: unknown): NestedSkillsConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("configuration must be an object");
+  }
+  const raw = value as ConfigObject;
+  const configured = raw.skillRoots === undefined ? raw.skillsDir : raw.skillRoots;
+  const roots = normalizeRootValues(configured);
+  if (roots === undefined) {
+    throw new Error('configuration field "skillRoots" must be a string or an array of strings');
+  }
+  return { skillRoots: roots };
+}
+
+/** 读取配置文件并返回规范化前的根目录值或明确诊断。 */
 function readConfigFile(path: string): { value?: string[]; warning?: string } {
   if (!existsSync(path)) return {};
 
@@ -96,23 +109,16 @@ function readConfigFile(path: string): { value?: string[]; warning?: string } {
   }
 }
 
-function environmentRoots(env: NodeJS.ProcessEnv): string[] | undefined {
-  const raw = env[SKILL_ROOTS_ENV] ?? env[LEGACY_SKILLS_DIR_ENV];
-  if (raw === undefined) return undefined;
-  return raw
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
+/** 将技能根目录配置写入 Pi agent 配置目录。 */
+export function saveConfig(config: NestedSkillsConfig, agentDir = getAgentDir()): string {
+  const path = configPath(agentDir);
+  mkdirSync(join(agentDir, "extensions", CONFIG_DIRECTORY_NAME), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return path;
 }
 
-/**
- * 读取技能根目录配置：配置文件 > 环境变量 > Pi 标准默认目录。
- * 相对路径以 agent 目录为基准，避免把当前工作目录或维护者机器路径写进配置。
- */
-export function loadConfig(
-  agentDir = getAgentDir(),
-  env: NodeJS.ProcessEnv = process.env,
-): LoadedNestedSkillsConfig {
+/** 读取技能根目录配置：配置文件 > Pi 标准默认目录。 */
+export function loadConfig(agentDir = getAgentDir()): LoadedNestedSkillsConfig {
   const path = configPath(agentDir);
   const fileResult = readConfigFile(path);
   const warnings = fileResult.warning ? [fileResult.warning] : [];
@@ -123,18 +129,6 @@ export function loadConfig(
         skillRoots: fileResult.value.map((value) => resolveSkillRoot(value, agentDir)),
       },
       source: "file",
-      warnings,
-      explicit: true,
-    };
-  }
-
-  const envValue = environmentRoots(env);
-  if (envValue !== undefined) {
-    return {
-      config: {
-        skillRoots: envValue.map((value) => resolveSkillRoot(value, agentDir)),
-      },
-      source: "environment",
       warnings,
       explicit: true,
     };

--- a/packages/pi-nested-skills/src/index.ts
+++ b/packages/pi-nested-skills/src/index.ts
@@ -6,7 +6,7 @@ import type {
 import { fuzzyFilter } from "@earendil-works/pi-tui";
 import type { AutocompleteItem, AutocompleteProvider } from "@earendil-works/pi-tui";
 import { createTranslator, loadCatalog } from "pi-extensions-i18n";
-import { loadConfig, type LoadedNestedSkillsConfig } from "./config.ts";
+import { loadConfig, parseConfig, saveConfig, type LoadedNestedSkillsConfig } from "./config.ts";
 import { scanSkillRoots, type NestedSkill, type SkillScanResult } from "./skills.ts";
 
 const messages = loadCatalog(new URL("../locales/index.json", import.meta.url));
@@ -14,6 +14,12 @@ const i18n = createTranslator(messages);
 
 const COMMAND_NAME = "skills";
 const COMMAND_ALIASES = [COMMAND_NAME] as const;
+const CONFIG_COMMAND_ALIASES = ["config:nested-skills", "nested-skills-config", "pi-nested-skills-config"] as const;
+const CONFIG_RESET_COMMAND = "reset";
+const DEFAULT_CONFIG_ROOT = "skills";
+const NOTICE_WARNING = "warning" as const;
+const NOTICE_INFO = "info" as const;
+const NOTICE_ERROR = "error" as const;
 const SKILL_COMMAND_PREFIX = "skill:";
 const INPUT_SOURCES = new Set(["interactive", "rpc"]);
 
@@ -194,6 +200,43 @@ function formatSkillsMessage(index: SkillIndex): string {
   return lines.join("\n");
 }
 
+/** 注册配置命令，允许通过 JSON 参数或交互式输入持久化技能根目录。 */
+function registerConfigCommand(pi: ExtensionAPI): void {
+  const command = {
+    description: i18n.t("configCommandDescription"),
+    getArgumentCompletions: () => null,
+    handler: async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+      let value = args.trim();
+      if (!value) {
+        if (!ctx.hasUI) {
+          ctx.ui.notify(i18n.t("configCommandInteractiveOnly"), NOTICE_WARNING);
+          return;
+        }
+        const current = loadConfig().config;
+        const input = await ctx.ui.input(
+          i18n.t("configCommandInput"),
+          JSON.stringify(current),
+        );
+        if (input === undefined) return;
+        value = input.trim();
+      }
+
+      try {
+        const config = value === CONFIG_RESET_COMMAND
+          ? parseConfig({ skillRoots: [DEFAULT_CONFIG_ROOT] })
+          : parseConfig(JSON.parse(value));
+        const path = saveConfig(config);
+        ctx.ui.notify(i18n.t("configCommandSaved", { path }), NOTICE_INFO);
+      } catch (error) {
+        ctx.ui.notify(i18n.t("configCommandInvalid", {
+          error: error instanceof Error ? error.message : String(error),
+        }), NOTICE_ERROR);
+      }
+    },
+  };
+  for (const name of CONFIG_COMMAND_ALIASES) pi.registerCommand(name, command);
+}
+
 function registerSkillsCommand(pi: ExtensionAPI, index: SkillIndex): void {
   const command = {
     description: i18n.t("commandDescription"),
@@ -209,18 +252,18 @@ function registerSkillsCommand(pi: ExtensionAPI, index: SkillIndex): void {
 function notifyDiagnostics(ctx: ExtensionContext, loaded: LoadedNestedSkillsConfig, index: SkillIndex): void {
   if (!ctx.hasUI) return;
   for (const warning of loaded.warnings) {
-    ctx.ui.notify(i18n.t("configWarning", { reason: warning }), "warning");
+    ctx.ui.notify(i18n.t("configWarning", { reason: warning }), NOTICE_WARNING);
   }
   for (const warning of index.warnings) {
     ctx.ui.notify(
       i18n.t("scanWarning", { path: warning.path, reason: warning.reason }),
-      "warning",
+      NOTICE_WARNING,
     );
   }
   if (loaded.explicit && index.skills.length === 0) {
     ctx.ui.notify(
       i18n.t("noSkills", { roots: loaded.config.skillRoots.join(", ") || i18n.t("noRoots") }),
-      "warning",
+      NOTICE_WARNING,
     );
   }
 }
@@ -254,6 +297,7 @@ export default function nestedSkillsExtension(pi: ExtensionAPI): void {
     ctx.ui.addAutocompleteProvider((current) => createAutocompleteProvider(current, index));
   });
 
+  registerConfigCommand(pi);
   registerSkillsCommand(pi, index);
 }
 

--- a/packages/pi-nested-skills/tests/config.test.ts
+++ b/packages/pi-nested-skills/tests/config.test.ts
@@ -18,7 +18,7 @@ test("uses the Pi agent skills directory by default", () => {
   const agentDir = makeAgentDir();
   try {
     assert.deepEqual(defaultSkillRoots(agentDir), [join(agentDir, "skills")]);
-    const loaded = loadConfig(agentDir, {});
+    const loaded = loadConfig(agentDir);
     assert.deepEqual(loaded.config.skillRoots, [join(agentDir, "skills")]);
     assert.equal(loaded.source, "default");
     assert.equal(loaded.explicit, false);
@@ -27,26 +27,18 @@ test("uses the Pi agent skills directory by default", () => {
   }
 });
 
-test("resolves environment roots and lets file configuration override them", () => {
+test("uses file configuration and ignores old environment configuration", () => {
   const agentDir = makeAgentDir();
   try {
-    const fromEnvironment = loadConfig(agentDir, {
-      PI_NESTED_SKILLS_ROOTS: "~/shared,project-skills",
-    });
-    assert.deepEqual(fromEnvironment.config.skillRoots, [
-      join(process.env.HOME ?? "/tmp", "shared"),
-      join(agentDir, "project-skills"),
-    ]);
-    assert.equal(fromEnvironment.source, "environment");
-
     mkdirSync(join(agentDir, "extensions", "pi-nested-skills"), { recursive: true });
     writeFileSync(
       configPath(agentDir),
       JSON.stringify({ skillRoots: ["configured-skills"] }),
     );
-    const fromFile = loadConfig(agentDir, { PI_NESTED_SKILLS_ROOTS: "ignored" });
-    assert.deepEqual(fromFile.config.skillRoots, [join(agentDir, "configured-skills")]);
-    assert.equal(fromFile.source, "file");
+    const loaded = loadConfig(agentDir);
+    assert.deepEqual(loaded.config.skillRoots, [join(agentDir, "configured-skills")]);
+    assert.equal(loaded.source, "file");
+    assert.equal(loaded.explicit, true);
   } finally {
     rmSync(agentDir, { recursive: true, force: true });
   }
@@ -57,10 +49,10 @@ test("accepts the legacy single-directory configuration and reports malformed fi
   try {
     mkdirSync(join(agentDir, "extensions", "pi-nested-skills"), { recursive: true });
     writeFileSync(configPath(agentDir), JSON.stringify({ skillsDir: "legacy" }));
-    assert.deepEqual(loadConfig(agentDir, {}).config.skillRoots, [join(agentDir, "legacy")]);
+    assert.deepEqual(loadConfig(agentDir).config.skillRoots, [join(agentDir, "legacy")]);
 
     writeFileSync(configPath(agentDir), "not-json");
-    const malformed = loadConfig(agentDir, {});
+    const malformed = loadConfig(agentDir);
     assert.equal(malformed.source, "default");
     assert.equal(malformed.warnings.length, 1);
   } finally {

--- a/packages/pi-nested-skills/tests/index.test.ts
+++ b/packages/pi-nested-skills/tests/index.test.ts
@@ -78,7 +78,11 @@ test("registers resources, input transformation, command and completion hooks", 
       sendUserMessage: async () => {},
     } as unknown as ExtensionAPI;
 
-    process.env.PI_NESTED_SKILLS_ROOTS = root;
+    mkdirSync(join(agentDir, "extensions", "pi-nested-skills"), { recursive: true });
+    writeFileSync(
+      join(agentDir, "extensions", "pi-nested-skills", "config.json"),
+      JSON.stringify({ skillRoots: [root] }),
+    );
     process.env.PI_CODING_AGENT_DIR = agentDir;
     const context = {
       hasUI: true,
@@ -112,7 +116,6 @@ test("registers resources, input transformation, command and completion hooks", 
     assert.ok(autocompleteFactory);
     assert.ok(commands.has("skills"));
   } finally {
-    delete process.env.PI_NESTED_SKILLS_ROOTS;
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
     rmSync(agentDir, { recursive: true, force: true });

--- a/packages/pi-notifications/README.md
+++ b/packages/pi-notifications/README.md
@@ -55,7 +55,7 @@ For example, a custom adapter can use an executable directly:
 }
 ```
 
-The configuration file is read when the extension loads. Reload Pi after changing it. A missing file uses the default `terminal-notifier` configuration. A malformed file is reported in Pi and uses the default configuration.
+The configuration file is read when the extension loads. Use `/config:notifications` to edit the complete JSON configuration (or pass JSON directly), and run `/reload` after saving. A missing file uses the default `terminal-notifier` configuration. A malformed file is reported in Pi and uses the default configuration.
 
 ## Default adapter
 

--- a/packages/pi-notifications/README.zh-CN.md
+++ b/packages/pi-notifications/README.zh-CN.md
@@ -55,7 +55,7 @@ pi install npm:pi-notifications
 }
 ```
 
-配置在扩展加载时读取。修改后请重新加载 Pi。配置文件不存在时使用默认的 `terminal-notifier` 配置；配置格式损坏时会在 Pi 中明确提示并使用默认配置。
+配置在扩展加载时读取。使用 `/config:notifications` 交互编辑完整 JSON 配置，也可以直接传入 JSON；保存后执行 `/reload`。配置文件不存在时使用默认的 `terminal-notifier` 配置；配置格式损坏时会在 Pi 中明确提示并使用默认配置。
 
 ## 默认 adapter
 

--- a/packages/pi-notifications/SKILL.md
+++ b/packages/pi-notifications/SKILL.md
@@ -18,6 +18,10 @@ description: 配置与排查 pi-notifications 的外部通知命令、argv 参�
 
 修改配置后执行 `/reload`。配置文件损坏会明确提示，并使用默认配置继续启动。
 
+使用 `/config:notifications` 修改完整通知配置；可以直接传入 JSON，省略参数时进入交互编辑，输入 `reset` 恢复默认值。保存后执行 `/reload`。
+
+Use `/config:notifications` to edit the complete notification configuration; pass JSON directly or omit the argument for interactive editing, and use `reset` for defaults. Run `/reload` after saving.
+
 ## 运行行为
 
 - `ask_user_question` 和 `ask_user` 在真正等待输入前发送通知。

--- a/packages/pi-notifications/locales/index.json
+++ b/packages/pi-notifications/locales/index.json
@@ -42,5 +42,25 @@
   "configInvalid": {
     "zh-CN": "通知配置读取失败：{path}（{reason}）。已使用默认配置。",
     "en-US": "Failed to read notification config: {path} ({reason}). Default configuration is being used."
+  },
+  "configCommandDescription": {
+    "zh-CN": "配置系统通知（参数为 JSON，省略参数时进入编辑）",
+    "en-US": "Configure system notifications (pass JSON, or omit it to edit interactively)"
+  },
+  "configCommandInput": {
+    "zh-CN": "输入完整的通知配置 JSON（输入 reset 恢复默认值）",
+    "en-US": "Enter the complete notification configuration JSON (or reset for defaults)"
+  },
+  "configCommandInteractiveOnly": {
+    "zh-CN": "无交互界面时请直接传入配置 JSON。",
+    "en-US": "Pass configuration JSON directly when no interactive UI is available."
+  },
+  "configCommandSaved": {
+    "zh-CN": "通知配置已保存：{path}。请执行 /reload 使配置生效。",
+    "en-US": "Notification configuration saved to {path}. Run /reload to apply it."
+  },
+  "configCommandInvalid": {
+    "zh-CN": "通知配置无效：{error}",
+    "en-US": "Invalid notification configuration: {error}"
   }
 }

--- a/packages/pi-notifications/src/config.ts
+++ b/packages/pi-notifications/src/config.ts
@@ -1,6 +1,6 @@
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type { NotificationAdapterConfig } from "./adapter.ts";
 
 export interface NotificationConfig {
@@ -47,6 +47,13 @@ export function configPath(): string {
   return join(getAgentDir(), "extensions", CONFIG_DIRECTORY_NAME, CONFIG_FILE_NAME);
 }
 
+/** 将经过校验的通知配置写入配置文件。 */
+export function saveConfig(config: NotificationConfig, path = configPath()): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return path;
+}
+
 /** 读取通知配置；文件缺失时使用默认配置。 */
 export function loadConfig(): NotificationConfig {
   return loadConfigWithDiagnostics().config;
@@ -76,7 +83,8 @@ export function loadConfigWithDiagnostics(): LoadedNotificationConfig {
   }
 }
 
-function parseConfig(value: unknown): NotificationConfig {
+/** 解析并校验通知配置，供文件加载和配置命令共同使用。 */
+export function parseConfig(value: unknown): NotificationConfig {
   if (!isRecord(value)) throw new Error("configuration must be a JSON object");
 
   const enabled = value.enabled === undefined ? true : value.enabled;

--- a/packages/pi-notifications/src/index.ts
+++ b/packages/pi-notifications/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   ExtensionAPI,
+  ExtensionCommandContext,
   ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { basename } from "node:path";
@@ -9,7 +10,7 @@ import {
   type NotificationFailure,
   type NotificationPayload,
 } from "./adapter.ts";
-import { loadConfigWithDiagnostics, type NotificationConfig } from "./config.ts";
+import { loadConfigWithDiagnostics, parseConfig, saveConfig, type NotificationConfig } from "./config.ts";
 import { i18n } from "./i18n.ts";
 
 export type { NotificationConfig } from "./config.ts";
@@ -29,7 +30,7 @@ export {
   renderNotificationArgs,
   runArgvCommand,
 } from "./adapter.ts";
-export { configPath, loadConfig, loadConfigWithDiagnostics } from "./config.ts";
+export { configPath, loadConfig, loadConfigWithDiagnostics, parseConfig, saveConfig } from "./config.ts";
 
 interface Notice {
   level: "warning";
@@ -43,9 +44,47 @@ interface NotificationRuntime {
   context?: ExtensionContext;
 }
 
+const CONFIG_COMMAND_ALIASES = ["config:notifications", "notifications-config", "pi-notifications-config"] as const;
+const CONFIG_RESET_COMMAND = "reset";
+const NOTICE_WARNING = "warning" as const;
+const NOTICE_INFO = "info" as const;
+const NOTICE_ERROR = "error" as const;
+
 const pendingNotices: Notice[] = [];
 let activeRuntime: NotificationRuntime | undefined;
 let noticeKeys = new Set<string>();
+
+/** 注册配置命令，允许通过 JSON 参数或交互式输入持久化通知配置。 */
+function registerConfigCommand(pi: ExtensionAPI): void {
+  const command = {
+    description: i18n.t("configCommandDescription"),
+    getArgumentCompletions: () => null,
+    handler: async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+      let value = args.trim();
+      if (!value) {
+        if (!ctx.hasUI) {
+          ctx.ui.notify(i18n.t("configCommandInteractiveOnly"), NOTICE_WARNING);
+          return;
+        }
+        const current = loadConfigWithDiagnostics().config;
+        const input = await ctx.ui.input(i18n.t("configCommandInput"), JSON.stringify(current));
+        if (input === undefined) return;
+        value = input.trim();
+      }
+
+      try {
+        const config = value === CONFIG_RESET_COMMAND ? parseConfig({}) : parseConfig(JSON.parse(value));
+        const path = saveConfig(config);
+        ctx.ui.notify(i18n.t("configCommandSaved", { path }), NOTICE_INFO);
+      } catch (error) {
+        ctx.ui.notify(i18n.t("configCommandInvalid", {
+          error: error instanceof Error ? error.message : String(error),
+        }), NOTICE_ERROR);
+      }
+    },
+  };
+  for (const name of CONFIG_COMMAND_ALIASES) pi.registerCommand(name, command);
+}
 
 /** 导出给其他扩展使用；通知发送在后台执行，不阻塞当前 Pi 事件。 */
 export function notify(title: string, subtitle: string, message: string): void {
@@ -55,6 +94,7 @@ export function notify(title: string, subtitle: string, message: string): void {
 }
 
 export default function piNotifications(pi: ExtensionAPI): void {
+  registerConfigCommand(pi);
   const runtime = createRuntime();
   let turnCount = 0;
   let taskStartTime = 0;

--- a/packages/pi-notifications/tests/extension.test.ts
+++ b/packages/pi-notifications/tests/extension.test.ts
@@ -57,6 +57,8 @@ test("formats input and completion notifications through the lifecycle handlers"
       on(event: string, handler: RegisteredHandler["handler"]) {
         handlers.push({ event, handler });
       },
+      // 配置命令仅需在真实宿主中注册，生命周期测试使用空实现。
+      registerCommand() {},
     } as unknown as ExtensionAPI;
     piNotifications(pi);
 

--- a/packages/pi-notifications/tests/index.test.ts
+++ b/packages/pi-notifications/tests/index.test.ts
@@ -14,6 +14,8 @@ test("registers lifecycle handlers and the public default export", () => {
     on(event: string, handler: (...args: any[]) => unknown) {
       handlers.push({ event, handler });
     },
+    // 配置命令仅需在真实宿主中注册，生命周期测试使用空实现。
+    registerCommand() {},
   } as unknown as ExtensionAPI;
 
   piNotifications(pi);

--- a/packages/pi-safety-guards/README.md
+++ b/packages/pi-safety-guards/README.md
@@ -50,6 +50,8 @@ Replace `example-command` with the command to match. See also [config.example.js
 - `message`: optional non-empty text or an object containing `zh-CN` and `en-US`. If omitted, feedback shows the rule ID and action.
 - Empty presets and rules disable checking and report that no protection is active.
 
+Use `/config:safety-guards` to edit the complete JSON configuration (or pass JSON directly), and run `/reload` after saving.
+
 ### Actions
 
 | Action | Behavior |

--- a/packages/pi-safety-guards/README.zh-CN.md
+++ b/packages/pi-safety-guards/README.zh-CN.md
@@ -50,6 +50,8 @@ pi install npm:pi-safety-guards
 - `message`：可选的非空文本，或包含 `zh-CN`、`en-US` 的对象。不填写时反馈规则 ID 和动作。
 - 预设和规则都为空时关闭检查，并提示当前没有启用保护。
 
+使用 `/config:safety-guards` 交互编辑完整 JSON 配置，也可以直接传入 JSON；保存后执行 `/reload`。
+
 ### 动作
 
 | 动作 | 行为 |

--- a/packages/pi-safety-guards/SKILL.md
+++ b/packages/pi-safety-guards/SKILL.md
@@ -9,8 +9,8 @@ description: "配置安全预设、规则动作和自定义匹配器。Use when 
 
 `<pi-agent-dir>/extensions/pi-safety-guards/config.json`
 
-遵守 `PI_CODING_AGENT_DIR`，修改后执行 `/reload`。
-Respect `PI_CODING_AGENT_DIR` and run `/reload` after changes.
+遵守 `PI_CODING_AGENT_DIR`，可以使用 `/config:safety-guards` 交互编辑，也可以传入完整 JSON；输入 `reset` 恢复默认预设，保存后执行 `/reload`。
+Respect `PI_CODING_AGENT_DIR`; use `/config:safety-guards` for interactive editing or pass complete JSON, use `reset` for default presets, and reload after saving.
 
 ## 选择规则 / Select rules
 

--- a/packages/pi-safety-guards/index.ts
+++ b/packages/pi-safety-guards/index.ts
@@ -1,6 +1,9 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
 import { dirname } from "node:path";
-import { configPath, loadConfig } from "./src/config.ts";
+import { configPath, loadConfig, parseConfig, saveConfig } from "./src/config.ts";
 import { compileRules, evaluateRules, type ModuleLoader } from "./src/engine.ts";
 import { i18n } from "./src/i18n.ts";
 import type { SafetyConfig, SafetyRule } from "./src/types.ts";
@@ -8,9 +11,52 @@ import type { SafetyConfig, SafetyRule } from "./src/types.ts";
 const BASH_TOOL = "bash";
 const ERROR_LEVEL = "error";
 const INFO_LEVEL = "info";
+const WARN_LEVEL = "warning";
 const BLOCK_ACTION = "block";
 const CONFIRM_ACTION = "confirm";
 const WARN_ACTION = "warn";
+const CONFIG_COMMAND_ALIASES = ["config:safety-guards", "safety-guards-config", "pi-safety-guards-config"] as const;
+const CONFIG_RESET_COMMAND = "reset";
+
+/** 注册配置命令，允许通过 JSON 参数或交互式输入持久化安全规则。 */
+function registerConfigCommand(pi: ExtensionAPI): void {
+  const command = {
+    description: i18n.t("configCommandDescription"),
+    getArgumentCompletions: () => null,
+    handler: async (args: string, ctx: ExtensionCommandContext): Promise<void> => {
+      let value = args.trim();
+      if (!value) {
+        if (!ctx.hasUI) {
+          ctx.ui.notify(i18n.t("configCommandInteractiveOnly"), WARN_LEVEL);
+          return;
+        }
+        let current: SafetyConfig;
+        try {
+          current = loadConfig();
+        } catch (error) {
+          ctx.ui.notify(i18n.t("configCommandInvalid", {
+            error: error instanceof Error ? error.message : String(error),
+          }), ERROR_LEVEL);
+          return;
+        }
+        const input = await ctx.ui.input(i18n.t("configCommandInput"), JSON.stringify(current));
+        if (input === undefined) return;
+        value = input.trim();
+      }
+
+      try {
+        const config = value === CONFIG_RESET_COMMAND ? parseConfig({}) : parseConfig(JSON.parse(value));
+        const path = saveConfig(config);
+        ctx.ui.notify(i18n.t("configCommandSaved", { path }), INFO_LEVEL);
+      } catch (error) {
+        ctx.ui.notify(i18n.t("configCommandInvalid", {
+          error: error instanceof Error ? error.message : String(error),
+        }), ERROR_LEVEL);
+      }
+    },
+  };
+  for (const name of CONFIG_COMMAND_ALIASES) pi.registerCommand(name, command);
+}
 
 /** 将规则 ID 和用户选择的说明一起展示，不自动执行替代命令。 */
 function describeRule(rule: SafetyRule): string {
@@ -64,6 +110,7 @@ export async function registerSafetyGuards(
 
 /** 配置或启用规则加载失败时阻断 Bash，避免把失败当作关闭保护。 */
 export default async function piSafetyGuards(pi: ExtensionAPI): Promise<void> {
+  registerConfigCommand(pi);
   try {
     await registerSafetyGuards(pi, loadConfig());
   } catch (error) {
@@ -75,5 +122,6 @@ export default async function piSafetyGuards(pi: ExtensionAPI): Promise<void> {
   }
 }
 
+export { configPath, loadConfig, parseConfig, saveConfig } from "./src/config.ts";
 export type { RuleContext, RuleMatcher } from "./src/types.ts";
 export { findOutOfScopeBashPaths } from "./src/bash-directory-scope-utils.ts";

--- a/packages/pi-safety-guards/locales/i18n.json
+++ b/packages/pi-safety-guards/locales/i18n.json
@@ -58,5 +58,25 @@
   "moduleTimeout": {
     "zh-CN": "规则模块加载或匹配超时。",
     "en-US": "Rule module loading or matching timed out."
+  },
+  "configCommandDescription": {
+    "zh-CN": "配置安全规则（参数为 JSON，省略参数时进入编辑）",
+    "en-US": "Configure safety rules (pass JSON, or omit it to edit interactively)"
+  },
+  "configCommandInput": {
+    "zh-CN": "输入完整的安全规则配置 JSON（输入 reset 恢复默认预设）",
+    "en-US": "Enter the complete safety configuration JSON (or reset to default presets)"
+  },
+  "configCommandInteractiveOnly": {
+    "zh-CN": "无交互界面时请直接传入配置 JSON。",
+    "en-US": "Pass configuration JSON directly when no interactive UI is available."
+  },
+  "configCommandSaved": {
+    "zh-CN": "安全规则配置已保存：{path}。请执行 /reload 使配置生效。",
+    "en-US": "Safety configuration saved to {path}. Run /reload to apply it."
+  },
+  "configCommandInvalid": {
+    "zh-CN": "安全规则配置无效：{error}",
+    "en-US": "Invalid safety configuration: {error}"
   }
 }

--- a/packages/pi-safety-guards/src/config.ts
+++ b/packages/pi-safety-guards/src/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_PRESETS, PRESETS } from "./presets.ts";
 import { i18n } from "./i18n.ts";
@@ -15,6 +15,13 @@ const DETECTORS = new Set<unknown>(["disk-format", "fork-bomb", "in-place-edit",
 /** 返回 agent 目录下的显式用户配置位置。 */
 export function configPath(): string {
   return join(getAgentDir(), EXTENSIONS_DIR, PACKAGE_NAME, CONFIG_FILENAME);
+}
+
+/** 将经过校验的安全规则配置写入配置文件。 */
+export function saveConfig(config: SafetyConfig, path = configPath()): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return path;
 }
 
 /** 将配置错误转换成双语诊断，不悄悄忽略未知配置。 */

--- a/packages/pi-safety-guards/tests/extension.test.ts
+++ b/packages/pi-safety-guards/tests/extension.test.ts
@@ -15,7 +15,11 @@ function host(hasUI = true, accepted = true) {
   const handlers = new Map<string, Handler>();
   const prompts: string[] = [];
   const notices: string[] = [];
-  const pi = { on: (name: string, handler: Handler) => handlers.set(name, handler) } as unknown as ExtensionAPI;
+  const pi = {
+    on: (name: string, handler: Handler) => handlers.set(name, handler),
+    // 配置命令仅需在真实宿主中注册，安全规则测试使用空实现。
+    registerCommand: () => undefined,
+  } as unknown as ExtensionAPI;
   const ctx = {
     cwd: tmpdir(), hasUI,
     ui: {

--- a/packages/pi-session-resources/README.md
+++ b/packages/pi-session-resources/README.md
@@ -49,7 +49,15 @@ Candidate labels are OSC 8 hyperlinks. Pi fullscreen mode can open them with a c
 /config:session-resources disable     Disable the # resource picker
 ```
 
-`show`/`hide` remain compatibility aliases for `enable`/`disable`, and `/session-resources` remains available as a command alias.
+`show`/`hide` remain compatibility aliases for `enable`/`disable`, and `/session-resources` remains available as a command alias. The setting is stored in `<pi-agent-dir>/extensions/pi-session-resources/config.json`; use [`config.example.json`](./config.example.json) as a starting point:
+
+```json
+{
+  "enabled": true
+}
+```
+
+Use `/config:session-resources enable` or `/config:session-resources disable` to change and persist it. Run `/reload` after changing the file manually.
 
 ## Install
 

--- a/packages/pi-session-resources/README.zh-CN.md
+++ b/packages/pi-session-resources/README.zh-CN.md
@@ -49,7 +49,15 @@
 /config:session-resources disable     禁用 # 资源选择器
 ```
 
-`show`/`hide` 分别兼容 `enable`/`disable`，`/session-resources` 继续作为命令别名保留。
+`show`/`hide` 分别兼容 `enable`/`disable`，`/session-resources` 继续作为命令别名保留。配置保存在 `<Pi agent 目录>/extensions/pi-session-resources/config.json`，可参考 [`config.example.json`](./config.example.json)：
+
+```json
+{
+  "enabled": true
+}
+```
+
+使用 `/config:session-resources enable|disable` 会写入配置文件；手动修改文件后执行 `/reload`。
 
 ## 安装
 

--- a/packages/pi-session-resources/SKILL.md
+++ b/packages/pi-session-resources/SKILL.md
@@ -5,14 +5,14 @@ description: "启用、禁用与排查 pi-session-resources 的 # 文件、URL �
 
 # 配置 pi-session-resources
 
-这个扩展没有持久化配置文件。选择器每次扩展加载时默认启用，命令只修改当前运行实例：
+配置文件为 `<Pi agent 目录>/extensions/pi-session-resources/config.json`，默认启用选择器。可以使用 `/config:session-resources enable|disable` 修改并持久化配置：
 
 ```text
 /config:session-resources
 /config:session-resources enable|disable
 ```
 
-`show|hide` 分别兼容 `enable|disable`，`/session-resources` 是命令别名。不要声称 enable/disable 会跨 `/reload` 持久化。
+`show|hide` 分别兼容 `enable|disable`，`/session-resources` 是命令别名。修改配置文件后执行 `/reload`。
 
 ## 排查
 

--- a/packages/pi-session-resources/config.example.json
+++ b/packages/pi-session-resources/config.example.json
@@ -1,0 +1,3 @@
+{
+  "enabled": true
+}

--- a/packages/pi-session-resources/locales/index.json
+++ b/packages/pi-session-resources/locales/index.json
@@ -7,6 +7,14 @@
     "zh-CN": "用法：/config:session-resources [enable|disable]",
     "en-US": "Usage: /config:session-resources [enable|disable]"
   },
+  "configLoadFailed": {
+    "zh-CN": "会话资源配置读取失败：{path}（{error}）。当前使用启用状态。",
+    "en-US": "Failed to read session resource configuration: {path} ({error}). The picker remains enabled."
+  },
+  "configSaveFailed": {
+    "zh-CN": "会话资源配置保存失败：{path}（{error}）。",
+    "en-US": "Failed to save session resource configuration: {path} ({error})."
+  },
   "referenceHint": {
     "zh-CN": "在输入框键入 # 并继续输入即可筛选会话资源；←/→ 或 Tab/Shift+Tab 切换类型，↑/↓ 选择，Enter 插入引用",
     "en-US": "Type # in the editor and continue typing to filter session resources; Left/Right or Tab/Shift+Tab switch types, Up/Down selects, and Enter inserts the reference"

--- a/packages/pi-session-resources/src/config.ts
+++ b/packages/pi-session-resources/src/config.ts
@@ -1,0 +1,52 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const PACKAGE_NAME = "pi-session-resources";
+const CONFIG_FILE_NAME = "config.json";
+const EXTENSIONS_DIRECTORY = "extensions";
+const UTF8_ENCODING = "utf8";
+const FILE_NOT_FOUND_CODE = "ENOENT";
+
+export interface SessionResourcesConfig {
+  enabled: boolean;
+}
+
+export const DEFAULT_SESSION_RESOURCES_CONFIG: SessionResourcesConfig = { enabled: true };
+
+/** 返回会话资源选择器的配置文件路径。 */
+export function configPath(agentDir = getAgentDir()): string {
+  return join(agentDir, EXTENSIONS_DIRECTORY, PACKAGE_NAME, CONFIG_FILE_NAME);
+}
+
+/** 解析并校验会话资源选择器配置。 */
+export function parseConfig(value: unknown): SessionResourcesConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("configuration must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  for (const key of Object.keys(raw)) {
+    if (key !== "enabled") throw new Error(`unknown configuration field: ${key}`);
+  }
+  if (raw.enabled !== undefined && typeof raw.enabled !== "boolean") {
+    throw new Error("enabled must be a boolean");
+  }
+  return { enabled: raw.enabled ?? DEFAULT_SESSION_RESOURCES_CONFIG.enabled };
+}
+
+/** 读取配置文件；缺少文件时使用默认启用状态。 */
+export function loadConfig(path = configPath()): SessionResourcesConfig {
+  try {
+    return parseConfig(JSON.parse(readFileSync(path, UTF8_ENCODING)));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === FILE_NOT_FOUND_CODE) return { ...DEFAULT_SESSION_RESOURCES_CONFIG };
+    throw error;
+  }
+}
+
+/** 将经过校验的配置写入配置文件。 */
+export function saveConfig(config: SessionResourcesConfig, path = configPath()): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, UTF8_ENCODING);
+  return path;
+}

--- a/packages/pi-session-resources/src/index.ts
+++ b/packages/pi-session-resources/src/index.ts
@@ -7,6 +7,7 @@ import {
 import { collectSessionResources, collectToolResources, ResourceIndex } from "./collector.ts";
 import { i18n } from "./i18n.ts";
 import { SessionResourceEditor } from "./picker.ts";
+import { configPath, loadConfig, saveConfig } from "./config.ts";
 
 const COMMAND_NAMES = ["config:session-resources", "session-resources"] as const;
 const COMMAND_ACTION = {
@@ -22,6 +23,12 @@ type CommandAction = (typeof COMMAND_ACTION)[keyof typeof COMMAND_ACTION];
 export default function sessionResourcesExtension(pi: ExtensionAPI): void {
   const resources = new ResourceIndex();
   let pickerEnabled = true;
+  let configError: unknown;
+  try {
+    pickerEnabled = loadConfig().enabled;
+  } catch (error) {
+    configError = error;
+  }
 
   /** Wraps the current editor so the resource picker renders directly above it. */
   function bindResourceEditor(ctx: ExtensionContext): void {
@@ -46,6 +53,12 @@ export default function sessionResourcesExtension(pi: ExtensionAPI): void {
   }
 
   pi.on("session_start", (_event, ctx) => {
+    if (configError !== undefined) {
+      ctx.ui.notify(i18n.t("configLoadFailed", {
+        path: configPath(),
+        error: configError instanceof Error ? configError.message : String(configError),
+      }), "warning");
+    }
     rebuildFromSession(ctx);
     bindResourceEditor(ctx);
   });
@@ -91,13 +104,23 @@ export default function sessionResourcesExtension(pi: ExtensionAPI): void {
         return;
       }
 
-      pickerEnabled = action === COMMAND_ACTION.enable || action === COMMAND_ACTION.show;
-      ctx.ui.notify(i18n.t(pickerEnabled ? "enabled" : "disabled"), "info");
+      const enabled = action === COMMAND_ACTION.enable || action === COMMAND_ACTION.show;
+      try {
+        saveConfig({ enabled });
+        pickerEnabled = enabled;
+        ctx.ui.notify(i18n.t(pickerEnabled ? "enabled" : "disabled"), "info");
+      } catch (error) {
+        ctx.ui.notify(i18n.t("configSaveFailed", {
+          path: configPath(),
+          error: error instanceof Error ? error.message : String(error),
+        }), "error");
+      }
     },
   };
   for (const name of COMMAND_NAMES) pi.registerCommand(name, command);
 }
 
+export { configPath, loadConfig, parseConfig, saveConfig } from "./config.ts";
 export * from "./autocomplete.ts";
 export * from "./collector.ts";
 export * from "./picker.ts";

--- a/packages/pi-session-resources/tests/index.test.ts
+++ b/packages/pi-session-resources/tests/index.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import type {
   ExtensionAPI,
@@ -7,6 +9,7 @@ import type {
   ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import sessionResourcesExtension from "../src/index.ts";
+import { loadConfig } from "../src/config.ts";
 
 type EventHandler = (...args: unknown[]) => unknown;
 type SessionResourcesCommand = {
@@ -45,6 +48,10 @@ function createPiMock(): {
 }
 
 test("registers a composable custom editor picker without persistent widgets or shortcuts", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "pi-session-resources-agent-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  try {
   process.env.PI_EXTENSIONS_LOCALE = "en-US";
   const { pi, events, commands, shortcuts } = createPiMock();
   let editorFactory: EditorFactory | undefined;
@@ -102,10 +109,16 @@ test("registers a composable custom editor picker without persistent widgets or 
   const command = commands.get("config:session-resources") as SessionResourcesCommand;
   await command.handler("disable", context as unknown as ExtensionCommandContext);
   assert.match(notifications.at(-1) ?? "", /disabled/);
+  assert.equal(loadConfig().enabled, false);
   await command.handler("enable", context as unknown as ExtensionCommandContext);
   assert.match(notifications.at(-1) ?? "", /enabled/);
+  assert.equal(loadConfig().enabled, true);
 
   const shutdown = events.get("session_shutdown");
   assert.ok(shutdown);
-  shutdown({}, context);
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    rmSync(agentDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## 背景
近期新增插件的配置入口不统一：部分插件只有配置文件、部分只有内存开关，且新插件仍暴露插件专属环境变量，导致配置方式不一致。

## 变更
- 为 `pi-naming`、`pi-nested-skills`、`pi-notifications`、`pi-safety-guards` 增加配置斜杠命令和配置文件写入。
- 移除 `pi-nested-skills` 的新配置环境变量入口。
- 为 `pi-metrics` 增加 `enabled` 配置、`/config:metrics` 和配置示例。
- 让 `pi-session-resources` 的 enable/disable 配置持久化到配置文件。
- 补齐中英文 README、SKILL、配置示例、本地化文案和测试。
- 保留旧版本兼容环境变量、Pi agent 目录变量和终端运行环境探测变量。

## 验证
- `npm run check`
- 1267 个测试全部通过。
- typecheck、i18n、package config、no-local-path、no-private-domain 和 UI 输出门禁全部通过。

## 影响范围
仅涉及插件配置入口、文档、本地化和对应测试；不会自动发布 npm 包。
