### PR TITLE
fix: 隐藏 supervisor 审查错误的原始 TUI 输出

### DIFF
--- a/packages/pi-tool-supervisor/src/tool-display-bridge.ts
+++ b/packages/pi-tool-supervisor/src/tool-display-bridge.ts
@@ -18,6 +18,13 @@ function getAudit(result: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+const DIAGNOSTIC_AUDIT_STATUSES = new Set(["rejected", "failed"]);
+
+/** Returns whether the audit should replace raw diagnostic tool output in the TUI. */
+function isDiagnosticAudit(audit: Record<string, unknown>): boolean {
+  return typeof audit.status === "string" && DIAGNOSTIC_AUDIT_STATUSES.has(audit.status);
+}
+
 /** Renders supervisor panels for every tool carrying a valid audit. */
 const supervisorMiddleware: ResultMiddleware = (context, next) => {
   const audit = getAudit(context.result);
@@ -30,7 +37,10 @@ const supervisorMiddleware: ResultMiddleware = (context, next) => {
   if (!rendered) return next();
 
   const panel = createSupervisorAuditComponent(rendered, context.theme);
-  return appendResultRenderPanel(next(), panel);
+  // The full diagnostic remains in result.content for the model, while the
+  // TUI shows the audit panel and the notify toast instead of printing it as
+  // ordinary tool output in the editor area.
+  return isDiagnosticAudit(audit) ? panel : appendResultRenderPanel(next(), panel);
 };
 
 export function registerSupervisorToolDisplayMiddleware(): () => void {

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -438,6 +438,30 @@ test("pi-tool-supervisor 通过通用 tool-display result middleware 追加审�
     const output = component.render(120).join("\n");
     assert.match(output, /基础 diff/);
     assert.match(output, /⛨ Supervisor  ✓ 已通过  edit · 1 个审查器 · 1\.4s • Ctrl\+O 展开/);
+
+    const rejectedComponent = registration.middleware({
+      toolName: "edit",
+      result: {
+        content: [{ type: "text", text: "Error: [文件编辑审查未通过]" }],
+        details: {
+          fileEditReview: {
+            status: "rejected",
+            durationMs: 1400,
+            reviewers: [{ name: "coding-taste", status: "rejected", durationMs: 1200 }],
+          },
+        },
+      },
+      options: { expanded: false },
+      theme: {
+        fg: (_color: string, text: string) => text,
+        bold: (text: string) => text,
+      },
+    }, () => {
+      throw new Error("raw tool output should be hidden");
+    });
+    const rejectedOutput = rejectedComponent.render(120).join("\n");
+    assert.match(rejectedOutput, /⛨ Supervisor  ✕ 未通过/);
+    assert.doesNotMatch(rejectedOutput, /Error: \[文件编辑审查未通过\]/);
   } finally {
     dispose();
     delete (globalThis as any)[apiKey];


### PR DESCRIPTION
## 问题

pi-tool-supervisor 已通过 `ctx.ui.notify` 报告审查拒绝，但完整诊断仍保留在 `tool_result.content`，Pi 原生 TUI 会把它再次渲染成普通工具输出，导致错误文本刷到输入区。

## 变更

- 审查状态为 `rejected` 或 `failed` 时，仅渲染 Supervisor 审查卡片，不再渲染原始诊断文本。
- 完整诊断继续保留在工具结果中，模型仍能获得修复依据。
- 增加拒绝结果不显示原始错误文本的回归测试。

## 验证

- `npm run typecheck --workspace=pi-tool-supervisor`
- `npm test --workspace=pi-tool-supervisor`（45/45）
- `npm run check:tool-supervisor-ui`
