### PR TITLE
fix: explain blocked external Bash paths

### DIFF
--- a/packages/pi-safety-guards/index.ts
+++ b/packages/pi-safety-guards/index.ts
@@ -1,7 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { dirname } from "node:path";
 import { configPath, loadConfig } from "./src/config.ts";
-import { compileRules, evaluateRules, type ModuleLoader } from "./src/engine.ts";
+import { compileRules, evaluateRules, type ModuleLoader, type PathRuleEvidence } from "./src/engine.ts";
+import { addedDirectoryPathsFromSession } from "./src/bash-directory-scope-utils.ts";
 import { i18n } from "./src/i18n.ts";
 import type { SafetyConfig, SafetyRule } from "./src/types.ts";
 
@@ -13,9 +14,19 @@ const CONFIRM_ACTION = "confirm";
 const WARN_ACTION = "warn";
 
 /** 将规则 ID 和用户选择的说明一起展示，不自动执行替代命令。 */
-function describeRule(rule: SafetyRule): string {
+function describeRule(rule: SafetyRule, evidence?: PathRuleEvidence): string {
   const message = typeof rule.message === "string" ? rule.message : rule.message?.[i18n.locale()];
-  return message ? `[${rule.id}] ${message}` : i18n.t("ruleMatched", { id: rule.id });
+  const description = message ? `[${rule.id}] ${message}` : i18n.t("ruleMatched", { id: rule.id });
+  if (!evidence) return description;
+  const violations = evidence.violations.map(({ inputPath, resolvedPath }) =>
+    i18n.t("pathViolation", { inputPath, resolvedPath }),
+  ).join("\n");
+  return `${description}\n${i18n.t("pathEvidence", {
+    commandPath: violations,
+    cwd: evidence.cwd,
+    allowedRoots: evidence.allowedRoots.join(", "),
+    suggestion: evidence.suggestedDirectories.map((directory) => i18n.t("addDirectorySuggestion", { directory })).join("\n"),
+  })}`;
 }
 
 /** 先加载规则再注册统一执行入口，禁用规则不会执行模块。 */
@@ -36,9 +47,13 @@ export async function registerSafetyGuards(
     if (event.toolName !== BASH_TOOL) return;
     const command = String(event.input.command ?? "");
     try {
-      const decision = await evaluateRules(rules, command, ctx.cwd);
+      const additionalRoots = addedDirectoryPathsFromSession(
+        ctx.sessionManager.getEntries(),
+        ctx.sessionManager.getBranch(),
+      );
+      const decision = await evaluateRules(rules, command, ctx.cwd, additionalRoots);
       if (!decision) return;
-      const details = decision.matches.map(describeRule).join("\n");
+      const details = decision.matches.map((rule) => describeRule(rule, decision.pathEvidence.get(rule.id))).join("\n");
       if (decision.action === BLOCK_ACTION) return { block: true, reason: i18n.t("blocked", { details }) };
       if (decision.action === CONFIRM_ACTION) {
         if (!ctx.hasUI) return { block: true, reason: i18n.t("confirmationUnavailable", { details }) };
@@ -47,7 +62,9 @@ export async function registerSafetyGuards(
       }
       const warned = decision.matches.filter((rule) => rule.action === WARN_ACTION);
       if (warned.length) {
-        warnings.set(event.toolCallId, i18n.t("warning", { details: warned.map(describeRule).join("\n") }));
+        warnings.set(event.toolCallId, i18n.t("warning", {
+          details: warned.map((rule) => describeRule(rule, decision.pathEvidence.get(rule.id))).join("\n"),
+        }));
       }
     } catch (error) {
       return { block: true, reason: error instanceof Error ? error.message : String(error) };

--- a/packages/pi-safety-guards/locales/i18n.json
+++ b/packages/pi-safety-guards/locales/i18n.json
@@ -15,6 +15,18 @@
     "zh-CN": "命中规则 [{id}]",
     "en-US": "Matched rule [{id}]"
   },
+  "pathEvidence": {
+    "zh-CN": "被拦路径：\n{commandPath}\n当前工作目录：{cwd}\n允许范围：{allowedRoots}\n建议：先调用 add_directory 将所需外部目录加入当前会话，再重试；不要扩大安全规则或绕过拦截。\n{suggestion}",
+    "en-US": "Blocked paths:\n{commandPath}\nCurrent working directory: {cwd}\nAllowed roots: {allowedRoots}\nSuggestion: call add_directory to add the required external directory to this session, then retry; do not broaden safety rules or bypass the block.\n{suggestion}"
+  },
+  "pathViolation": {
+    "zh-CN": "  {inputPath} → {resolvedPath}",
+    "en-US": "  {inputPath} → {resolvedPath}"
+  },
+  "addDirectorySuggestion": {
+    "zh-CN": "  可加入：add_directory({directory})",
+    "en-US": "  Add with: add_directory({directory})"
+  },
   "blocked": {
     "zh-CN": "安全规则已阻断操作：\n{details}",
     "en-US": "Safety rules blocked the operation:\n{details}"

--- a/packages/pi-safety-guards/src/bash-directory-scope-utils.ts
+++ b/packages/pi-safety-guards/src/bash-directory-scope-utils.ts
@@ -52,9 +52,27 @@ interface PatternPathOptions {
   valueOptionWidths: Readonly<Record<string, number>>;
 }
 
+interface AddedDirectoryState {
+  dirs?: Array<{ absolutePath?: unknown }>;
+}
+
+const ADD_DIRECTORY_STATE_TYPE = "add-dir:state";
+const SESSION_SQUASH_TYPE = "session-squash";
+
 export interface BashPathViolation {
   inputPath: string;
   resolvedPath: string;
+}
+
+/** 返回目录规则实际使用的规范化允许根，供阻断反馈准确说明授权范围。 */
+export function resolveBashDirectoryRoots(
+  cwd: string,
+  roots: readonly string[],
+): string[] {
+  return canonicalRoots(roots.map((root) => {
+    const expanded = expandKnownPathPrefix(root, cwd);
+    return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
+  }));
 }
 
 const EMPTY_OPTIONS = new Set<string>();
@@ -124,16 +142,32 @@ const JQ_VALUE_OPTION_WIDTHS: Readonly<Record<string, number>> = {
   "--argjson": NAME_AND_VALUE_OPTION_COUNT,
 };
 
+/**
+ * 从当前会话恢复 add_directory 白名单。
+ *
+ * session_squash 会把当前分支切到较早的 user entry，再追加新的摘要消息；
+ * 因此压缩前的 add-dir:state 不再位于 active branch，但仍保留在 session entries
+ * 中。沿 summary details.sourceLeafId 回溯，才能得到压缩时实际生效的目录状态。
+ */
+export function addedDirectoryPathsFromSession(
+  entries: readonly unknown[],
+  activeBranch: readonly unknown[],
+): string[] {
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const entry of entries) {
+    if (isRecord(entry) && typeof entry.id === "string") byId.set(entry.id, entry);
+  }
+
+  return replayDirectoryState(activeBranch, byId, new Map(), new Set()).paths;
+}
+
 /** 找出 Bash 命令中显式引用、但不在允许目录内的本地路径。 */
 export function findOutOfScopeBashPaths(
   command: string,
   cwd: string,
   roots: readonly string[],
 ): BashPathViolation[] {
-  const allowedRoots = canonicalRoots(roots.map((root) => {
-    const expanded = expandKnownPathPrefix(root, cwd);
-    return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
-  }));
+  const allowedRoots = resolveBashDirectoryRoots(cwd, roots);
   const referencedPaths = collectReferencedPaths(command);
   const violations: BashPathViolation[] = [];
   const seen = new Set<string>();
@@ -150,6 +184,94 @@ export function findOutOfScopeBashPaths(
   }
 
   return violations;
+}
+
+interface DirectoryState {
+  known: boolean;
+  paths: string[];
+}
+
+/** 按分支时序回放目录状态；squash checkpoint 会覆盖此前状态。 */
+function replayDirectoryState(
+  branch: readonly unknown[],
+  byId: ReadonlyMap<string, Record<string, unknown>>,
+  memo: Map<string, DirectoryState | undefined>,
+  resolving: Set<string>,
+): DirectoryState {
+  let state: DirectoryState = { known: false, paths: [] };
+  for (const entry of branch) {
+    if (isAddDirectoryState(entry)) {
+      state = parseAddedDirectoryState(entry);
+      continue;
+    }
+    if (!isSessionSquashEntry(entry)) continue;
+
+    const source = sourceLeafId(entry);
+    const sourceState = source === undefined
+      ? undefined
+      : resolveDirectoryStateAtLeaf(source, byId, memo, resolving);
+    state = sourceState?.known ? sourceState : { known: true, paths: [] };
+  }
+  return state;
+}
+
+function resolveDirectoryStateAtLeaf(
+  leafId: string,
+  byId: ReadonlyMap<string, Record<string, unknown>>,
+  memo: Map<string, DirectoryState | undefined>,
+  resolving: Set<string>,
+): DirectoryState | undefined {
+  if (memo.has(leafId)) return memo.get(leafId);
+  if (resolving.has(leafId)) return undefined;
+  const branch = ancestorEntries(leafId, byId);
+  if (branch.length === 0) return undefined;
+
+  resolving.add(leafId);
+  const state = replayDirectoryState(branch, byId, memo, resolving);
+  resolving.delete(leafId);
+  memo.set(leafId, state);
+  return state;
+}
+
+function parseAddedDirectoryState(entry: Record<string, unknown>): DirectoryState {
+  const data = isRecord(entry.data) ? entry.data as AddedDirectoryState : undefined;
+  const dirs = Array.isArray(data?.dirs) ? data.dirs : [];
+  return {
+    known: true,
+    paths: [...new Set(dirs
+      .map((dir) => isRecord(dir) ? dir.absolutePath : undefined)
+      .filter((value): value is string => typeof value === "string" && isAbsolute(value)))]
+  };
+}
+
+function isAddDirectoryState(entry: unknown): entry is Record<string, unknown> {
+  return isRecord(entry) && entry.type === "custom" && entry.customType === ADD_DIRECTORY_STATE_TYPE;
+}
+
+function isSessionSquashEntry(entry: unknown): entry is Record<string, unknown> {
+  return isRecord(entry) && entry.type === "custom_message" && entry.customType === SESSION_SQUASH_TYPE;
+}
+
+function sourceLeafId(entry: Record<string, unknown>): string | undefined {
+  const details = isRecord(entry.details) ? entry.details : undefined;
+  return typeof details?.sourceLeafId === "string" ? details.sourceLeafId : undefined;
+}
+
+function ancestorEntries(
+  leafId: string,
+  byId: ReadonlyMap<string, Record<string, unknown>>,
+): Record<string, unknown>[] {
+  const ancestors: Record<string, unknown>[] = [];
+  const visited = new Set<string>();
+  let currentId: string | null = leafId;
+  while (currentId && !visited.has(currentId)) {
+    visited.add(currentId);
+    const entry = byId.get(currentId);
+    if (!entry) break;
+    ancestors.push(entry);
+    currentId = typeof entry.parentId === "string" ? entry.parentId : null;
+  }
+  return ancestors.reverse();
 }
 
 /** 从共享 Shell 分析结果收集命令参数、wrapper、重定向和文件测试中的路径。 */

--- a/packages/pi-safety-guards/src/engine.ts
+++ b/packages/pi-safety-guards/src/engine.ts
@@ -1,8 +1,12 @@
 import { statSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { analyzeShellCommand, type ShellCommandAnalysis } from "./shell-command-utils.ts";
-import { findOutOfScopeBashPaths } from "./bash-directory-scope-utils.ts";
+import {
+  findOutOfScopeBashPaths,
+  resolveBashDirectoryRoots,
+  type BashPathViolation,
+} from "./bash-directory-scope-utils.ts";
 import { i18n } from "./i18n.ts";
 import type { Detector, RuleAction, RuleContext, RuleMatcher, RuleMatch, SafetyConfig, SafetyRule } from "./types.ts";
 
@@ -22,9 +26,17 @@ export interface CompiledRule {
   readonly rule: SafetyRule;
   readonly matcher?: RuleMatcher;
 }
+export interface PathRuleEvidence {
+  readonly cwd: string;
+  readonly allowedRoots: readonly string[];
+  readonly violations: readonly BashPathViolation[];
+  readonly suggestedDirectories: readonly string[];
+}
+
 export interface PolicyDecision {
   readonly action: RuleAction;
   readonly matches: readonly SafetyRule[];
+  readonly pathEvidence: ReadonlyMap<string, PathRuleEvidence>;
 }
 export type ModuleLoader = (path: string) => Promise<unknown>;
 
@@ -112,15 +124,41 @@ function withDeadline<T>(operation: () => Promise<T> | T): Promise<T> {
 }
 
 /** 命令名只建立一次索引；内置检测保持明确的分支。 */
+interface BuiltinMatch {
+  matched: boolean;
+  pathEvidence?: PathRuleEvidence;
+}
+
 function matchesBuiltin(
   match: RuleMatch,
   context: RuleContext,
   analysis: ShellCommandAnalysis,
   commandNames: ReadonlySet<string>,
-): boolean {
-  if ("commands" in match) return match.commands.some((name) => commandNames.has(name));
-  if ("detector" in match) return detect(match.detector, analysis, context.command);
-  if ("outsideRoots" in match) return findOutOfScopeBashPaths(context.command, context.cwd, match.outsideRoots).length > 0;
+  additionalRoots: readonly string[],
+): BuiltinMatch {
+  if ("commands" in match) return { matched: match.commands.some((name) => commandNames.has(name)) };
+  if ("detector" in match) return { matched: detect(match.detector, analysis, context.command) };
+  if ("outsideRoots" in match) {
+    const roots = [...match.outsideRoots, ...additionalRoots];
+    const violations = findOutOfScopeBashPaths(context.command, context.cwd, roots);
+    if (violations.length === 0) return { matched: false };
+    const suggestedDirectories = [...new Set(violations.map(({ resolvedPath }) => {
+      try {
+        return statSync(resolvedPath).isDirectory() ? resolvedPath : dirname(resolvedPath);
+      } catch {
+        return dirname(resolvedPath);
+      }
+    }))];
+    return {
+      matched: true,
+      pathEvidence: {
+        cwd: context.cwd,
+        allowedRoots: resolveBashDirectoryRoots(context.cwd, roots),
+        violations,
+        suggestedDirectories,
+      },
+    };
+  }
   throw new Error(i18n.t("moduleMustExportMatcher"));
 }
 
@@ -137,6 +175,7 @@ export async function evaluateRules(
   rules: readonly CompiledRule[],
   command: string,
   cwd: string,
+  additionalRoots: readonly string[] = [],
 ): Promise<PolicyDecision | undefined> {
   if (rules.length === 0) return undefined;
   const analysis = analyzeShellCommand(command);
@@ -144,17 +183,21 @@ export async function evaluateRules(
   const context = moduleContext(command, cwd, analysis);
   const commandNames = new Set(analysis.commands.map(({ name }) => name));
   const matches: SafetyRule[] = [];
+  const pathEvidence = new Map<string, PathRuleEvidence>();
   for (const { rule, matcher } of rules) {
     try {
-      const matched = matcher
-        ? await withDeadline(() => matcher(context))
-        : matchesBuiltin(rule.match, context, analysis, commandNames);
-      if (typeof matched !== "boolean") throw new Error(i18n.t("matcherMustReturnBoolean"));
-      if (matched) matches.push(rule);
+      const result = matcher
+        ? { matched: await withDeadline(() => matcher(context)) }
+        : matchesBuiltin(rule.match, context, analysis, commandNames, additionalRoots);
+      if (typeof result.matched !== "boolean") throw new Error(i18n.t("matcherMustReturnBoolean"));
+      if (result.matched) {
+        matches.push(rule);
+        if (result.pathEvidence) pathEvidence.set(rule.id, result.pathEvidence);
+      }
     } catch (error) {
       throw ruleFailure(rule.id, error);
     }
   }
   const action = ACTION_ORDER.find((action) => matches.some((rule) => rule.action === action));
-  return action ? { action, matches } : undefined;
+  return action ? { action, matches, pathEvidence } : undefined;
 }

--- a/packages/pi-safety-guards/tests/engine.test.ts
+++ b/packages/pi-safety-guards/tests/engine.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseConfig } from "../src/config.ts";
@@ -45,12 +45,29 @@ test("可以按相同配置格式限制任意构建工具，不只 Maven", async
   }
 });
 
-test("显式选择目录预设才限制路径，允许范围可覆盖", async () => {
-  const cwd = join(tmpdir(), "policy-cwd");
-  const blocked = await compileRules(parseConfig({ presets: ["workspace-boundary"] }), tmpdir());
-  assert.equal((await evaluateRules(blocked, "cat ../outside/file", cwd))?.action, "block");
-  const overridden = await compileRules(parseConfig({ presets: ["workspace-boundary"], rules: [{ id: "paths.workspace", match: { outsideRoots: [".", "../outside"] } }] }), tmpdir());
-  assert.equal(await evaluateRules(overridden, "cat ../outside/file", cwd), undefined);
+test("显式选择目录预设才限制路径，保留证据并允许正确的额外范围", async () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "policy-cwd-"));
+  const cwd = join(fixtureRoot, "workspace");
+  const external = join(fixtureRoot, "external");
+  const unrelated = join(fixtureRoot, "unrelated");
+  mkdirSync(cwd);
+  mkdirSync(external);
+  mkdirSync(unrelated);
+  writeFileSync(join(external, "one.md"), "one");
+  writeFileSync(join(external, "two.md"), "two");
+  writeFileSync(join(external, "three.md"), "three");
+  const command = `cat ${join(external, "one.md")} ${join(external, "two.md")} ${join(external, "three.md")}`;
+  const rules = await compileRules(parseConfig({ presets: ["workspace-boundary"] }), tmpdir());
+  const blocked = await evaluateRules(rules, command, cwd);
+  assert.equal(blocked?.action, "block");
+  const evidence = blocked?.pathEvidence.get("paths.workspace");
+  assert.equal(evidence?.violations.length, 3);
+  assert.equal(evidence?.cwd, cwd);
+  assert.deepEqual(evidence?.allowedRoots, [realpathSync(cwd)]);
+  assert.deepEqual(evidence?.suggestedDirectories, [realpathSync(external)]);
+  assert.equal((await evaluateRules(rules, command, cwd, [external]))?.action, undefined);
+  assert.equal((await evaluateRules(rules, `cat ${join(unrelated, "secret.md")}`, cwd, [external]))?.action, "block");
+  assert.equal((await evaluateRules(await compileRules(parseConfig({}), tmpdir()), "rm file", cwd))?.action, "confirm");
 });
 
 test("只加载显式启用的本地规则模块，配置目录决定相对路径", async () => {

--- a/packages/pi-safety-guards/tests/extension.test.ts
+++ b/packages/pi-safety-guards/tests/extension.test.ts
@@ -18,6 +18,7 @@ function host(hasUI = true, accepted = true) {
   const pi = { on: (name: string, handler: Handler) => handlers.set(name, handler) } as unknown as ExtensionAPI;
   const ctx = {
     cwd: tmpdir(), hasUI,
+    sessionManager: { getEntries: () => [], getBranch: () => [] },
     ui: {
       confirm: async (_title: string, text: string) => { prompts.push(text); return accepted; },
       notify: (text: string) => notices.push(text),
@@ -110,6 +111,41 @@ test("损坏配置不默默恢复默认预设，而是通知并阻断 Bash", asy
   assert.equal(fake.notices.length, 1);
   assert.equal((await fake.emit("tool_call", call("npm test")) as { block: boolean }).block, true);
   assert.equal(await fake.emit("tool_call", { toolName: "read", input: {} }), undefined);
+});
+
+test("目录越界反馈真实路径、范围和 add_directory 建议", async () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "safety-evidence-"));
+  const cwd = join(fixtureRoot, "workspace");
+  const external = join(fixtureRoot, "external");
+  mkdirSync(cwd);
+  mkdirSync(external);
+  writeFileSync(join(external, "workflow.md"), "workflow");
+  const fake = host();
+  (fake.ctx as unknown as { cwd: string }).cwd = cwd;
+  await registerSafetyGuards(fake.pi, parseConfig({ presets: ["workspace-boundary"] }));
+  const command = `cat ${join(external, "workflow.md")}`;
+  const result = await fake.emit("tool_call", call(command)) as { block: boolean; reason: string };
+  assert.equal(result.block, true);
+  assert.match(result.reason, /workflow\.md/);
+  assert.match(result.reason, /Current working directory|当前工作目录/);
+  assert.match(result.reason, /Allowed roots|允许范围/);
+  assert.match(result.reason, /add_directory/);
+  assert.match(result.reason, /external/);
+
+  const state = {
+    id: "state-1",
+    type: "custom",
+    customType: "add-dir:state",
+    data: { dirs: [{ absolutePath: external }] },
+  };
+  (fake.ctx as unknown as { sessionManager: unknown }).sessionManager = {
+    getEntries: () => [state],
+    getBranch: () => [state],
+  };
+  assert.equal(await fake.emit("tool_call", call(command)), undefined);
+  const unrelated = join(fixtureRoot, "unrelated");
+  mkdirSync(unrelated);
+  assert.equal((await fake.emit("tool_call", call(`cat ${join(unrelated, "secret.md")}`)) as { block: boolean }).block, true);
 });
 
 test("未填写说明时仅反馈规则 ID 和动作，不附加替代方案", async () => {


### PR DESCRIPTION
## Summary

- preserve evidence for `paths.workspace` Bash blocks, including blocked paths, cwd, and allowed roots
- explain the safe `add_directory({"path":"..."})` retry path and honor the current session authorization
- add regression coverage for multiple blocked files, authorization, unrelated paths, and existing safety rules

## Verification

- `npm run --workspace pi-safety-guards test` (58 passed)
- `npm run --workspace pi-safety-guards typecheck`
- six existing `pi-interactive-subagents` baseline failures remain outside this change
