### PR TITLE
feat: 支持鼠标展开工具结果

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,7 +1013,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3560,6 +3560,19 @@
       "resolved": "packages/pi-tool-supervisor",
       "link": true
     },
+    "node_modules/pi-viewport-mouse": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmmirror.com/pi-viewport-mouse/-/pi-viewport-mouse-0.1.1.tgz",
+      "integrity": "sha512-XsOhWn1ZewAKrIBAgaCzlK6NKMSUjXkaMgesdqoUwwwcbvfieHumfogta1SYEL9GU5WHvnLEw/vauBKWv/uVyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -3804,6 +3817,9 @@
     "packages/pi-extensions-tool-display": {
       "version": "1.1.1",
       "license": "MIT",
+      "dependencies": {
+        "pi-viewport-mouse": "^0.1.1"
+      },
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "0.80.10",
         "@earendil-works/pi-tui": "0.80.10",
@@ -3815,8 +3831,8 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
-        "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
+        "@earendil-works/pi-coding-agent": ">=0.80.0 <0.86.0",
+        "@earendil-works/pi-tui": ">=0.80.0 <0.86.0"
       }
     },
     "packages/pi-interactive-subagents": {

--- a/packages/pi-extensions-tool-display/README.md
+++ b/packages/pi-extensions-tool-display/README.md
@@ -6,7 +6,18 @@ It provides:
 
 - registration, disposal, and activity checks for result-render middleware;
 - a pending registration queue for when the Pi display host loads later;
-- safe component detection and a helper for appending an audit panel to the original tool result.
+- safe component detection and a helper for appending an audit panel to the original tool result;
+- optional mouse click toggling for individual tool results in Pi fullscreen TUI mode.
+
+Mouse expansion uses the separate `pi-viewport-mouse` extension. Install both packages and run Pi in fullscreen mode:
+
+```bash
+pi install npm:pi-viewport-mouse
+pi install npm:pi-extensions-tool-display
+pi --tui-mode fullscreen
+```
+
+Clicking an expandable tool result toggles only that result. `Ctrl+O` keeps its native global expand/collapse behavior. Mouse expansion is inactive in regular TUI mode and does not affect scrolling, selection, or drag behavior.
 
 It is also a standalone Pi extension. Install or include this package in Pi's package list to load the actual tool-display host. Feature package manifests include this dependency's extension entry, so installing either feature package loads one shared host without requiring a second host package.
 

--- a/packages/pi-extensions-tool-display/README.zh-CN.md
+++ b/packages/pi-extensions-tool-display/README.zh-CN.md
@@ -6,7 +6,18 @@
 
 - 结果渲染 middleware 的注册、注销和状态判断；
 - Pi 展示宿主尚未加载时的 pending 注册队列；
-- 安全识别组件，以及把审计面板追加到原始工具结果后的通用组件组合。
+- 安全识别组件，以及把审计面板追加到原始工具结果后的通用组件组合；
+- Pi fullscreen TUI 下用鼠标点击单独展开或收起工具结果。
+
+鼠标展开依赖单独的 `pi-viewport-mouse` 扩展。请同时安装两个包，并使用 fullscreen 模式运行 Pi：
+
+```bash
+pi install npm:pi-viewport-mouse
+pi install npm:pi-extensions-tool-display
+pi --tui-mode fullscreen
+```
+
+点击可展开的工具结果时，只会切换当前结果；`Ctrl+O` 仍然保留 Pi 原生的全局展开/收起行为。普通 TUI 模式下不会启用鼠标展开，也不会影响滚动、文本选择和拖拽。
 
 它同时是一个独立的 Pi 扩展。可以把这个包直接加入 Pi 的 package 列表加载工具展示宿主；`pi-distill`、`pi-tool-supervisor` 的包清单也会声明这个依赖的扩展入口，因此安装功能包时只会加载一个公共宿主，不需要额外安装第二份宿主包。
 

--- a/packages/pi-extensions-tool-display/package.json
+++ b/packages/pi-extensions-tool-display/package.json
@@ -48,8 +48,11 @@
     "tool-display"
   ],
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.80.0 <0.81.0",
-    "@earendil-works/pi-tui": ">=0.80.0 <0.81.0"
+    "@earendil-works/pi-coding-agent": ">=0.80.0 <0.86.0",
+    "@earendil-works/pi-tui": ">=0.80.0 <0.86.0"
+  },
+  "dependencies": {
+    "pi-viewport-mouse": "^0.1.1"
   },
   "pi": {
     "extensions": [

--- a/packages/pi-extensions-tool-display/src/index.ts
+++ b/packages/pi-extensions-tool-display/src/index.ts
@@ -16,6 +16,7 @@ import { registerToolDisplayOverrides } from "./tool-overrides.js";
 import { logToolDisplayDebug } from "./debug-logger.js";
 import { disposeAll, resetDisposed } from "./disposable.js";
 import { registerThinkingLabeling } from "./thinking-label.js";
+import { registerToolDisplayViewportMouse } from "./viewport-mouse.js";
 import registerNativeUserMessageBox from "./user-message-box-native.js";
 import {
   BUILT_IN_TOOL_OVERRIDE_NAMES,
@@ -131,6 +132,7 @@ export function ensureToolDisplayHost(
 
   if (initial.config.enabled) {
     registerToolDisplayOverrides(pi, getEffectiveConfig, activeBuiltInToolNamesBeforeReload);
+    registerToolDisplayViewportMouse();
     registerNativeUserMessageBox(pi, getConfig);
     registerThinkingLabeling(pi);
   }

--- a/packages/pi-extensions-tool-display/src/viewport-mouse.ts
+++ b/packages/pi-extensions-tool-display/src/viewport-mouse.ts
@@ -1,0 +1,46 @@
+import {
+  onViewportClick,
+  type ViewportClickEvent,
+} from "pi-viewport-mouse/client";
+import { registerCleanup } from "./disposable.js";
+
+const VIEWPORT_MOUSE_HANDLER_KEY = "pi-extensions-tool-display";
+
+type ExpandableComponent = {
+  expanded?: boolean;
+  setExpanded(expanded: boolean): void;
+};
+
+/** Find the nearest runtime component that exposes Pi's expansion method. */
+export function findExpandableComponent(event: ViewportClickEvent): ExpandableComponent | undefined {
+  const component = event.closest((candidate) =>
+    Boolean(candidate && typeof candidate.setExpanded === "function"),
+  );
+
+  return component as ExpandableComponent | undefined;
+}
+
+/** Toggle one tool result, request a redraw, and pass through unrelated clicks. */
+export function toggleToolResultFromViewportClick(event: ViewportClickEvent): boolean {
+  const component = findExpandableComponent(event);
+  if (!component) {
+    return false;
+  }
+
+  component.setExpanded(component.expanded !== true);
+  event.requestRender();
+  return true;
+}
+
+/**
+ * Enable per-component mouse expansion when pi-viewport-mouse is installed.
+ * The mouse extension owns terminal input and this package only owns the
+ * tool-display action, so regular/inline TUI mode remains a no-op.
+ */
+export function registerToolDisplayViewportMouse(): void {
+  const unsubscribe = onViewportClick(
+    VIEWPORT_MOUSE_HANDLER_KEY,
+    toggleToolResultFromViewportClick,
+  );
+  registerCleanup(unsubscribe);
+}

--- a/packages/pi-extensions-tool-display/tests/viewport-mouse.test.ts
+++ b/packages/pi-extensions-tool-display/tests/viewport-mouse.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ViewportClickEvent } from "pi-viewport-mouse/client";
+import {
+  findExpandableComponent,
+  toggleToolResultFromViewportClick,
+} from "../src/viewport-mouse.ts";
+
+/** Build the smallest viewport-click fixture needed by the pure toggle handler. */
+function createClickEvent(component: unknown): { event: ViewportClickEvent; renderRequested: () => boolean } {
+  let requested = false;
+  const event = {
+    closest: (predicate: (candidate: unknown) => boolean) => predicate(component) ? component : undefined,
+    requestRender: () => {
+      requested = true;
+    },
+  } as unknown as ViewportClickEvent;
+
+  return {
+    event,
+    renderRequested: () => requested,
+  };
+}
+
+test("findExpandableComponent returns the nearest expandable component", () => {
+  const component = { expanded: false, setExpanded: () => undefined };
+  const { event } = createClickEvent(component);
+
+  assert.equal(findExpandableComponent(event), component);
+});
+
+test("toggleToolResultFromViewportClick expands a collapsed result and redraws", () => {
+  let expanded: boolean | undefined = false;
+  const component = {
+    // Mirror the private runtime state exposed by Pi's expandable component.
+    get expanded() {
+      return expanded;
+    },
+    // Capture the state change requested by the click handler.
+    setExpanded(value: boolean) {
+      expanded = value;
+    },
+  };
+  const { event, renderRequested } = createClickEvent(component);
+
+  assert.equal(toggleToolResultFromViewportClick(event), true);
+  assert.equal(expanded, true);
+  assert.equal(renderRequested(), true);
+});
+
+test("toggleToolResultFromViewportClick collapses an expanded result", () => {
+  let expanded: boolean | undefined = true;
+  const component = {
+    // Mirror the private runtime state exposed by Pi's expandable component.
+    get expanded() {
+      return expanded;
+    },
+    // Capture the state change requested by the click handler.
+    setExpanded(value: boolean) {
+      expanded = value;
+    },
+  };
+  const { event } = createClickEvent(component);
+
+  assert.equal(toggleToolResultFromViewportClick(event), true);
+  assert.equal(expanded, false);
+});
+
+test("toggleToolResultFromViewportClick passes through clicks without an expandable component", () => {
+  const { event, renderRequested } = createClickEvent({ render: () => [] });
+
+  assert.equal(toggleToolResultFromViewportClick(event), false);
+  assert.equal(renderRequested(), false);
+});


### PR DESCRIPTION
## 背景

Pi fullscreen TUI 已支持鼠标点击，但 Pi 不会直接把 transcript 内的点击事件分发给工具组件。tool-display 需要一种按单个工具结果切换展开状态的交互。

## 变更

- 接入 `pi-viewport-mouse` 点击事件协议。
- 鼠标点击可展开组件时，切换当前工具结果的 `expanded` 状态并请求重绘。
- 保留 Pi 原生 `Ctrl+O` 全局展开/收起行为。
- 普通 TUI 模式下不启用鼠标展开。
- 增加单元测试、依赖声明和中英文使用说明。
- tool-display 支持 Pi `0.80.x` 至 `0.85.x`。

## 使用

```bash
pi install npm:pi-viewport-mouse
pi install npm:pi-extensions-tool-display
pi --tui-mode fullscreen
```

## 验证

- `npm run check`
- 1279 项测试通过
- typecheck 通过
- package config、local-path、private-domain、i18n 和 UI 输出门禁通过

真实 fullscreen 终端点击需要在 Pi `0.85.1` 环境中手动验收；自动化测试覆盖了鼠标处理器的展开、收起和无目标透传逻辑。
