### PR TITLE
fix: hide supervisor reviewer failures from Agent

### DIFF
--- a/packages/pi-tool-supervisor/README.md
+++ b/packages/pi-tool-supervisor/README.md
@@ -9,7 +9,7 @@ An edit tool can complete successfully while the resulting file still violates l
 ## How it works
 
 - Each reviewer selects `tools`, a `trigger`, and optionally a local `condition` module: omitted fields default to `edit`/`write` + `after`, and `"*"` matches every built-in or custom tool.
-- Before reviewers inspect the proposed input and an explicit rejection blocks the native Pi tool call; model failures remain fail-open and visible, while condition module failures block the before call.
+- Before reviewers inspect the proposed input and an explicit rejection blocks the native Pi tool call; model failures remain fail-open without injecting errors into the Agent's tool result, while the audit card keeps the failed status. Condition module failures block the before call.
 - Captures the file state before `edit` / `write` and the actual file state after the tool result.
 - Sends the real-line-numbered post-edit file with the diff; files above `maxFileContextChars` use bounded excerpts around the first and last changed lines.
 - Supports multiple reviewers running in parallel, each with its own model and one or more rule files.
@@ -133,9 +133,9 @@ A condition returning `false` skips the reviewer without loading its rules or ca
 
 ## Review semantics
 
-- A before reviewer rejection blocks the native tool call and emits a standalone audit with the complete reason; model failures/skips remain fail-open and visible on the next tool result. Condition module load or execution failures are treated as a failed gate and block the before call.
-- An after rejection is diagnostic only and never rolls back a completed tool call; a failed tool skips after review and preserves the original error.
-- Review rejections, reviewer failures, and configuration warnings use Pi's `ctx.ui.notify`; the extension does not call `console.warn` or `console.error` directly.
+- A before reviewer rejection blocks the native tool call and sends the complete reason to the Agent; model failures/skips remain fail-open and stay only in the audit details, without appending an error to the tool result. Condition module load or execution failures are treated as a failed gate and block the before call.
+- An after rejection is diagnostic only and sends the diagnostic to the Agent without rolling back a completed tool call; an after model failure stays only in the audit details and does not append an error diagnostic. A failed tool skips after review and preserves the original error.
+- Review rejections and configuration warnings use Pi's `ctx.ui.notify`; reviewer failures remain in the audit card and are not injected into the Agent's context. The extension does not call `console.warn` or `console.error` directly.
 - If the parent Agent request is interrupted, every in-flight reviewer model request is cancelled together; reviewers not yet started are skipped, and parent cancellation is reported as skipped rather than as a provider failure.
 - A failed tool call or an unchanged file is skipped.
 - The extension does not roll back edits, block the operating system, or replace Pi's permission and sandbox controls.

--- a/packages/pi-tool-supervisor/README.zh-CN.md
+++ b/packages/pi-tool-supervisor/README.zh-CN.md
@@ -9,7 +9,7 @@
 ## 工作方式
 
 - 每个 reviewer 可选择 `tools`、`trigger`，并可选配置本地 `condition` 模块；省略时保持旧默认：`edit`/`write` + `after`，`"*"` 匹配全部内建和自定义工具。
-- before reviewer 审查执行前输入，明确拒绝会通过 Pi 原生机制阻断调用；模型审查失败仍 fail-open 且可见，condition 模块加载或执行失败会阻断 before 调用。
+- before reviewer 审查执行前输入，明确拒绝会通过 Pi 原生机制阻断调用；模型审查失败仍 fail-open，但不会把错误追加给 Agent，审计卡片仍保留失败状态；condition 模块加载或执行失败会阻断 before 调用。
 - 在 `edit` / `write` 前捕获文件状态，在工具返回后读取实际文件状态。
 - 将带真实行号的修改后文件与 diff 一起发送；超过 `maxFileContextChars` 时，截取首次和末次变更附近并明确标记截断。
 - 构建 diff，并只选择规则文件匹配当前变更文件的 reviewer。
@@ -134,9 +134,9 @@ condition 返回 `false` 时跳过该 reviewer，不读取其规则文件，也�
 
 ## 审查语义
 
-- before reviewer 明确拒绝会阻断 Pi 原生工具调用，并用完整 reason 展示独立审计；模型失败/跳过会放行但保持可见，condition 模块加载或执行失败会阻断 before 调用。
-- after 拒绝只提供诊断，不回滚已完成的工具调用；工具失败时跳过 after 审查并保留原始错误。
-- 审查拒绝、模型失败和配置警告都通过 Pi 的 `ctx.ui.notify` 展示，不直接调用 `console.warn` 或 `console.error`。
+- before reviewer 明确拒绝会阻断 Pi 原生工具调用，并把完整 reason 展示给 Agent；模型失败/跳过会放行，但失败信息只保留在审计详情中，不追加到 tool result。condition 模块加载或执行失败会阻断 before 调用。
+- after 拒绝只提供诊断并展示给 Agent，不回滚已完成的工具调用；after 模型失败只保留在审计详情中，不追加错误诊断；工具失败时跳过 after 审查并保留原始错误。
+- 审查拒绝和配置警告通过 Pi 的 `ctx.ui.notify` 展示；审查失败保留在审计卡片中，不向 Agent 注入错误文本；扩展不直接调用 `console.warn` 或 `console.error`。
 - 如果用户打断上级 Agent 请求，所有尚未完成的 reviewer 模型请求会一起取消；尚未发起的 reviewer 会跳过；上级中断记为 skipped，而不是模型调用失败。
 - 工具调用失败或文件内容没有变化时跳过审查。
 - 扩展不会回滚编辑、阻断操作系统，也不替代 Pi 的权限与沙箱控制。

--- a/packages/pi-tool-supervisor/SKILL.md
+++ b/packages/pi-tool-supervisor/SKILL.md
@@ -23,7 +23,7 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 优先使用 `/config:tool-supervisor`；`/pi-tool-supervisor` 是兼容别名。只修改目标 reviewer 和规则：
 
-- `before` 审查工具输入；明确拒绝会阻断原生工具，模型失败或跳过则 fail-open 但保持可见，condition 模块加载或执行失败则阻断 before 调用；
+- `before` 审查工具输入；明确拒绝会阻断原生工具，模型失败或跳过则 fail-open，但错误只保留在审计详情中，不注入 Agent 的 tool result；condition 模块加载或执行失败则阻断 before 调用；
 - `after` 审查工具结果；拒绝只诊断、不回滚，原工具失败时跳过 after；
 - `edit/write` 使用真实文件前后快照、带真实行号的 diff 和修改后文件上下文；超出 `maxFileContextChars` 时只保留首次与末次变更附近的有界片段并明确标记；其他工具使用有界序列化的 input/result；
 - 带 `filePatterns` 的规则只用于文件审查，通用工具规则不要设置 `filePatterns`；
@@ -33,4 +33,4 @@ description: "配置与排查 pi-tool-supervisor 的 before/after 工具审查�
 
 ## 验证
 
-先回读配置和所有规则，确认模型、路径、生命周期、condition 模块与文件匹配。再按目标触发一个最小工具调用：before 拒绝应阻断；after 拒绝应保留原结果并附诊断；condition 返回 false 应跳过模型；模型失败应可见且按 fail-open 处理。未运行真实工具/模型审查时报告 `NOT_RUN`，不能用 JSON 可解析冒充已生效。
+先回读配置和所有规则，确认模型、路径、生命周期、condition 模块与文件匹配。再按目标触发一个最小工具调用：before 拒绝应阻断；after 拒绝应保留原结果并附诊断；condition 返回 false 应跳过模型；模型失败应 fail-open、保留审计状态但不注入 Agent。未运行真实工具/模型审查时报告 `NOT_RUN`，不能用 JSON 可解析冒充已生效。

--- a/packages/pi-tool-supervisor/src/index.ts
+++ b/packages/pi-tool-supervisor/src/index.ts
@@ -2,7 +2,7 @@
  * 文件编辑侧边审查器。
  *
  * edit/write 已经执行完成后，提取实际文件变化并并发交给配置的审查模型。
- * 审查失败不回滚文件；不通过项会追加到 Agent 可见的 tool result，要求立即修正。
+ * 审查失败不回滚文件；只有明确拒绝才会把诊断追加到 Agent 可见的 tool result。
  * 配置文件位于 Pi 的用户扩展配置目录：
  * ~/.pi/agent/extensions/pi-tool-supervisor/config.json
  */
@@ -237,40 +237,26 @@ function withReviewAbortedWarning(warnings: string[], signal?: AbortSignal): str
   return warnings.includes(warning) ? warnings : [...warnings, warning];
 }
 
-/** Produces visible diagnostics for rejected and failed reviewers. */
-function createReviewDiagnostic(
+/** Produces an Agent-visible diagnostic only for explicit reviewer rejections. */
+function createReviewRejectionDiagnostic(
   audit: FileEditReviewAudit,
-  configPath?: string,
 ): string | undefined {
   const rejected = audit.reviewers.filter((reviewer) => reviewer.status === "rejected");
-  const failed = audit.reviewers.filter((reviewer) => reviewer.status === "failed");
-  const lines: string[] = [];
+  if (rejected.length === 0) return undefined;
 
-  if (rejected.length > 0) {
-    lines.push("[文件编辑审查未通过，必须立即修正]");
-    lines.push(audit.filePath ? `文件：${audit.filePath}` : `工具：${audit.toolName}`);
-    for (const reviewer of rejected) {
-      lines.push(`规则审查：${reviewer.name}（${reviewer.rulesFiles?.join(", ") ?? reviewer.rulesFile ?? "未指定规则文件"}）`);
-      if (reviewer.summary) lines.push(`结论：${reviewer.summary}`);
-      for (const finding of reviewer.findings ?? []) {
-        const location = finding.line ? `第 ${finding.line} 行：` : "";
-        const ruleGroup = finding.ruleGroup ? `[${finding.ruleGroup}] ` : "";
-        lines.push(`- ${ruleGroup}${location}${finding.message}`);
-      }
+  const lines: string[] = ["[文件编辑审查未通过，必须立即修正]"];
+  lines.push(audit.filePath ? `文件：${audit.filePath}` : `工具：${audit.toolName}`);
+  for (const reviewer of rejected) {
+    lines.push(`规则审查：${reviewer.name}（${reviewer.rulesFiles?.join(", ") ?? reviewer.rulesFile ?? "未指定规则文件"}）`);
+    if (reviewer.summary) lines.push(`结论：${reviewer.summary}`);
+    for (const finding of reviewer.findings ?? []) {
+      const location = finding.line ? `第 ${finding.line} 行：` : "";
+      const ruleGroup = finding.ruleGroup ? `[${finding.ruleGroup}] ` : "";
+      lines.push(`- ${ruleGroup}${location}${finding.message}`);
     }
-    lines.push("请先修正以上问题，再继续后续任务。不要忽略这条审查结果。");
   }
-
-  if (failed.length > 0) {
-    lines.push("[文件编辑审查未完成，已放行但必须注意]");
-    lines.push(audit.filePath ? `文件：${audit.filePath}` : `工具：${audit.toolName}`);
-    for (const reviewer of failed) {
-      lines.push(`- ${reviewer.name}（${reviewer.rulesFiles?.join(", ") ?? reviewer.rulesFile ?? "未指定规则文件"}）：${reviewer.error ?? "审查模型调用失败"}`);
-    }
-    lines.push(`审查配置：${configPath ?? "未找到"}`);
-  }
-
-  return lines.length > 0 ? lines.join("\n") : undefined;
+  lines.push("请先修正以上问题，再继续后续任务。不要忽略这条审查结果。");
+  return lines.join("\n");
 }
 
 /** Executes one reviewer with parent cancellation and timeout fail-open behavior. */
@@ -393,7 +379,6 @@ async function reviewToolResult(options: {
   context: FileReviewExecutionContext;
   toolName: "edit" | "write";
   config: FileEditReviewConfig;
-  configPath: string;
   configWarnings: string[];
   snapshot: FileSnapshot;
   fallbackDiff: string;
@@ -401,7 +386,7 @@ async function reviewToolResult(options: {
   afterReviewers?: FileEditReviewReviewerConfig[];
   beforeAudit?: FileEditReviewAudit;
 }): Promise<ToolResult> {
-  const { context, toolName, config, configPath, configWarnings, snapshot, fallbackDiff, result, afterReviewers, beforeAudit } = options;
+  const { context, toolName, config, configWarnings, snapshot, fallbackDiff, result, afterReviewers, beforeAudit } = options;
   const configuredAfterReviewers = afterReviewers ?? config.reviewers.filter((reviewer) => reviewer.enabled !== false && reviewerTrigger(reviewer) === AFTER_TRIGGER && reviewerMatchesTool(reviewer, toolName));
   const beforeReviewers = beforeAudit?.reviewers ?? [];
   const startedAt = performance.now();
@@ -464,7 +449,7 @@ async function reviewToolResult(options: {
       durationMs: Math.round(performance.now() - startedAt),
       warnings: [...configWarnings, ...(beforeAudit?.warnings ?? []), i18n.t("unchangedFileSkipped")],
     };
-    const diagnostic = createReviewDiagnostic(audit, configPath);
+    const diagnostic = createReviewRejectionDiagnostic(audit);
     if (diagnostic) context.ctx.ui?.notify(diagnostic, "error");
     return {
       ...result,
@@ -507,7 +492,7 @@ async function reviewToolResult(options: {
       durationMs: Math.round(performance.now() - startedAt),
       warnings: [...configWarnings, ...(beforeAudit?.warnings ?? [])],
     };
-    const diagnostic = createReviewDiagnostic(audit, configPath);
+    const diagnostic = createReviewRejectionDiagnostic(audit);
     if (diagnostic) context.ctx.ui?.notify(diagnostic, "error");
     return {
       ...result,
@@ -545,7 +530,7 @@ async function reviewToolResult(options: {
     durationMs: Math.round(performance.now() - startedAt),
     warnings: auditWarnings,
   };
-  const diagnostic = createReviewDiagnostic(audit, configPath);
+  const diagnostic = createReviewRejectionDiagnostic(audit);
   if (diagnostic) {
     context.ctx.ui?.notify(diagnostic, "error");
   }
@@ -706,7 +691,7 @@ async function processGenericReviewResult(context: FileReviewExecutionContext, p
     context.signal,
   );
   const audit: FileEditReviewAudit = { status: getOverallReviewStatus(reviewersWithBefore), toolName: context.toolName, trigger: AFTER_TRIGGER, reviewers: reviewersWithBefore, durationMs: (pending.beforeAudit?.durationMs ?? 0) + afterDurationMs, warnings };
-  const diagnostic = createReviewDiagnostic({ ...audit, filePath: context.toolName }, pending.loaded.configPath);
+  const diagnostic = createReviewRejectionDiagnostic({ ...audit, filePath: context.toolName });
   if (diagnostic) context.ctx.ui?.notify(diagnostic, "error");
   return { ...result, details: { ...(result.details ?? {}), fileEditReview: audit }, content: diagnostic ? [...result.content, { type: "text", text: diagnostic }] : result.content };
 }
@@ -726,7 +711,6 @@ async function processFileReviewResult(
     context,
     toolName: pending.toolName as typeof EDIT_TOOL | typeof WRITE_TOOL,
     config: loaded.config,
-    configPath: loaded.configPath,
     configWarnings: loaded.warnings,
     snapshot: pending.snapshot,
     fallbackDiff: pending.fallbackDiff,
@@ -961,7 +945,7 @@ export default function piSupervisorExtension(pi: ExtensionAPI) {
     const pending = await prepareFileReviewCall(context);
     pendingCalls.set(event.toolCallId, pending);
     if (pending.beforeAudit?.status === REJECTED_STATUS) {
-      const diagnostic = createReviewDiagnostic(pending.beforeAudit, pending.loaded.configPath);
+      const diagnostic = createReviewRejectionDiagnostic(pending.beforeAudit);
       if (diagnostic) ctx.ui?.notify(diagnostic, "error");
       pendingCalls.delete(event.toolCallId);
       appendSupervisorFallbackAudit(pi, event.toolName, { fileEditReview: pending.beforeAudit });

--- a/packages/pi-tool-supervisor/src/tool-display-bridge.ts
+++ b/packages/pi-tool-supervisor/src/tool-display-bridge.ts
@@ -18,6 +18,13 @@ function getAudit(result: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+const DIAGNOSTIC_AUDIT_STATUSES = new Set(["rejected", "failed"]);
+
+/** Returns whether the audit should replace raw diagnostic tool output in the TUI. */
+function isDiagnosticAudit(audit: Record<string, unknown>): boolean {
+  return typeof audit.status === "string" && DIAGNOSTIC_AUDIT_STATUSES.has(audit.status);
+}
+
 /** Renders supervisor panels for every tool carrying a valid audit. */
 const supervisorMiddleware: ResultMiddleware = (context, next) => {
   const audit = getAudit(context.result);
@@ -30,7 +37,10 @@ const supervisorMiddleware: ResultMiddleware = (context, next) => {
   if (!rendered) return next();
 
   const panel = createSupervisorAuditComponent(rendered, context.theme);
-  return appendResultRenderPanel(next(), panel);
+  // The full diagnostic remains in result.content for the model, while the
+  // TUI shows the audit panel and the notify toast instead of printing it as
+  // ordinary tool output in the editor area.
+  return isDiagnosticAudit(audit) ? panel : appendResultRenderPanel(next(), panel);
 };
 
 export function registerSupervisorToolDisplayMiddleware(): () => void {

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -438,6 +438,30 @@ test("pi-tool-supervisor 通过通用 tool-display result middleware 追加审�
     const output = component.render(120).join("\n");
     assert.match(output, /基础 diff/);
     assert.match(output, /⛨ Supervisor  ✓ 已通过  edit · 1 个审查器 · 1\.4s • Ctrl\+O 展开/);
+
+    const rejectedComponent = registration.middleware({
+      toolName: "edit",
+      result: {
+        content: [{ type: "text", text: "Error: [文件编辑审查未通过]" }],
+        details: {
+          fileEditReview: {
+            status: "rejected",
+            durationMs: 1400,
+            reviewers: [{ name: "coding-taste", status: "rejected", durationMs: 1200 }],
+          },
+        },
+      },
+      options: { expanded: false },
+      theme: {
+        fg: (_color: string, text: string) => text,
+        bold: (text: string) => text,
+      },
+    }, () => {
+      throw new Error("raw tool output should be hidden");
+    });
+    const rejectedOutput = rejectedComponent.render(120).join("\n");
+    assert.match(rejectedOutput, /⛨ Supervisor  ✕ 未通过/);
+    assert.doesNotMatch(rejectedOutput, /Error: \[文件编辑审查未通过\]/);
   } finally {
     dispose();
     delete (globalThis as any)[apiKey];

--- a/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
+++ b/packages/pi-tool-supervisor/tests/pi-tool-supervisor.test.ts
@@ -819,8 +819,8 @@ test("generic before 即使输入含 path 也只使用无文件模式规则", as
   }
 });
 
-test("自定义工具支持精确名和通配符 after 审查并展示审计", async () => {
-  type ReviewResult = { details: { fileEditReview: { reviewers: Array<{ name: string }>; status: string }; source: string } };
+test("自定义工具支持精确名和通配符 after 审查并展示失败审计但不注入 Agent", async () => {
+  type ReviewResult = { content: Array<{ text?: string }>; details: { fileEditReview: { reviewers: Array<{ name: string }>; status: string }; source: string } };
   type TestHandler = (...args: unknown[]) => Promise<unknown> | unknown;
   const { default: piSupervisorExtension } = await import("../src/index.ts");
   const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -870,9 +870,8 @@ test("自定义工具支持精确名和通配符 after 审查并展示审计", a
     assert.deepEqual(result.details.fileEditReview.reviewers.map((reviewer) => reviewer.name), ["exact", "wildcard"]);
     assert.equal(result.details.fileEditReview.status, "failed");
     assert.equal(result.details.source, "custom");
-    assert.equal(notifications.length, 1);
-    assert.equal(notifications[0]?.type, "error");
-    assert.match(notifications[0]?.message ?? "", /审查未完成/);
+    assert.deepEqual(result.content, [{ type: "text", text: "ok" }]);
+    assert.equal(notifications.length, 0);
   } finally {
     await handlers.get("session_shutdown")?.();
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
@@ -880,7 +879,7 @@ test("自定义工具支持精确名和通配符 after 审查并展示审计", a
   }
 });
 
-test("generic 载荷序列化失败形成可见 failed 审计并保持原结果", async () => {
+test("generic 载荷序列化失败形成 failed 审计但不注入 Agent", async () => {
   type ReviewResult = { content: Array<{ text?: string }>; details: { original: boolean; fileEditReview: { status: string; reviewers: Array<{ error?: string }> } } };
   type TestHandler = (...args: unknown[]) => Promise<unknown> | unknown;
   const { default: piSupervisorExtension } = await import("../src/index.ts");
@@ -994,7 +993,7 @@ test("generic before rejected 阻断时诊断使用工具名并追加独立审�
   }
 });
 
-test("before failed 和 skipped 放行时在 tool_result 中保留可见审计", async () => {
+test("before failed 和 skipped 放行时只在 tool_result 详情中保留审计", async () => {
   type TestHandler = (...args: unknown[]) => Promise<unknown> | unknown;
   const { default: piSupervisorExtension } = await import("../src/index.ts");
   const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -1043,8 +1042,7 @@ test("before failed 和 skipped 放行时在 tool_result 中保留可见审计",
     const reviewResult = result as { details: { fileEditReview: { status: string; reviewers: Array<{ status: string }> } }; content: Array<{ text?: string }> };
     assert.equal(reviewResult.details.fileEditReview.status, "failed");
     assert.deepEqual(reviewResult.details.fileEditReview.reviewers.map((reviewer) => reviewer.status), ["failed", "skipped"]);
-    assert.match(reviewResult.content.at(-1)?.text ?? "", /文件：custom-tool/);
-    assert.doesNotMatch(reviewResult.content.at(-1)?.text ?? "", /文件：undefined/);
+    assert.deepEqual(reviewResult.content, [{ type: "text", text: "original" }]);
   } finally {
     faux.unregister();
     await handlers.get("session_shutdown")?.();


### PR DESCRIPTION
## 问题

pi-tool-supervisor 会把 reviewer 模型调用失败的错误追加到 tool result，导致 Agent 看到上游网络错误、超时等与代码修复无关的信息。

## 变更

- 只有 reviewer 明确返回 `rejected` 时，才向 Agent 追加审查诊断。
- reviewer 调用失败、序列化失败或跳过时，继续 fail-open，并仅保留在 Supervisor 审计详情/卡片中。
- 保留原始工具结果，不再为 reviewer 失败发送错误通知。
- 补充回归测试和中英文文档说明。

## 验证

- `npm run check --workspace packages/pi-tool-supervisor`
- 45 个测试通过
- TypeScript typecheck 通过
- npm pack dry-run 通过
