### PR TITLE
feat: 支持斜杠命令配置 subagent 扩展

### DIFF
--- a/packages/pi-interactive-subagents/README.md
+++ b/packages/pi-interactive-subagents/README.md
@@ -173,6 +173,8 @@ The persisted Herdr mode, child-spawning policy, and explicit child-extension li
 
 `herdrMode` accepts `split` (default, backward-compatible pane layout) or `tab` (one background tab per subagent). The `/config:subagent herdr split|tab` command updates this field. `allowSubagentSpawning` is a global switch for whether child subagents may create or manage other subagents; it defaults to `false`. Set it to `true` to enable the lifecycle tools in child sessions when the corresponding extension is selected. `subagentExtensions` is an optional list of extension paths to load explicitly in child sessions; automatic project/global extension discovery is disabled. Paths may be absolute, start with `~/`, or be relative to `PI_CODING_AGENT_DIR`. `subagent-done.ts` is always loaded. Explicit `deny-tools` restrictions still apply.
 
+You can configure `subagentExtensions` from the input slash-command menu instead of editing JSON: `/config:subagent extensions` opens a one-path-per-line editor, `/config:subagent extensions path-a.ts,path-b.ts` saves directly, and `/config:subagent extensions clear` removes all entries. The dedicated `/config:subagent-extensions` command (also `/subagent-extensions`) supports the same behavior. Changes apply to the next child session.
+
 `config.json` is gitignored so local overrides don't get committed.
 
 ---

--- a/packages/pi-interactive-subagents/README.zh-CN.md
+++ b/packages/pi-interactive-subagents/README.zh-CN.md
@@ -62,7 +62,9 @@ zellij --session pi   # 然后运行 pi
 }
 ```
 
-`herdrMode` 支持 `split`（默认，兼容原有 pane 布局）和 `tab`（每个 subagent 独立后台 Tab）。`allowSubagentSpawning` 是全局开关，控制子 agent 是否可以创建或管理其他 subagent，默认值为 `false`；设置为 `true` 后，子 agent 才会获得这些生命周期工具。`subagentExtensions` 是可选扩展路径列表；子 agent 不再自动发现项目级和全局扩展，只加载列表中的扩展，`subagent-done.ts` 始终加载。路径可以是绝对路径、`~/` 路径，或相对于 `PI_CODING_AGENT_DIR` 的路径。`/config:subagent herdr split|tab` 会更新 Herdr 字段。
+`herdrMode` 支持 `split`（默认，兼容原有分屏布局）和 `tab`（每个 subagent 独立后台 Tab）。`allowSubagentSpawning` 是全局开关，控制子 agent 是否可以创建或管理其他 subagent，默认值为 `false`；设置为 `true` 后，子 agent 才会获得这些生命周期工具。`subagentExtensions` 是可选扩展路径列表；子 agent 不再自动发现项目级和全局扩展，只加载列表中的扩展，`subagent-done.ts` 始终加载。路径可以是绝对路径、`~/` 路径，或相对于 `PI_CODING_AGENT_DIR` 的路径。`/config:subagent herdr split|tab` 会更新 Herdr 字段。
+
+现在也可以直接在输入框使用斜杠命令配置扩展：`/config:subagent extensions` 打开“每行一个路径”的编辑器，`/config:subagent extensions path-a.ts,path-b.ts` 直接保存，`/config:subagent extensions clear` 清空列表。另提供 `/config:subagent-extensions`（别名 `/subagent-extensions`），用法相同。修改会在下一个子会话启动时生效。
 
 ## 致谢
 

--- a/packages/pi-interactive-subagents/SKILL.md
+++ b/packages/pi-interactive-subagents/SKILL.md
@@ -11,6 +11,8 @@ description: "配置与排查 interactive subagents 的终端复用器、Herdr s
 
 环境变量优先级：`PI_TERMINAL_MUX` > `PI_SUBAGENT_MUX` > 持久化 `mux` > `auto`；`PI_SUBAGENT_HERDR_MODE` > 持久化 `herdrMode` > `split`。
 
+`/config:subagent extensions` 或 `/config:subagent-extensions` 可直接配置 `subagentExtensions`：编辑器每行填写一个路径，命令参数用逗号分隔，输入 `clear` 清空。
+
 ## 修改
 
 优先运行：

--- a/packages/pi-interactive-subagents/locales/index.json
+++ b/packages/pi-interactive-subagents/locales/index.json
@@ -46,5 +46,37 @@
   "muxInteractiveOnly": {
     "zh-CN": "请在支持 UI 的 Pi 会话中运行 /config:subagent。",
     "en-US": "Run /config:subagent in a Pi session with UI support."
+  },
+  "extensionCommandDescription": {
+    "zh-CN": "配置子 agent 显式加载的扩展",
+    "en-US": "Configure extensions explicitly loaded by child subagents"
+  },
+  "extensionConfigTitle": {
+    "zh-CN": "配置子 agent 扩展（每行一个路径；命令参数用逗号分隔）",
+    "en-US": "Configure subagent extensions (one path per line; comma-separated in commands)"
+  },
+  "extensionSaved": {
+    "zh-CN": "子 agent 扩展已设置为：{value}",
+    "en-US": "Subagent extensions set to: {value}"
+  },
+  "extensionInvalid": {
+    "zh-CN": "扩展配置无效：{value}。编辑器中每行输入一个路径；命令参数请使用逗号分隔，或输入 clear 清空。",
+    "en-US": "Invalid extension configuration: {value}. Use one path per line in the editor, comma-separated paths in commands, or clear to remove them."
+  },
+  "extensionInteractiveOnly": {
+    "zh-CN": "请在支持 UI 的 Pi 会话中配置子 agent 扩展。",
+    "en-US": "Configure subagent extensions in a Pi session with UI support."
+  },
+  "extensionNone": {
+    "zh-CN": "未配置",
+    "en-US": "none"
+  },
+  "extensionClearDescription": {
+    "zh-CN": "清空子 agent 扩展列表",
+    "en-US": "Clear the child-session extension list"
+  },
+  "extensionConfiguredDescription": {
+    "zh-CN": "当前配置的扩展路径",
+    "en-US": "Currently configured extension path"
   }
 }

--- a/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/index.ts
@@ -51,6 +51,7 @@ import {
   loadSubagentSpawningConfig,
   saveHerdrMode,
   saveMuxPreference,
+  saveSubagentExtensions,
   SUBAGENT_MUX_BACKENDS,
   type HerdrSurfaceMode,
   type SubagentMuxPreference,
@@ -1037,7 +1038,135 @@ function parseMuxConfigRequest(requested: string): MuxConfigSelection | null {
   return { preference, herdrMode: requestedMode as HerdrSurfaceMode };
 }
 
-/** 保存 mux 选择，并在 Herdr 选项携带模式时一并持久化。 */
+const SUBAGENT_EXTENSIONS_COMMAND = "extensions";
+const SUBAGENT_EXTENSIONS_CLEAR = "clear";
+const SUBAGENT_EXTENSIONS_COMMAND_NAMES = [
+  "config:subagent-extensions",
+  "subagent-extensions",
+] as const;
+
+/** Parse comma-separated extension paths from a slash-command argument. */
+function parseSubagentExtensionPaths(value: string): string[] | null {
+  const parts = value.split(",").map((part) => part.trim());
+  if (parts.length === 0 || parts.some((part) => !part)) return null;
+  return [...new Set(parts)];
+}
+
+/** Format the configured child-session extension paths for user-facing messages. */
+function formatSubagentExtensions(extensions: readonly string[]): string {
+  return extensions.length > 0 ? extensions.join(", ") : i18n.t("extensionNone");
+}
+
+/** Complete the shared subagent configuration command's first argument. */
+function getSubagentConfigArgumentCompletions(argumentPrefix: string) {
+  const trimmedPrefix = argumentPrefix.trimStart();
+  const [firstToken] = trimmedPrefix.split(/\s+/, 1);
+  if (firstToken?.toLowerCase() === SUBAGENT_EXTENSIONS_COMMAND && trimmedPrefix !== firstToken) {
+    return getSubagentExtensionsArgumentCompletions(trimmedPrefix.slice(firstToken.length).trimStart());
+  }
+
+  const prefix = argumentPrefix.trim().toLowerCase();
+  const options = [
+    {
+      value: SUBAGENT_EXTENSIONS_COMMAND,
+      label: SUBAGENT_EXTENSIONS_COMMAND,
+      description: i18n.t("extensionCommandDescription"),
+    },
+    { value: AUTO_MUX_PREFERENCE, label: AUTO_MUX_PREFERENCE, description: i18n.t("muxAuto") },
+    ...SUBAGENT_MUX_BACKENDS.map((backend) => ({
+      value: backend,
+      label: backend,
+      description: i18n.t("muxCommandDescription"),
+    })),
+  ];
+  return options.filter((option) => !prefix || option.value.startsWith(prefix));
+}
+
+/** Complete the dedicated extension command with clear and current paths. */
+function getSubagentExtensionsArgumentCompletions(argumentPrefix: string) {
+  const prefix = argumentPrefix.trim().toLowerCase();
+  const configured = loadSubagentExtensionsConfig().extensions;
+  const options = [
+    {
+      value: SUBAGENT_EXTENSIONS_CLEAR,
+      label: SUBAGENT_EXTENSIONS_CLEAR,
+      description: i18n.t("extensionClearDescription"),
+    },
+    ...configured.map((extension) => ({
+      value: extension,
+      label: extension,
+      description: i18n.t("extensionConfiguredDescription"),
+    })),
+  ];
+  return options.filter((option) => !prefix || option.value.toLowerCase().startsWith(prefix));
+}
+
+/** Edit and persist the explicit extension list used by child sessions. */
+async function editSubagentExtensions(ctx: ExtensionContext): Promise<void> {
+  if (!ctx.hasUI) {
+    ctx.ui.notify(i18n.t("extensionInteractiveOnly"), "warning");
+    return;
+  }
+
+  const current = loadSubagentExtensionsConfig().extensions;
+  const value = await ctx.ui.editor(i18n.t("extensionConfigTitle"), current.join("\n"));
+  if (value === null || value === undefined) return;
+
+  const extensions = value
+    .split(/\r?\n/)
+    .map((extension) => extension.trim())
+    .filter(Boolean);
+  const saved = saveSubagentExtensions(extensions);
+  ctx.ui.notify(
+    i18n.t("extensionSaved", { value: formatSubagentExtensions(saved.extensions) }),
+    "info",
+  );
+}
+
+/** Handle `/config:subagent extensions ...` or the dedicated extension command. */
+async function handleSubagentExtensionsCommand(
+  args: string,
+  ctx: ExtensionContext,
+  hasKeyword: boolean,
+): Promise<boolean> {
+  const requested = args.trim();
+  let extensionArgs = requested;
+
+  if (hasKeyword) {
+    const [keyword] = requested.split(/\s+/, 1);
+    if (keyword?.toLowerCase() !== SUBAGENT_EXTENSIONS_COMMAND) return false;
+    extensionArgs = requested.slice(keyword.length).trim();
+  }
+
+  if (!extensionArgs) {
+    await editSubagentExtensions(ctx);
+    return true;
+  }
+
+  if (extensionArgs.toLowerCase() === SUBAGENT_EXTENSIONS_CLEAR) {
+    const saved = saveSubagentExtensions([]);
+    ctx.ui.notify(
+      i18n.t("extensionSaved", { value: formatSubagentExtensions(saved.extensions) }),
+      "info",
+    );
+    return true;
+  }
+
+  const extensions = parseSubagentExtensionPaths(extensionArgs);
+  if (!extensions) {
+    ctx.ui.notify(i18n.t("extensionInvalid", { value: requested }), "warning");
+    return true;
+  }
+
+  const saved = saveSubagentExtensions(extensions);
+  ctx.ui.notify(
+    i18n.t("extensionSaved", { value: formatSubagentExtensions(saved.extensions) }),
+    "info",
+  );
+  return true;
+}
+
+/** Save mux selection, and optionally its Herdr surface mode. */
 function saveMuxConfigSelection(selection: MuxConfigSelection): MuxConfigSelection {
   const savedMux = saveMuxPreference(selection.preference);
   const savedMode = selection.herdrMode ? saveHerdrMode(selection.herdrMode).herdrMode : undefined;
@@ -1048,8 +1177,10 @@ function saveMuxConfigSelection(selection: MuxConfigSelection): MuxConfigSelecti
 function registerMuxConfigCommand(pi: ExtensionAPI): void {
   const command = {
     description: i18n.t("muxCommandDescription"),
+    getArgumentCompletions: getSubagentConfigArgumentCompletions,
     handler: async (args, ctx) => {
       const requested = args.trim();
+      if (requested && await handleSubagentExtensionsCommand(requested, ctx, true)) return;
       if (requested) {
         const selection = parseMuxConfigRequest(requested);
         if (!selection) {
@@ -1131,6 +1262,17 @@ function registerMuxConfigCommand(pi: ExtensionAPI): void {
   for (const name of ["config:subagent", "subagent-config", "pi-subagent-config"] as const) {
     pi.registerCommand(name, command);
   }
+
+  const extensionsCommand = {
+    description: i18n.t("extensionCommandDescription"),
+    getArgumentCompletions: getSubagentExtensionsArgumentCompletions,
+    handler: async (args: string, ctx: ExtensionContext) => {
+      await handleSubagentExtensionsCommand(args, ctx, false);
+    },
+  };
+  for (const name of SUBAGENT_EXTENSIONS_COMMAND_NAMES) {
+    pi.registerCommand(name, extensionsCommand);
+  }
 }
 
 /** 每次启动或恢复都用新 surface 重建归属，不能继承父进程的改名范围。 */
@@ -1143,6 +1285,9 @@ export const __test__ = {
   buildTerminalRenameEnvironment,
   borderLine,
   parseMuxConfigRequest,
+  parseSubagentExtensionPaths,
+  getSubagentConfigArgumentCompletions,
+  getSubagentExtensionsArgumentCompletions,
   getShellReadyDelayMs,
   renderSubagentWidgetLines,
   loadAgentDefaults,

--- a/packages/pi-interactive-subagents/pi-extension/subagents/mux-config.ts
+++ b/packages/pi-interactive-subagents/pi-extension/subagents/mux-config.ts
@@ -146,6 +146,16 @@ export function loadSubagentExtensionsConfig(path = muxConfigPath()): SubagentEx
   return { extensions: [...DEFAULT_SUBAGENT_EXTENSIONS], source: "default" };
 }
 
+/** Persist the explicit extension list for child sessions. */
+export function saveSubagentExtensions(
+  extensions: readonly string[],
+  path = muxConfigPath(),
+): SubagentExtensionsConfig {
+  const normalized = [...new Set(extensions.map((extension) => extension.trim()).filter(Boolean))];
+  writeConfigObject(path, { ...readConfigObject(path), subagentExtensions: normalized });
+  return { extensions: normalized, source: "file" };
+}
+
 /** Apply persisted mux and Herdr mode settings when no explicit environment override exists. */
 export function applyPersistedMuxPreference(path = muxConfigPath()): void {
   if (!environmentPreference()) {

--- a/packages/pi-interactive-subagents/test/test.ts
+++ b/packages/pi-interactive-subagents/test/test.ts
@@ -63,6 +63,7 @@ import {
   loadSubagentSpawningConfig,
   saveHerdrMode,
   saveMuxPreference,
+  saveSubagentExtensions,
 } from "../pi-extension/subagents/mux-config.ts";
 
 // --- Helpers ---
@@ -852,6 +853,21 @@ describe("subagent mux config", () => {
     });
   });
 
+  it("saves and normalizes explicit child extensions", () => {
+    withTempDir((dir) => {
+      const configPath = join(dir, "config.json");
+      const saved = saveSubagentExtensions([" ~/one.ts ", "two.ts", "~/one.ts"], configPath);
+
+      assert.deepEqual(saved, {
+        extensions: ["~/one.ts", "two.ts"],
+        source: "file",
+      });
+      assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), {
+        subagentExtensions: ["~/one.ts", "two.ts"],
+      });
+    });
+  });
+
   it("saves a preference and makes it effective immediately", () => {
     withTempDir((dir) => {
       const configPath = join(dir, "config.json");
@@ -930,6 +946,7 @@ describe("subagent mux command parsing", () => {
         preference: string;
         herdrMode?: string;
       } | null;
+      parseSubagentExtensionPaths: (value: string) => string[] | null;
     };
   }).__test__;
 
@@ -946,10 +963,18 @@ describe("subagent mux command parsing", () => {
     assert.equal(testApi.parseMuxConfigRequest("tmux tab"), null);
     assert.equal(testApi.parseMuxConfigRequest("herdr tiles"), null);
   });
+
+  it("parses comma-separated extension paths and rejects empty entries", () => {
+    assert.deepEqual(testApi.parseSubagentExtensionPaths("~/one.ts, relative.ts,~/one.ts"), [
+      "~/one.ts",
+      "relative.ts",
+    ]);
+    assert.equal(testApi.parseSubagentExtensionPaths("~/one.ts,,relative.ts"), null);
+  });
 });
 
 describe("subagent discovery", () => {
-  const testApi = (subagentsModule as any).__test__;
+  const testApi = subagentsModule.__test__;
 
   it("loads session-mode from frontmatter", async () => {
     await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {


### PR DESCRIPTION
## 变更
- 支持通过 `/config:subagent extensions` 编辑、保存和清空子 agent 扩展列表
- 新增 `/config:subagent-extensions` 和 `/subagent-extensions` 命令及参数补全
- 增加配置持久化、去重、本地化、文档和测试

## 验证
- `npm run check -w @maplezzk/pi-interactive-subagents`
- 133 个测试全部通过
- `npm pack --dry-run` 通过