### PR TITLE
feat: 通用化终端命名目标解析

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Release PR 合并后按包发布 npm（OIDC trusted publishing，免 token）
+  # 其它独立包并行发布；terminal-mux 与 naming 有明确的发布顺序。
   publish-npm:
     needs: release-please
     if: ${{ github.event_name == 'push' && needs.release-please.outputs.paths_released }}
     runs-on: ubuntu-latest
     strategy:
-      # 单个包发布失败（如缺 trusted publisher / 版本冲突）不连累其它包，各自独立发布
+      # 单个包发布失败（如缺 trusted publisher / 版本冲突）不连累其它独立包。
       fail-fast: false
       matrix:
         include:
@@ -51,7 +51,6 @@ jobs:
           - dir: packages/pi-distill
           - dir: packages/pi-tool-supervisor
           - dir: packages/pi-extensions-tool-display
-          - dir: packages/pi-terminal-mux
           - dir: packages/pi-metrics
           - dir: packages/pi-models-discovery
           - dir: packages/pi-session-tools
@@ -61,7 +60,6 @@ jobs:
           - dir: packages/pi-safety-guards
           - dir: packages/pi-nested-skills
           - dir: packages/pi-notifications
-          - dir: packages/pi-naming
     steps:
       - uses: actions/checkout@v4
 
@@ -86,6 +84,89 @@ jobs:
       - name: Publish to npm
         if: ${{ contains(needs.release-please.outputs.paths_released, matrix.dir) }}
         working-directory: ${{ matrix.dir }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
+            echo "Publishing prerelease version $VERSION with tag 'beta'"
+            npm publish --provenance --tag beta
+          else
+            echo "Publishing stable version $VERSION"
+            npm publish --provenance
+          fi
+
+  # pi-naming imports terminal-mux at runtime. When both changed, wait for mux npm publication.
+  publish-terminal-mux:
+    needs: release-please
+    if: ${{ github.event_name == 'push' && contains(needs.release-please.outputs.paths_released, 'packages/pi-terminal-mux') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Update npm for OIDC support
+        run: |
+          corepack enable npm
+          corepack prepare npm@latest --activate
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        working-directory: packages/pi-terminal-mux
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
+            echo "Publishing prerelease version $VERSION with tag 'beta'"
+            npm publish --provenance --tag beta
+          else
+            echo "Publishing stable version $VERSION"
+            npm publish --provenance
+          fi
+
+  # If mux is not released in this run, an already published compatible mux satisfies naming.
+  # If mux is released, naming is eligible only after its npm publication succeeds.
+  publish-naming:
+    needs: [release-please, publish-terminal-mux]
+    if: ${{ always() && github.event_name == 'push' && contains(needs.release-please.outputs.paths_released, 'packages/pi-naming') && (needs.publish-terminal-mux.result == 'success' || needs.publish-terminal-mux.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Update npm for OIDC support
+        run: |
+          corepack enable npm
+          corepack prepare npm@latest --activate
+          npm --version
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify published terminal-mux dependency
+        working-directory: packages/pi-naming
+        run: |
+          RANGE=$(node -p "require('./package.json').dependencies['pi-terminal-mux']")
+          npm view "pi-terminal-mux@$RANGE" version > /dev/null
+
+      - name: Publish to npm
+        working-directory: packages/pi-naming
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if [[ "$VERSION" =~ -[a-zA-Z] ]]; then
@@ -130,6 +211,13 @@ jobs:
         run: |
           ACTUAL_VERSION=$(node -p "require('./package.json').version")
           test "$ACTUAL_VERSION" = "$EXPECTED_VERSION"
+
+      - name: Verify published terminal-mux dependency for naming retry
+        if: ${{ inputs.package_dir == 'packages/pi-naming' }}
+        working-directory: packages/pi-naming
+        run: |
+          RANGE=$(node -p "require('./package.json').dependencies['pi-terminal-mux']")
+          npm view "pi-terminal-mux@$RANGE" version > /dev/null
 
       - name: Publish to npm
         working-directory: ${{ inputs.package_dir }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       "devDependencies": {
         "@types/node": "24.12.4",
         "tsx": "4.23.1",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22"
@@ -3714,6 +3715,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "scripts": {
     "test": "node scripts/run-workspaces.mjs test",
     "typecheck": "node scripts/run-workspaces.mjs typecheck",
-    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs && node scripts/check-release-order.mjs",
+    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs && node scripts/check-release-order.mjs && npm run test:release-publish-coverage",
     "check:tool-supervisor-ui": "node scripts/check-tool-supervisor-ui-output.mjs",
-    "check:release-order": "node scripts/check-release-order.mjs"
+    "check:release-order": "node scripts/check-release-order.mjs",
+    "test:release-publish-coverage": "node --test scripts/release-publish-coverage.test.mjs"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   "scripts": {
     "test": "node scripts/run-workspaces.mjs test",
     "typecheck": "node scripts/run-workspaces.mjs typecheck",
-    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs",
-    "check:tool-supervisor-ui": "node scripts/check-tool-supervisor-ui-output.mjs"
+    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs && node scripts/check-release-order.mjs",
+    "check:tool-supervisor-ui": "node scripts/check-tool-supervisor-ui-output.mjs",
+    "check:release-order": "node scripts/check-release-order.mjs"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "24.12.4",
     "tsx": "4.23.1",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/pi-naming/README.md
+++ b/packages/pi-naming/README.md
@@ -42,7 +42,7 @@ File: `<pi-agent-dir>/extensions/pi-naming/config.json`; respects `PI_CODING_AGE
 }
 ```
 
-`automaticNaming` and `manualNaming` independently control the automatic input hook and `/rename`. `targets` controls session, workspace and tab separately; all default to enabled. Disable both terminal targets for session-only naming without loading the terminal module.
+`automaticNaming` and `manualNaming` independently control the automatic input hook and `/rename`. `targets` directly controls session, workspace and tab separately; all targets default to enabled. Disable both terminal targets for session-only naming without loading the terminal module.
 
 | Title field | Default | Meaning |
 | --- | --- | --- |
@@ -64,9 +64,9 @@ For longer English titles use `maxLength: 60`, `preferredLength: 40`, `language:
 - tmux/WezTerm/Otty/Orca splits do not prove exclusive window/tab ownership. Unverified targets are skipped with an explanation rather than expanding the operation's scope.
 - With `pi-interactive-subagents`, explicitly include this package's entrypoint in `subagentExtensions`. Installing it in the parent does not bypass child extension isolation.
 
-Ordinary sessions use the configured terminal-mux defaults. The following terminal-mux variables remain only as compatibility inputs for older launchers: `PI_SUBAGENT_RENAME_TMUX_WINDOW=1`, `PI_SUBAGENT_RENAME_TMUX_SESSION=1`, `PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`. Missing target IDs never fall back to current focus or the first tab. Actual targets can be panes, tabs, windows, workspaces or sessions and are reported in results.
+Ordinary sessions request every enabled target with an explicit ID, including supported tmux and Herdr targets. This target-resolution path deliberately ignores the legacy `PI_SUBAGENT_RENAME_TMUX_WINDOW`, `PI_SUBAGENT_RENAME_TMUX_SESSION` and `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` switches; those variables remain only for terminal-mux's older public rename APIs. A disabled `targets` entry does not run even if an environment variable is set. Missing IDs never fall back to current focus or the first tab.
 
-Before publication, align the terminal-mux dependency minimum with a published version providing the target ownership API.
+`pi-naming` requires a `pi-terminal-mux` release that exports `resolveTerminalRenameTargets` and `renameTerminalTarget`. Release-please must release terminal-mux first; its generated pi-naming release PR then updates the minimum dependency range. Do not manually publish or preemptively raise the range to an unpublished version.
 
 ## Validation
 

--- a/packages/pi-naming/README.md
+++ b/packages/pi-naming/README.md
@@ -66,7 +66,7 @@ For longer English titles use `maxLength: 60`, `preferredLength: 40`, `language:
 
 Ordinary sessions request every enabled target with an explicit ID, including supported tmux and Herdr targets. This target-resolution path deliberately ignores the legacy `PI_SUBAGENT_RENAME_TMUX_WINDOW`, `PI_SUBAGENT_RENAME_TMUX_SESSION` and `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` switches; those variables remain only for terminal-mux's older public rename APIs. A disabled `targets` entry does not run even if an environment variable is set. Missing IDs never fall back to current focus or the first tab.
 
-`pi-naming` requires a `pi-terminal-mux` release that exports `resolveTerminalRenameTargets` and `renameTerminalTarget`. Release-please must release terminal-mux first; its generated pi-naming release PR then updates the minimum dependency range. Do not manually publish or preemptively raise the range to an unpublished version.
+`pi-naming` requires a published `pi-terminal-mux` version that exports `resolveTerminalRenameTargets` and `renameTerminalTarget`. Release-please updates workspace dependency ranges in release PRs. When one release publishes both packages, CI publishes terminal-mux first and publishes naming only after that npm publication succeeds; a naming-only release uses the already published compatible mux. Do not manually publish or preemptively raise the range to an unpublished version.
 
 ## Validation
 

--- a/packages/pi-naming/README.zh-CN.md
+++ b/packages/pi-naming/README.zh-CN.md
@@ -42,7 +42,7 @@ pi install npm:pi-naming
 }
 ```
 
-`automaticNaming` 和 `manualNaming` 独立控制自动入口和 `/rename` 命令。`targets` 分别控制 session、workspace、tab；全部默认开启。仅需 session 命名时关闭两个终端目标，此时不加载终端模块。
+`automaticNaming` 和 `manualNaming` 独立控制自动入口和 `/rename` 命令。`targets` 直接分别控制 session、workspace、tab，三个目标默认开启。仅需 session 命名时关闭两个终端目标，此时不加载终端模块。
 
 | 标题字段 | 默认值 | 含义 |
 | --- | --- | --- |
@@ -64,9 +64,9 @@ pi install npm:pi-naming
 - tmux/WezTerm/Otty/Orca 分屏不代表独占 window/tab，归属无法确认时跳过并说明原因，不扩大操作范围。
 - 使用 `pi-interactive-subagents` 时，需在它的 `subagentExtensions` 中显式加载本包入口；仅在主会话安装本包不会绕过子代理的扩展隔离设置。
 
-普通会话使用配置文件中的 mux 默认值。以下终端变量仅作为旧版启动器的兼容输入保留：`PI_SUBAGENT_RENAME_TMUX_WINDOW=1`、`PI_SUBAGENT_RENAME_TMUX_SESSION=1`、`PI_SUBAGENT_RENAME_HERDR_WORKSPACE=1`。终端目标缺少 ID 时不会使用当前焦点或第一个 tab 代替。实际目标可能是 pane、tab、window、workspace 或 session，结果中会说明。
+普通会话会请求每个启用且具备明确 ID 的目标，包括受支持的 tmux 和 Herdr 目标。此目标解析路径刻意忽略旧变量 `PI_SUBAGENT_RENAME_TMUX_WINDOW`、`PI_SUBAGENT_RENAME_TMUX_SESSION`、`PI_SUBAGENT_RENAME_HERDR_WORKSPACE`；它们仅保留给 terminal-mux 的旧公开改名接口。即使环境变量为 `1`，关闭的 `targets` 也绝不执行。终端目标缺少 ID 时不会使用当前焦点或第一个 tab 代替。实际目标可能是 pane、tab、window、workspace 或 session，结果中会说明。
 
-发布前，terminal-mux 依赖下限必须对齐实际提供目标归属 API 的已发布版本。
+`pi-naming` 依赖已发布且导出 `resolveTerminalRenameTargets`、`renameTerminalTarget` 的 `pi-terminal-mux` 版本。必须先由 release-please 发布 terminal-mux，再由其生成的 pi-naming Release PR 更新最低依赖范围；不手动发布，也不预先把范围改成未发布版本。
 
 ## 验证
 

--- a/packages/pi-naming/README.zh-CN.md
+++ b/packages/pi-naming/README.zh-CN.md
@@ -66,7 +66,7 @@ pi install npm:pi-naming
 
 普通会话会请求每个启用且具备明确 ID 的目标，包括受支持的 tmux 和 Herdr 目标。此目标解析路径刻意忽略旧变量 `PI_SUBAGENT_RENAME_TMUX_WINDOW`、`PI_SUBAGENT_RENAME_TMUX_SESSION`、`PI_SUBAGENT_RENAME_HERDR_WORKSPACE`；它们仅保留给 terminal-mux 的旧公开改名接口。即使环境变量为 `1`，关闭的 `targets` 也绝不执行。终端目标缺少 ID 时不会使用当前焦点或第一个 tab 代替。实际目标可能是 pane、tab、window、workspace 或 session，结果中会说明。
 
-`pi-naming` 依赖已发布且导出 `resolveTerminalRenameTargets`、`renameTerminalTarget` 的 `pi-terminal-mux` 版本。必须先由 release-please 发布 terminal-mux，再由其生成的 pi-naming Release PR 更新最低依赖范围；不手动发布，也不预先把范围改成未发布版本。
+`pi-naming` 依赖已发布且导出 `resolveTerminalRenameTargets`、`renameTerminalTarget` 的 `pi-terminal-mux` 版本。release-please 会在 Release PR 中更新 workspace 依赖范围；同一次发布同时包含两包时，CI 先发布 terminal-mux，只有其 npm 发布成功后才发布 naming；仅发布 naming 时使用已发布的兼容 mux。不手动发布，也不预先把范围改成未发布版本。
 
 ## 验证
 

--- a/packages/pi-naming/SKILL.md
+++ b/packages/pi-naming/SKILL.md
@@ -9,9 +9,9 @@ description: 配置 Pi 统一 /rename、首条消息命名和终端目标归属�
 
 Use `/config:naming` to open the normal TUI settings menu; use `reset` for defaults and reload after saving.
 
-- `automaticNaming` / `manualNaming` 控制自动输入和 `/rename [名称]`，`targets` 分别控制 session/workspace/tab。Control automatic input and `/rename [name]`; `targets` selects session/workspace/tab.
+- `automaticNaming` / `manualNaming` 控制自动输入和 `/rename [名称]`，`targets` 直接分别控制 session/workspace/tab。Control automatic input and `/rename [name]`; `targets` directly selects session/workspace/tab.
 - `title` 控制长度、语言、补充提示和超时；模型鉴权复用 Pi。Controls length, language, instructions and timeout; model authentication comes from Pi.
-- 无终端也可命名 session；终端失败与跳过必须报告。Session naming works without a terminal; report terminal failures and skips.
+- 无终端也可命名 session；终端失败与跳过必须报告。普通会话明确目标路径不受旧 `PI_SUBAGENT_RENAME_*` 变量影响；关闭 target 即使变量为 `1` 也不执行。Session naming works without a terminal; report terminal failures and skips. The ordinary-session explicit-target path ignores legacy `PI_SUBAGENT_RENAME_*` variables; a disabled target never runs even when a variable is `1`.
 - 子进程归属由启动方通过 mux 协议提供，不把 pane 扩大为共享 tab，不修改父 workspace。Launchers grant child targets through the mux protocol; never expand a pane to a shared tab or rename the parent workspace.
 - 子代理需要显式配置 `subagentExtensions` 加载 naming。Child extension isolation requires explicitly loading naming in `subagentExtensions`.
 

--- a/packages/pi-naming/src/index.ts
+++ b/packages/pi-naming/src/index.ts
@@ -48,8 +48,17 @@ function report(pi: ExtensionAPI, ctx: ExtensionContext, notice: { message: stri
   else pi.sendMessage({ customType: MESSAGE_TYPE, content: message, display: true }, { triggerTurn: false });
 }
 
+export interface NamingConfigStore {
+  load(): NamingConfig;
+  save(config: NamingConfig): void;
+  path(): string;
+}
+
 /** 注册配置命令，通过 TUI 菜单和输入框修改命名配置。 */
-function registerNamingConfigCommand(pi: ExtensionAPI): void {
+export function registerNamingConfigCommand(
+  pi: ExtensionAPI,
+  store: NamingConfigStore = { load: loadConfig, save: saveConfig, path: configPath },
+): void {
   const command = {
     description: i18n.t("configCommandDescription"),
     getArgumentCompletions: () => [{ value: CONFIG_RESET_COMMAND, label: CONFIG_RESET_COMMAND }],
@@ -61,9 +70,9 @@ function registerNamingConfigCommand(pi: ExtensionAPI): void {
       }
       if (argument === CONFIG_RESET_COMMAND) {
         try {
-          saveConfig(parseConfig({}));
+          store.save(parseConfig({}));
           report(pi, ctx, {
-            message: i18n.t("configCommandSaved", { path: configPath() }),
+            message: i18n.t("configCommandSaved", { path: store.path() }),
             level: "info",
           });
         } catch (error) {
@@ -78,7 +87,7 @@ function registerNamingConfigCommand(pi: ExtensionAPI): void {
 
       let config: NamingConfig;
       try {
-        config = loadConfig();
+        config = store.load();
       } catch (error) {
         report(pi, ctx, { message: i18n.t("configCommandInvalid", { error: errorMessage(error) }), level: "error" });
         return;
@@ -87,9 +96,9 @@ function registerNamingConfigCommand(pi: ExtensionAPI): void {
       /** Saves one validated menu change and reports its result. */
       const save = (next: NamingConfig): boolean => {
         try {
-          saveConfig(next);
+          store.save(next);
           config = next;
-          report(pi, ctx, { message: i18n.t("configCommandSaved", { path: configPath() }), level: "info" });
+          report(pi, ctx, { message: i18n.t("configCommandSaved", { path: store.path() }), level: "info" });
           return true;
         } catch (error) {
           report(pi, ctx, { message: i18n.t("configCommandInvalid", { error: errorMessage(error) }), level: "error" });

--- a/packages/pi-naming/tests/config.test.ts
+++ b/packages/pi-naming/tests/config.test.ts
@@ -32,7 +32,7 @@ test("标题偏好可配置，未知字段与非法值明确拒绝", () => {
   const title = { maxLength: 60, preferredLength: 40, language: "en", instructions: "Use sentence case", timeoutMs: 20000 };
   assert.deepEqual(parseConfig({ title }).title, title);
   for (const value of [null, [],
-    { unknown: true }, { targets: null }, { targets: { unknown: true } }, { targets: { session: "false" } },
+    { unknown: true }, { allowWorkspaceRename: false }, { targets: null }, { targets: { unknown: true } }, { targets: { session: "false" } },
     { title: null }, { title: { typo: 1 } }, { title: { maxLength: 0 } },
     { title: { maxLength: 1.5 } }, { title: { preferredLength: 16 } },
     { title: { timeoutMs: -1 } }, { title: { timeoutMs: 2147483648 } },

--- a/packages/pi-naming/tests/rename.test.ts
+++ b/packages/pi-naming/tests/rename.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { createSurfaceRenameContext, resolveTerminalRenameTargets, TERMINAL_RENAME_CONTEXT_ENV, type TerminalRenameTarget } from "pi-terminal-mux";
 import { parseConfig } from "../src/config.ts";
-import { registerNaming, type TerminalNamingAdapter } from "../src/index.ts";
+import { registerNaming, registerNamingConfigCommand, type TerminalNamingAdapter } from "../src/index.ts";
 import type { SessionNameRequest } from "../src/session-name.ts";
 
 type Input = { text?: string; source?: string };
@@ -48,6 +48,55 @@ test("只注册 /rename，显式名称同步三个目标且不调用模型", asy
   await h.commands.get("rename")!.handler(label, h.ctx);
   assert.equal(h.name(), label);
   assert.deepEqual(h.renamed.map(([, title]) => title), [label, label]);
+});
+
+test("命名仅按 targets 请求明确终端目标，不转换后端环境变量", async () => {
+  const h = harness();
+  let options: Parameters<TerminalNamingAdapter["resolve"]>[0] | undefined;
+  h.terminal.resolve = (value) => { options = value; return []; };
+  await registerNaming(h.pi, parseConfig({ targets: { session: false, workspace: true, tab: false } }), { loadTerminal: async () => h.terminal });
+  await h.commands.get("rename")!.handler("Workspace title", h.ctx);
+  assert.deepEqual(options, { tab: false, workspace: true });
+});
+
+test("配置菜单保存 targets 后，reload 的自动与手动入口只作用于保存的目标", async () => {
+  const menu = harness();
+  let saved = parseConfig({});
+  let selectedTarget = false;
+  Object.assign(menu.ctx.ui, {
+    select: async (_title: string, choices: string[]) => {
+      if (!selectedTarget) {
+        selectedTarget = true;
+        return choices.find((choice) => /session|会话/.test(choice));
+      }
+      return choices.at(-1);
+    },
+    input: async () => assert.fail("unexpected config input"),
+  });
+  registerNamingConfigCommand(menu.pi, {
+    load: () => saved,
+    save: (config) => { saved = config; },
+    path: () => "/configured/pi-naming.json",
+  });
+  await menu.commands.get("config:naming")!.handler("", menu.ctx);
+  assert.equal(saved.targets.session, false);
+
+  const manual = harness();
+  await registerNaming(manual.pi, saved, { loadTerminal: async () => manual.terminal });
+  await manual.commands.get("rename")!.handler("Saved target", manual.ctx);
+  assert.equal(manual.name(), undefined);
+  assert.deepEqual(manual.renamed.map(([reference]) => reference.operation), ["workspace", "tab"]);
+
+  const reloaded = harness();
+  await registerNaming(reloaded.pi, parseConfig({ automaticNaming: true, manualNaming: false, targets: { workspace: false, tab: false } }), {
+    loadTerminal: async () => assert.fail("terminal must not load after reload"),
+    requestName: async () => "Automatic session",
+  });
+  reloaded.events.get("session_start")!({}, reloaded.ctx);
+  reloaded.events.get("input")!({ text: "Task", source: "interactive" }, reloaded.ctx);
+  await flush();
+  assert.equal(reloaded.name(), "Automatic session");
+  assert.equal(reloaded.renamed.length, 0);
 });
 
 test("首条真实输入和手动生成使用相同目标、标题配置", async () => {
@@ -149,7 +198,7 @@ test("没有终端、加载失败或协议损坏仍能改 session，并报告原
   }
 });
 
-for (const backend of ["cmux", "tmux"] as const) {
+for (const backend of ["cmux", "tmux", "herdr"] as const) {
   test(`${backend} 组合子代理只修改获授目标，绝不改 workspace`, async () => {
     const h = harness();
     const context = createSurfaceRenameContext("child", backend);
@@ -159,7 +208,7 @@ for (const backend of ["cmux", "tmux"] as const) {
     await h.commands.get("rename")!.handler("Child", h.ctx);
     assert.equal(h.name(), "Child");
     assert.ok(h.renamed.every(([target]) => target.operation !== "workspace" && target.id === "child"));
-    assert.equal(h.renamed.length, backend === "cmux" ? 1 : 0);
+    assert.equal(h.renamed.length, backend === "cmux" || backend === "herdr" ? 1 : 0);
     assert.ok(h.notices.some((message) => /共享|shared/.test(message)));
   });
 }

--- a/packages/pi-terminal-mux/README.md
+++ b/packages/pi-terminal-mux/README.md
@@ -94,7 +94,7 @@ export PI_SUBAGENT_HERDR_MODE=tab
 | `pollForExit(surface, signal, opts)` | Wait for the process in a surface to exit: `.exit` sidecar file first, then a screen sentinel (`__SUBAGENT_DONE_<code>__`); headless uses child process exit |
 | `getLastSplitSource()` / `clearLastSplitSource()` | Source pane of the most recent split (for UI display) |
 
-Rename targets differ by backend: muxy/zellij tab rename targets a pane; tmux targets a window/session when its opt-in variables are enabled; WezTerm workspace rename targets the window; cmux and Herdr provide native workspace rename; Otty and Orca have no workspace rename. Headless reports `unsupported` instead of silently succeeding.
+Rename targets differ by backend: muxy/zellij tab rename targets a pane; tmux targets a window/session; WezTerm workspace rename targets the window; cmux and Herdr provide native workspace rename; Otty and Orca have no workspace rename. `resolveTerminalRenameTargets` is the explicit-ID path and ignores legacy opt-in variables; `getRenameCapability`, `renameCurrentTab` and `renameWorkspace` retain their legacy opt-in behavior. Headless reports `unsupported` instead of silently succeeding.
 
 ### Detection and utilities
 
@@ -124,9 +124,9 @@ These are opt-in capabilities — existing Bash callers and `pi-interactive-suba
 |----------|-------------|
 | `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` | Force a backend |
 | `PI_SUBAGENT_ZELLIJ_MIN_COLUMNS` / `PI_SUBAGENT_ZELLIJ_MIN_ROWS` | Minimum usable size for zellij splits (default 50x10; stacks instead when smaller) |
-| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | Allow renameCurrentTab / renameWorkspace on tmux (user naming untouched by default) |
+| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | Compatibility switches for legacy `getRenameCapability` / `renameCurrentTab` / `renameWorkspace` on tmux; ignored by explicit target resolution |
 | `PI_SUBAGENT_HERDR_MODE` | Herdr surface placement: `split` (default) or `tab` |
-| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | Allow renameWorkspace on herdr |
+| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | Compatibility switch for legacy `getRenameCapability` / `renameWorkspace` on herdr; ignored by explicit target resolution |
 | `PI_EXTENSIONS_LOCALE` | Hint language (`zh-CN` / `en-US` / `auto`), provided by pi-extensions-i18n |
 
 ## Design constraints
@@ -146,6 +146,6 @@ MIT
 
 `resolveTerminalRenameTargets({ tab, workspace })` returns explicit target IDs and `surface`/`shared` scope, or individual skipped/failed results. `renameTerminalTarget(reference, title)` executes against that captured identity. Callers decide when to rename and which targets to request; the library does not generate titles or change Pi sessions.
 
-A restricted child never renames a workspace. cmux surfaces, muxy/zellij panes, and Herdr panes or explicitly created Herdr tabs can be granted. tmux/WezTerm/Otty/Orca split surfaces do not prove exclusive ownership of their window/tab: naming is skipped rather than expanded to the shared parent. Ordinary sessions require their own target IDs; missing IDs never fall back to focus or the first tab. Existing backend rename opt-ins still apply to ordinary sessions.
+A restricted child never renames a workspace. cmux surfaces, muxy/zellij panes, and Herdr panes or explicitly created Herdr tabs can be granted. tmux/WezTerm/Otty/Orca split surfaces do not prove exclusive ownership of their window/tab: naming is skipped rather than expanded to the shared parent. Ordinary sessions require their own target IDs; missing IDs never fall back to focus or the first tab. Explicit target resolution uses backend capability directly, independent of legacy rename opt-ins.
 
 Invalid JSON or an unknown protocol version is an error, not unrestricted access. Legacy child identity variables without this protocol restrict terminal naming until the launcher supplies ownership. This is a cooperation contract for trusted local processes, not a security sandbox. WezTerm/Otty split creation does not rename a shared tab.

--- a/packages/pi-terminal-mux/README.zh-CN.md
+++ b/packages/pi-terminal-mux/README.zh-CN.md
@@ -93,7 +93,7 @@ export PI_SUBAGENT_HERDR_MODE=tab
 | `pollForExit(surface, signal, opts)` | 等待 surface 内进程退出：优先 `.exit` sidecar 文件，其次屏幕 sentinel（`__SUBAGENT_DONE_<code>__`），headless 走子进程 exit |
 | `getLastSplitSource()` / `clearLastSplitSource()` | 最近一次分屏的来源 pane（用于 UI 展示） |
 
-各后端的实际目标不同：muxy/zellij 的 tab 重命名作用于 pane；tmux 在开启对应变量后作用于 window/session；WezTerm 的 workspace 重命名作用于 window；cmux 和 Herdr 提供原生 workspace 重命名；Otty、Orca 没有 workspace 重命名。Headless 会明确返回 `unsupported`，不再静默成功。
+各后端的实际目标不同：muxy/zellij 的 tab 重命名作用于 pane；tmux 作用于 window/session；WezTerm 的 workspace 重命名作用于 window；cmux 和 Herdr 提供原生 workspace 重命名；Otty、Orca 没有 workspace 重命名。`resolveTerminalRenameTargets` 是明确 ID 路径，忽略旧环境开关；`getRenameCapability`、`renameCurrentTab`、`renameWorkspace` 保持旧开关行为。Headless 会明确返回 `unsupported`，不再静默成功。
 
 ### 探测与工具
 
@@ -123,9 +123,9 @@ export PI_SUBAGENT_HERDR_MODE=tab
 |------|------|
 | `PI_TERMINAL_MUX` / `PI_SUBAGENT_MUX` | 强制指定后端 |
 | `PI_SUBAGENT_ZELLIJ_MIN_COLUMNS` / `PI_SUBAGENT_ZELLIJ_MIN_ROWS` | zellij 分屏最小可用尺寸（默认 50×10，不满足时改堆叠） |
-| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | tmux 下允许 renameCurrentTab / renameWorkspace（默认不动用户命名） |
+| `PI_SUBAGENT_RENAME_TMUX_WINDOW` / `PI_SUBAGENT_RENAME_TMUX_SESSION` | tmux 下旧 `getRenameCapability` / `renameCurrentTab` / `renameWorkspace` 的兼容开关；明确目标解析忽略 |
 | `PI_SUBAGENT_HERDR_MODE` | herdr surface 放置模式：`split`（默认）或 `tab` |
-| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | herdr 下允许 renameWorkspace |
+| `PI_SUBAGENT_RENAME_HERDR_WORKSPACE` | herdr 下旧 `getRenameCapability` / `renameWorkspace` 的兼容开关；明确目标解析忽略 |
 | `PI_EXTENSIONS_LOCALE` | 提示文案语言（`zh-CN` / `en-US` / `auto`），由 pi-extensions-i18n 提供 |
 
 ## 设计约束
@@ -145,6 +145,6 @@ MIT
 
 `resolveTerminalRenameTargets({ tab, workspace })` 返回明确的目标 ID、`surface`/`shared` 范围，或逐目标跳过/失败结果。`renameTerminalTarget(reference, title)` 对捕获的身份执行改名。调用方决定何时改、改哪些目标；库不生成标题，也不修改 Pi session。
 
-受限子进程不能改 workspace。cmux surface、muxy/zellij pane、Herdr pane 或明确新建的 Herdr tab 可以授予。tmux/WezTerm/Otty/Orca 的分屏不能证明独占 window/tab，改名会跳过，不扩大到共享父目标。普通会话必须能确定自身目标 ID；缺失时不退回当前焦点或第一个 tab。普通会话仍遵守各后端原有的改名开关。
+受限子进程不能改 workspace。cmux surface、muxy/zellij pane、Herdr pane 或明确新建的 Herdr tab 可以授予。tmux/WezTerm/Otty/Orca 的分屏不能证明独占 window/tab，改名会跳过，不扩大到共享父目标。普通会话必须能确定自身目标 ID；缺失时不退回当前焦点或第一个 tab。明确目标解析直接使用后端能力，独立于旧改名开关。
 
 协议 JSON 损坏或版本未知会报错，不能退回无限制范围。只有旧子代理身份标志、没有归属协议时，终端改名受限，直到启动方提供归属。此协议用于可信本地进程协作，不是安全沙箱。WezTerm/Otty 创建分屏时不会重命名共享 tab。

--- a/packages/pi-terminal-mux/src/rename.ts
+++ b/packages/pi-terminal-mux/src/rename.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { getMuxBackend, type MuxBackend } from "./detection.ts";
-import { getRenameCapability, type RenameOperation, type RenameTarget } from "./surface.ts";
+import { type RenameOperation, type RenameTarget } from "./surface.ts";
 import { getCreatedHerdrTabId } from "./backends/herdr.ts";
 import { AGENT_OTTY_PANE_ID, getTabIdForPane } from "./backends/otty.ts";
 import { renameOrcaTerminal } from "./backends/orca.ts";
@@ -108,6 +108,25 @@ export interface ResolveRenameOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+/** 新的明确目标路径只判断后端能力；旧公开 API 的环境开关不参与这里。 */
+function explicitRenameCapability(
+  operation: RenameOperation,
+  backend: MuxBackend | null,
+): { backend: MuxBackend; target: RenameTarget } | undefined {
+  if (!backend) return undefined;
+  if (operation === "tab") {
+    const target: Record<MuxBackend, RenameTarget> = {
+      muxy: "pane", cmux: "tab", tmux: "window", zellij: "pane", wezterm: "tab",
+      herdr: "tab", otty: "tab", orca: "terminal",
+    };
+    return { backend, target: target[backend] };
+  }
+  const target: Partial<Record<MuxBackend, RenameTarget>> = {
+    cmux: "workspace", tmux: "session", wezterm: "window", herdr: "workspace",
+  };
+  return target[backend] ? { backend, target: target[backend] } : undefined;
+}
+
 /** 返回当前进程的明确目标 ID，不以当前焦点或第一个 tab 代替未知身份。 */
 function currentTargetId(reference: { backend: MuxBackend; operation: RenameOperation; env: NodeJS.ProcessEnv }, query: RenameIdQuery): string | undefined {
   const { backend, operation, env } = reference;
@@ -154,16 +173,15 @@ export function resolveTerminalRenameTargets(options: ResolveRenameOptions, quer
       }
       continue;
     }
-    const capability = getRenameCapability(operation, backend, env);
-    if (capability.status !== "supported") {
-      outcomes.push({ status: "skipped", operation, reason: capability.status,
-        ...(capability.status === "disabled" ? { setting: capability.setting } : {}) });
+    const capability = explicitRenameCapability(operation, backend);
+    if (!capability) {
+      outcomes.push({ status: "skipped", operation, reason: "unsupported" });
       continue;
     }
     try {
       const id = currentTargetId({ backend: capability.backend, operation, env }, query);
       outcomes.push(id?.trim() ? { status: "ready", reference: {
-        backend: capability.backend, operation, target: capability.backend === "orca" ? "tab" : capability.target, id,
+        backend: capability.backend, operation, target: capability.target, id,
         scope: operation === "workspace" || ["tmux", "wezterm", "herdr", "otty", "orca"].includes(capability.backend) ? "shared" : "surface",
       } } : { status: "skipped", operation, reason: "missing-id" });
     } catch (error) {

--- a/packages/pi-terminal-mux/tests/rename-context.test.ts
+++ b/packages/pi-terminal-mux/tests/rename-context.test.ts
@@ -21,6 +21,27 @@ test("普通会话解析自己的 workspace 和 tab ID，不使用焦点", () =>
   ]);
 });
 
+test("明确目标解析忽略旧环境开关，但关闭目标绝不产生结果", () => {
+  for (const value of [undefined, "0", "1"]) {
+    const env = {
+      TMUX_PANE: "%own",
+      HERDR_TAB_ID: "tab:own",
+      HERDR_WORKSPACE_ID: "workspace:own",
+      PI_SUBAGENT_RENAME_TMUX_WINDOW: value,
+      PI_SUBAGENT_RENAME_TMUX_SESSION: value,
+      PI_SUBAGENT_RENAME_HERDR_WORKSPACE: value,
+    };
+    const tmux = resolveTerminalRenameTargets({ tab: true, workspace: true, backend: "tmux", env },
+      (_command, args) => args.at(-1) === "#{window_id}" ? "@own" : "$own");
+    assert.deepEqual(tmux.map((result) => result.status === "ready" && result.reference.id), ["$own", "@own"]);
+    const herdr = resolveTerminalRenameTargets({ tab: true, workspace: true, backend: "herdr", env });
+    assert.deepEqual(herdr.map((result) => result.status === "ready" && result.reference.id), ["workspace:own", "tab:own"]);
+  }
+  assert.deepEqual(resolveTerminalRenameTargets({ tab: false, workspace: false, backend: "tmux", env: {
+    TMUX_PANE: "%own", PI_SUBAGENT_RENAME_TMUX_WINDOW: "1", PI_SUBAGENT_RENAME_TMUX_SESSION: "1",
+  } }), []);
+});
+
 for (const backend of ["tmux", "wezterm", "otty", "orca"] as MuxBackend[]) {
   test(`${backend} 子 pane 不授予共享 tab/window 改名权`, () => {
     const context = createSurfaceRenameContext("child-surface", backend);
@@ -80,14 +101,31 @@ test("精确目标使用 argv 传递名称，失败逐目标返回", () => {
   assert.equal(calls.length, 1);
 });
 
-test("Herdr 直接命名指定 pane/tab，不增加 workspace 前缀", () => {
-  const calls: string[][] = [];
-  for (const target of ["pane", "tab"] as const) {
-    renameTerminalTarget({ backend: "herdr", operation: "tab", target, id: "child", scope: "surface" }, "Task", {
-      run: (_command, args) => { calls.push(args); }, renameOrca: () => true,
-    });
+test("所有后端都按已捕获的 ID 执行各自的明确改名命令", () => {
+  const calls: Array<[string, string[]]> = [];
+  const run = (command: string, args: string[]) => { calls.push([command, args]); };
+  const title = "Task";
+  const references: TerminalRenameTarget[] = [
+    { backend: "cmux", operation: "tab", target: "tab", id: "cmux-tab", scope: "surface" },
+    { backend: "muxy", operation: "tab", target: "pane", id: "muxy-pane", scope: "surface" },
+    { backend: "tmux", operation: "workspace", target: "session", id: "tmux-session", scope: "shared" },
+    { backend: "zellij", operation: "tab", target: "pane", id: "zellij-pane", scope: "surface" },
+    { backend: "wezterm", operation: "workspace", target: "window", id: "wezterm-pane", scope: "shared" },
+    { backend: "herdr", operation: "tab", target: "pane", id: "herdr-pane", scope: "surface" },
+    { backend: "otty", operation: "tab", target: "tab", id: "otty-tab", scope: "shared" },
+  ];
+  for (const reference of references) {
+    assert.equal(renameTerminalTarget(reference, title, { run, renameOrca: () => true }).status, "renamed");
   }
-  assert.deepEqual(calls, [["pane", "rename", "child", "Task"], ["tab", "rename", "child", "Task"]]);
+  assert.deepEqual(calls, [
+    ["cmux", ["rename-tab", "--surface", "cmux-tab", title]],
+    ["muxy", ["rename-pane", "--pane", "muxy-pane", title]],
+    ["tmux", ["rename-session", "-t", "tmux-session", title]],
+    ["zellij", ["action", "rename-pane", title, "--pane-id", "zellij-pane"]],
+    ["wezterm", ["cli", "set-window-title", "--pane-id", "wezterm-pane", title]],
+    ["herdr", ["pane", "rename", "herdr-pane", title]],
+    ["otty", ["tab", "rename", "--tab", "otty-tab", title]],
+  ]);
 });
 
 test("Orca 失败由注入的后端报告，不触碰本机服务", () => {

--- a/scripts/check-package-config.mjs
+++ b/scripts/check-package-config.mjs
@@ -6,7 +6,7 @@
  *
  * Checks:
  * 1. release-please-config.json paths exist on disk
- * 2. release.yml publish matrix covers all release-please packages
+ * 2. release.yml publish jobs cover all release-please packages
  * 3. Each package has required files (package.json, index.ts, README.md, README.zh-CN.md, tsconfig.json)
  * 4. package.json has required fields (name, version, description, main, exports, files, license)
  * 5. i18n catalogs have both zh-CN and en-US for every key
@@ -17,6 +17,7 @@
 
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { collectPublishedPackageDirectories } from "./release-publish-coverage.mjs";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const PACKAGES_DIR = join(ROOT, "packages");
@@ -101,28 +102,27 @@ if (!existsSync(rpConfigPath)) {
   }
 
   // ---------------------------------------------------------------------------
-  // 2. release.yml publish matrix covers all release-please packages
+  // 2. release.yml publish jobs cover all release-please packages
   // ---------------------------------------------------------------------------
   const releaseYmlPath = join(ROOT, ".github/workflows/release.yml");
   if (!existsSync(releaseYmlPath)) {
     error(".github/workflows/release.yml not found");
   } else {
     const releaseContent = readFileSync(releaseYmlPath, "utf8");
-    // Extract "- dir: packages/xxx" entries from the publish-npm matrix
-    const matrixDirs = [...releaseContent.matchAll(/-\s*dir:\s*(packages\/[\w-]+)/g)].map((m) => m[1]);
+    const publishedDirectories = collectPublishedPackageDirectories(releaseContent);
 
-    if (matrixDirs.length === 0) {
-      error("release.yml: no '- dir: packages/...' entries found in publish matrix");
+    if (publishedDirectories.length === 0) {
+      error("release.yml: no package publish working directory found");
     } else {
       for (const pkgPath of rpPackages) {
-        if (!matrixDirs.includes(pkgPath)) {
-          error(`release.yml publish matrix is missing "${pkgPath}" (present in release-please-config.json)`);
+        if (!publishedDirectories.includes(pkgPath)) {
+          error(`release.yml publish jobs are missing "${pkgPath}" (present in release-please-config.json)`);
         }
       }
 
-      for (const dir of matrixDirs) {
+      for (const dir of publishedDirectories) {
         if (!rpPackages.includes(dir)) {
-          warn(`release.yml publish matrix has "${dir}" which is not in release-please-config.json`);
+          warn(`release.yml publish jobs include "${dir}" which is not in release-please-config.json`);
         }
       }
     }

--- a/scripts/check-release-order.mjs
+++ b/scripts/check-release-order.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+const packageDirectory = "packages/pi-terminal-mux";
+const namingDirectory = "packages/pi-naming";
+
+assert.match(workflow, /publish-terminal-mux:\n    needs: release-please\n    if: \$\{\{ github\.event_name == 'push' && contains\(needs\.release-please\.outputs\.paths_released, 'packages\/pi-terminal-mux'\) \}\}/);
+assert.match(workflow, /publish-naming:\n    needs: \[release-please, publish-terminal-mux\]\n    if: \$\{\{ always\(\) && github\.event_name == 'push' && contains\(needs\.release-please\.outputs\.paths_released, 'packages\/pi-naming'\) && \(needs\.publish-terminal-mux\.result == 'success' \|\| needs\.publish-terminal-mux\.result == 'skipped'\) \}\}/);
+
+const independentPublish = workflow.match(/publish-npm:\n[\s\S]*?\n  publish-terminal-mux:/)?.[0];
+assert.ok(independentPublish, "missing independent package publish job");
+assert.ok(!independentPublish.includes(packageDirectory), "terminal-mux must not publish in parallel with naming");
+assert.ok(!independentPublish.includes(namingDirectory), "naming must wait for terminal-mux");
+assert.match(workflow, /Verify published terminal-mux dependency\n        working-directory: packages\/pi-naming\n        run: \|\n          RANGE=\$\(node -p "require\('\.\/package\.json'\)\.dependencies\['pi-terminal-mux'\]\"\)\n          npm view "pi-terminal-mux@\$RANGE" version > \/dev\/null/);
+assert.match(workflow, /Verify published terminal-mux dependency for naming retry\n        if: \$\{\{ inputs\.package_dir == 'packages\/pi-naming' \}\}/);
+
+console.log("Release order check passed: terminal-mux publishes before pi-naming when both release.");

--- a/scripts/release-publish-coverage.mjs
+++ b/scripts/release-publish-coverage.mjs
@@ -1,0 +1,6 @@
+/** Extract package directories published by matrix or dedicated release workflow jobs. */
+export function collectPublishedPackageDirectories(workflow) {
+  const matrixDirectories = [...workflow.matchAll(/-\s*dir:\s*(packages\/[\w-]+)/g)].map((match) => match[1]);
+  const dedicatedDirectories = [...workflow.matchAll(/^\s*working-directory:\s*(packages\/[\w-]+)\s*$/gm)].map((match) => match[1]);
+  return [...new Set([...matrixDirectories, ...dedicatedDirectories])];
+}

--- a/scripts/release-publish-coverage.mjs
+++ b/scripts/release-publish-coverage.mjs
@@ -1,6 +1,71 @@
-/** Extract package directories published by matrix or dedicated release workflow jobs. */
-export function collectPublishedPackageDirectories(workflow) {
-  const matrixDirectories = [...workflow.matchAll(/-\s*dir:\s*(packages\/[\w-]+)/g)].map((match) => match[1]);
-  const dedicatedDirectories = [...workflow.matchAll(/^\s*working-directory:\s*(packages\/[\w-]+)\s*$/gm)].map((match) => match[1]);
-  return [...new Set([...matrixDirectories, ...dedicatedDirectories])];
+import { parseDocument } from "yaml";
+
+const MATRIX_DIRECTORY = "${{ matrix.dir }}";
+const PACKAGE_DIRECTORY = /^\.?\/?(packages\/[\w-]+)$/;
+
+/** Returns whether a job only runs for the manual retry dispatch. */
+function isManualOnlyJob(job) {
+  return typeof job.if === "string" && job.if.includes("github.event_name == 'workflow_dispatch'");
+}
+
+/** Recognizes a shell command line that actually invokes npm publish, not an echo or comment. */
+function publishesNpm(run) {
+  return run.split(/\r?\n/).some((line) => {
+    const command = line.trim();
+    return !command.startsWith("#") && /^(?:command\s+)?npm(?:\s+--[^\s]+)*\s+publish(?:\s|$)/.test(command);
+  });
+}
+
+/** Resolves a literal package working directory or throws rather than guessing a publish target. */
+function packageDirectory(value, jobName) {
+  if (typeof value !== "string") {
+    throw new Error(`release.yml ${jobName}: npm publish has no resolvable working-directory`);
+  }
+  const match = value.match(PACKAGE_DIRECTORY);
+  if (!match) {
+    throw new Error(`release.yml ${jobName}: cannot resolve npm publish working-directory "${value}"`);
+  }
+  return match[1];
+}
+
+/** Resolves the effective working directory for one publish step. */
+function resolveStepDirectories(step, job, workflow, jobName) {
+  const workingDirectory = step["working-directory"]
+    ?? job.defaults?.run?.["working-directory"]
+    ?? workflow.defaults?.run?.["working-directory"];
+  if (workingDirectory === MATRIX_DIRECTORY) {
+    const include = job.strategy?.matrix?.include;
+    if (!Array.isArray(include)) {
+      throw new Error(`release.yml ${jobName}: npm publish uses matrix.dir without strategy.matrix.include`);
+    }
+    const directories = include.map((entry) => packageDirectory(entry?.dir, jobName));
+    if (directories.length === 0) {
+      throw new Error(`release.yml ${jobName}: npm publish matrix has no package directories`);
+    }
+    return directories;
+  }
+  return [packageDirectory(workingDirectory, jobName)];
+}
+
+/** Extract package directories from automatic jobs containing an npm publish command. */
+export function collectPublishedPackageDirectories(workflowSource) {
+  const document = parseDocument(workflowSource);
+  if (document.errors.length > 0) {
+    throw new Error(`release.yml cannot be parsed: ${document.errors.map((error) => error.message).join("; ")}`);
+  }
+  const workflow = document.toJS();
+  if (!workflow || typeof workflow !== "object" || Array.isArray(workflow) || !workflow.jobs || typeof workflow.jobs !== "object") {
+    throw new Error("release.yml must contain a jobs mapping");
+  }
+
+  const directories = new Set();
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    if (!job || typeof job !== "object" || Array.isArray(job) || isManualOnlyJob(job)) continue;
+    if (!Array.isArray(job.steps)) continue;
+    for (const step of job.steps) {
+      if (!step || typeof step !== "object" || Array.isArray(step) || typeof step.run !== "string" || !publishesNpm(step.run)) continue;
+      for (const directory of resolveStepDirectories(step, job, workflow, jobName)) directories.add(directory);
+    }
+  }
+  return [...directories];
 }

--- a/scripts/release-publish-coverage.test.mjs
+++ b/scripts/release-publish-coverage.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { collectPublishedPackageDirectories } from "./release-publish-coverage.mjs";
+
+test("合并 matrix 与专用 job 的发布目录", () => {
+  const workflow = `
+  publish-npm:
+    strategy:
+      matrix:
+        include:
+          - dir: packages/independent
+    steps:
+      - name: Publish
+        working-directory: \${{ matrix.dir }}
+  publish-dependent:
+    steps:
+      - name: Publish
+        working-directory: packages/dependency
+  publish-retry:
+    steps:
+      - name: Publish
+        working-directory: \${{ inputs.package_dir }}
+`;
+  assert.deepEqual(collectPublishedPackageDirectories(workflow), [
+    "packages/independent",
+    "packages/dependency",
+  ]);
+});
+
+test("专用 job 目录与 matrix 重复时只计一次", () => {
+  const workflow = `
+          - dir: packages/shared
+      - working-directory: packages/shared
+`;
+  assert.deepEqual(collectPublishedPackageDirectories(workflow), ["packages/shared"]);
+});

--- a/scripts/release-publish-coverage.test.mjs
+++ b/scripts/release-publish-coverage.test.mjs
@@ -1,36 +1,106 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import { collectPublishedPackageDirectories } from "./release-publish-coverage.mjs";
 
-test("合并 matrix 与专用 job 的发布目录", () => {
-  const workflow = `
+function workflow(jobs) {
+  return `jobs:\n${jobs}`;
+}
+
+const publishRun = "npm publish --provenance";
+
+test("真实发布工作流覆盖 matrix 与专用自动发布 job，并去重", () => {
+  const source = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+  assert.deepEqual(collectPublishedPackageDirectories(source), [
+    "packages/pi-extensions-i18n",
+    "packages/pi-distill",
+    "packages/pi-tool-supervisor",
+    "packages/pi-extensions-tool-display",
+    "packages/pi-metrics",
+    "packages/pi-models-discovery",
+    "packages/pi-session-tools",
+    "packages/pi-session-resources",
+    "packages/pi-dynamic-workflows",
+    "packages/pi-interactive-subagents",
+    "packages/pi-safety-guards",
+    "packages/pi-nested-skills",
+    "packages/pi-notifications",
+    "packages/pi-terminal-mux",
+    "packages/pi-naming",
+  ]);
+});
+
+test("registry 验证 step 不是发布覆盖", () => {
+  const source = workflow(`
+  verify-only:
+    steps:
+      - working-directory: packages/pi-naming
+        run: npm view pi-terminal-mux version
+`);
+  assert.deepEqual(collectPublishedPackageDirectories(source), []);
+});
+
+test("删除专用 naming 或 mux publish step 后不再报告对应覆盖", () => {
+  const source = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+  const withoutMux = source.replace(/\n      - name: Publish to npm\n        working-directory: packages\/pi-terminal-mux\n        run: \|[\s\S]*?\n          fi\n/, "\n");
+  assert.ok(!collectPublishedPackageDirectories(withoutMux).includes("packages/pi-terminal-mux"));
+  const withoutNaming = source.replace(/\n      - name: Publish to npm\n        working-directory: packages\/pi-naming\n        run: \|[\s\S]*?\n          fi\n/, "\n");
+  assert.ok(!collectPublishedPackageDirectories(withoutNaming).includes("packages/pi-naming"));
+});
+
+test("只有 matrix 而没有 publish step 不算发布覆盖", () => {
+  const source = workflow(`
   publish-npm:
     strategy:
       matrix:
         include:
           - dir: packages/independent
     steps:
-      - name: Publish
-        working-directory: \${{ matrix.dir }}
-  publish-dependent:
-    steps:
-      - name: Publish
-        working-directory: packages/dependency
-  publish-retry:
-    steps:
-      - name: Publish
-        working-directory: \${{ inputs.package_dir }}
-`;
-  assert.deepEqual(collectPublishedPackageDirectories(workflow), [
-    "packages/independent",
-    "packages/dependency",
-  ]);
+      - working-directory: \${{ matrix.dir }}
+        run: npm test
+`);
+  assert.deepEqual(collectPublishedPackageDirectories(source), []);
 });
 
-test("专用 job 目录与 matrix 重复时只计一次", () => {
-  const workflow = `
-          - dir: packages/shared
-      - working-directory: packages/shared
+test("matrix 只在同一 publish job 使用 matrix.dir 时展开", () => {
+  const source = workflow(`
+  unrelated-matrix:
+    strategy:
+      matrix:
+        include:
+          - dir: packages/wrong
+    steps:
+      - run: echo ignored
+  publish-npm:
+    strategy:
+      matrix:
+        include:
+          - dir: packages/first
+          - dir: packages/second
+    steps:
+      - working-directory: \${{ matrix.dir }}
+        run: |
+          ${publishRun}
+`);
+  assert.deepEqual(collectPublishedPackageDirectories(source), ["packages/first", "packages/second"]);
+});
+
+test("run 默认目录适用于 publish step，无法解析的目录直接失败", () => {
+  const withDefault = `
+defaults:
+  run:
+    working-directory: packages/defaulted
+jobs:
+  publish-defaulted:
+    steps:
+      - run: ${publishRun}
 `;
-  assert.deepEqual(collectPublishedPackageDirectories(workflow), ["packages/shared"]);
+  assert.deepEqual(collectPublishedPackageDirectories(withDefault), ["packages/defaulted"]);
+
+  const unresolved = workflow(`
+  publish-unknown:
+    steps:
+      - run: ${publishRun}
+`);
+  assert.throws(() => collectPublishedPackageDirectories(unresolved), /no resolvable working-directory/);
 });


### PR DESCRIPTION
## 问题

`pi-naming` 需要按配置统一命名 Pi session 与明确归属的终端目标。此前终端重命名能力受旧子代理环境开关耦合，且 release 工作流可能与其运行时依赖 `pi-terminal-mux` 并行发布。

## 变更

- 将命名入口收敛到既有 `targets.session`、`targets.workspace`、`targets.tab`，移除额外 workspace 授权配置及环境变量转换。
- `resolveTerminalRenameTargets` 改为明确 ID 的新路径：忽略旧 `PI_SUBAGENT_RENAME_*` 开关，同时保留旧 `getRenameCapability`、`renameCurrentTab`、`renameWorkspace` 的兼容行为。
- 保留子代理所有权协议、坏协议显式失败、缺少 ID 不回退焦点，以及逐目标失败报告。
- 为 tmux/Herdr 与所有后端明确目标、targets 关闭、部分失败、配置保存/reload 增加行为回归测试。
- 将 release 工作流拆分为独立包并行发布、`pi-terminal-mux` 专用发布、依赖 mux 成功结果的 `pi-naming` 专用发布；naming 发布和手动重试均验证所需 mux 范围已在 npm 上可用。
- 发布覆盖校验改为 YAML job/step 语义解析，只统计实际 `npm publish` 步骤，并在不可解析的工作目录时显式失败。

## 文档与兼容性

更新 `pi-naming`、`pi-terminal-mux` 中英文文档和 naming SKILL，说明 targets 语义、旧环境变量仅适用于旧公开接口，以及 release-please 的依赖发布顺序。

## 验证

- `npm run check -w pi-terminal-mux`（107 tests）
- `npm run check -w pi-naming`（32 tests）
- `npm run typecheck`
- `npm run test:release-publish-coverage`（6 tests，含 registry-only、删除 mux/naming publish、空 matrix、跨 job matrix、默认/不可解析 cwd）
- `node scripts/check-package-config.mjs`
- `node scripts/check-release-order.mjs`
- `node scripts/check-no-local-bindings.mjs`
- `node scripts/check-tool-supervisor-ui-output.mjs`

`npm run check` 仍被仓库既有的 `@maplezzk/pi-interactive-subagents` 6 项工具注册断言失败阻断；该失败在本次改动前已复现，未作为远程必需检查的豁免。
