### PR TITLE
fix: 修正 lockfile 镜像来源并加依赖来源门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Local-binding gate
         run: node scripts/check-no-local-bindings.mjs
 
+      - name: Dependency source gate
+        run: node scripts/check-lockfile-registry.mjs
+
       - name: Package config gate
         run: node scripts/check-package-config.mjs
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# 固定官方 registry，避免本机镜像地址（registry.npmmirror.com 等）写进 package-lock.json。
+# npm 12 默认 allow-remote=none，lockfile 里的非官方 tarball 地址会让 `npm ci` 报 EALLOWREMOTE，
+# Release 工作流直接失败。需要镜像加速时用 `--registry=` 临时覆盖，但不要提交被改写的 lockfile。
+registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ npm run check
 
 The check command runs workspace type checks, tests, and the portability/i18n gates.
 
+The repository pins `https://registry.npmjs.org/` in `.npmrc` so lockfile tarball URLs stay portable. Installing through a mirror registry rewrites those URLs and makes `npm ci` fail on npm 12+ with `EALLOWREMOTE`; `node scripts/check-lockfile-registry.mjs` (part of `npm run check`) blocks that before merge.
+
 ## License
 
 [MIT](./LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,8 @@ npm run check
 
 `check` 会执行 workspace 类型检查、测试，以及可移植性和 i18n 门禁。
 
+仓库根 `.npmrc` 固定 `https://registry.npmjs.org/`，保证 lockfile 里的 tarball 地址可移植。用镜像 registry 安装会把地址改写成镜像域名，导致 npm 12+ 的 `npm ci` 报 `EALLOWREMOTE`；`node scripts/check-lockfile-registry.mjs`（已纳入 `npm run check`）在合并前拦下这类改动。
+
 ## 许可证
 
 [MIT](./LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3719,7 +3719,7 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "test": "node scripts/run-workspaces.mjs test",
     "typecheck": "node scripts/run-workspaces.mjs typecheck",
-    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs && node scripts/check-release-order.mjs && npm run test:release-publish-coverage",
+    "check": "npm run typecheck && npm test && node scripts/check-no-local-bindings.mjs && node scripts/check-lockfile-registry.mjs && node scripts/check-package-config.mjs && node scripts/check-tool-supervisor-ui-output.mjs && node scripts/check-release-order.mjs && npm run test:release-publish-coverage",
     "check:tool-supervisor-ui": "node scripts/check-tool-supervisor-ui-output.mjs",
     "check:release-order": "node scripts/check-release-order.mjs",
     "test:release-publish-coverage": "node --test scripts/release-publish-coverage.test.mjs"

--- a/scripts/check-lockfile-registry.mjs
+++ b/scripts/check-lockfile-registry.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * 依赖来源门禁
+ *
+ * 背景：本机若把 registry 指向镜像，npm 会把镜像地址写进 package-lock.json 的 resolved 字段。
+ * npm 12 默认 allow-remote=none，会拒绝拉取与配置 registry 不一致的 tarball，表现为
+ * `npm ci` 报 EALLOWREMOTE，Release 工作流在 Install dependencies 阶段整批失败。
+ * 这类问题在 Node 22 自带 npm 10 上不会暴露（CI 用 `npm ci`/`npm install` 都能过），
+ * 所以必须在提交前静态检查。
+ *
+ * 检查项：
+ * 1. 各 lockfile 的 resolved 只能指向 https://registry.npmjs.org/
+ * 2. 各包 package.json 的 publishConfig.registry（若存在）只能是 https://registry.npmjs.org
+ *
+ * 用法：node scripts/check-lockfile-registry.mjs [--lockfile <path>]
+ * 任一命中即退出码 1。
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const EXPECTED_REGISTRY = "https://registry.npmjs.org/";
+const EXPECTED_HOST = "registry.npmjs.org";
+const LOCKFILE_NAMES = new Set(["package-lock.json", "npm-shrinkwrap.json"]);
+const SKIP_DIRS = new Set(["node_modules", ".git"]);
+/** 单次最多逐条打印的违规条目数，避免输出淹没 CI 日志 */
+const MAX_REPORTED_OFFENDERS = 20;
+
+const problems = [];
+
+/** 记录一条门禁失败项：立即打印，最后统一决定退出码 */
+function report(message) {
+  problems.push(message);
+  console.error(`❌ ${message}`);
+}
+
+/** 解析 JSON 文件；解析失败时记录问题并返回 null */
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (e) {
+    report(`${file} 解析失败：${e.message}`);
+    return null;
+  }
+}
+
+/** 取 URL 的 host；非法 URL 返回空串（会被当作违规来源处理） */
+function hostOf(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}
+
+/** 递归收集 lockfile 路径，跳过 node_modules 与 .git */
+function findLockfiles(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      findLockfiles(full, acc);
+    } else if (LOCKFILE_NAMES.has(entry)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/** 检查单个 lockfile：所有 http(s) 来源必须指向官方 registry，非 http 来源只提示人工确认 */
+function checkLockfile(lockfile) {
+  const lock = readJson(lockfile);
+  if (lock === null) return;
+
+  const resolvedEntries = Object.entries(lock.packages ?? {})
+    // link 条目是 workspace 软链（resolved 为本地目录），不属于远程来源
+    .filter(([, meta]) => meta?.resolved && meta.link !== true)
+    .map(([name, meta]) => [name, meta.resolved]);
+  const httpEntries = resolvedEntries.filter(([, resolved]) => /^https?:\/\//.test(resolved));
+  const otherEntries = resolvedEntries.filter(([, resolved]) => !/^https?:\/\//.test(resolved));
+
+  for (const [name, resolved] of otherEntries) {
+    // git+/file: 等非常规来源：npm 12 默认同样禁止（allow-git=none），留给人判断是否有意为之
+    console.warn(`⚠️  [lockfile] ${name} 使用非 registry 来源：${resolved}`);
+  }
+
+  const offenders = httpEntries.filter(([, resolved]) => hostOf(resolved) !== EXPECTED_HOST);
+  if (offenders.length > 0) {
+    report(
+      `[lockfile] ${lockfile} 有 ${offenders.length} 条依赖未指向 ${EXPECTED_HOST}，npm 12 会以 EALLOWREMOTE 拒绝安装：`,
+    );
+    for (const [name, resolved] of offenders.slice(0, MAX_REPORTED_OFFENDERS)) {
+      console.error(`   - ${name} -> ${resolved}`);
+    }
+    if (offenders.length > MAX_REPORTED_OFFENDERS) {
+      console.error(`   ...另有 ${offenders.length - MAX_REPORTED_OFFENDERS} 条`);
+    }
+    return;
+  }
+  console.log(`✅ [lockfile] ${lockfile} 的 ${httpEntries.length} 条 tarball 来源均为 ${EXPECTED_HOST}`);
+}
+
+/** 检查各包 package.json 的 publishConfig.registry 是否指向官方 registry */
+function checkPublishConfig() {
+  const packagesDir = join(ROOT, "packages");
+  if (!existsSync(packagesDir)) return;
+
+  const offenders = [];
+  for (const pkg of readdirSync(packagesDir)) {
+    const manifest = join(packagesDir, pkg, "package.json");
+    if (!existsSync(manifest)) continue;
+    const json = readJson(manifest);
+    if (json === null) continue;
+    const registry = json.publishConfig?.registry;
+    const normalized = registry?.replace(/\/$/, "");
+    if (normalized && normalized !== EXPECTED_REGISTRY.replace(/\/$/, "")) {
+      offenders.push([`packages/${pkg}/package.json`, registry]);
+    }
+  }
+
+  if (offenders.length > 0) {
+    report("[publishConfig] 以下包声明了非官方发布 registry：");
+    for (const [file, registry] of offenders) console.error(`   - ${file} -> ${registry}`);
+    return;
+  }
+  console.log("✅ [publishConfig] 各包发布 registry 一致");
+}
+
+/** 入口：解析 --lockfile 参数，跑完所有检查后按结果决定退出码 */
+function main() {
+  const argv = process.argv.slice(2);
+  const flagIndex = argv.indexOf("--lockfile");
+  const explicitLockfile = flagIndex === -1 ? undefined : argv[flagIndex + 1];
+  const lockfiles = explicitLockfile ? [explicitLockfile] : findLockfiles(ROOT);
+
+  if (lockfiles.length === 0) {
+    report("[lockfile] 未找到任何 lockfile");
+  }
+  for (const lockfile of lockfiles) {
+    checkLockfile(lockfile);
+  }
+  checkPublishConfig();
+
+  if (problems.length > 0) {
+    console.error(
+      `\n依赖来源门禁未通过：请把 registry 统一到 ${EXPECTED_REGISTRY} 后重新生成 lockfile（仓库根 .npmrc 已固定）。`,
+    );
+    process.exit(1);
+  }
+  console.log("\n依赖来源门禁通过。");
+}
+
+main();


### PR DESCRIPTION
## 问题

Release 工作流（run [34377933642](https://github.com/maplezzk/pi-extensions/actions/runs/34377933642)）所有发布 job 都在 `Install dependencies` 失败：

```
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "yaml@https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz"
```

根因两条叠加：

1. npm 12（工作流里 `corepack prepare npm@latest` 升到 12.0.2）默认 `allow-remote=none`，拒绝拉取与配置 registry 不一致的 tarball；
2. `package-lock.json` 里 yaml@2.9.0 的 `resolved` 是本机镜像地址，来自提交 8fc9d6a 加 devDependency 时的本机镜像安装（同类问题在 a59a3d0 手工修过一次）。

Node 22 自带的 npm 10 不做这个校验，所以 CI 全绿、只有 Release 失败。

## 改动

- `package-lock.json`：yaml 的 `resolved` 改回 `https://registry.npmjs.org/`（integrity 与官方 registry 元数据一致，不需要重新解析依赖）。
- `.npmrc`（新增，仓库根）：固定 `registry=https://registry.npmjs.org/`，本机镜像配置不会再被写进 lockfile。
- `scripts/check-lockfile-registry.mjs`（新增）：检查 lockfile 的 tarball 来源只能是官方 registry，并校验各包 `publishConfig.registry`；接入 `npm run check` 和 ci.yml 的 Dependency source gate。
- `README.md` / `README.zh-CN.md`：补充 registry 固定与门禁说明。

## 验证

- 改前用 npm 12 复现：`npm ci` 报 EALLOWREMOTE（CI 日志）。
- 改后本地用 npm 12 重新安装依赖（`npm exec -y npm@12 -- ci`）成功，无 EALLOWREMOTE；随后 `npm run check` 通过：107 + 45 + 6 项测试与全部门禁全绿。
- 门禁失败路径验证：把 lockfile 里的 yaml 地址换回镜像域名时，脚本以退出码 1 报出两条违规依赖。
- 防回潮验证：用本机镜像环境执行 `npm install --package-lock-only` 新增依赖，写出的 277 条 `resolved` 全部是 registry.npmjs.org（项目 .npmrc 优先级高于用户 .npmrc）。

## 说明

Release 工作流仍使用 `npm@latest`；本次是 npm 大版本默认行为变化导致的静默失败，门禁已能提前拦截同类 lockfile 问题。如果希望发布工具链也固定版本（例如 `npm@12`），可以另开一个小改动，本次未动。